### PR TITLE
[#3] 헤더와 footer 콘텐츠 정렬 통일

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
             <SiteHeader />
             <main className="flex-1">{children}</main>
             <footer className="border-t py-6 md:py-0">
-              <div className="container flex flex-col items-center justify-between gap-4 md:h-16 md:flex-row">
+              <div className="container px-4 flex flex-col items-center justify-between gap-4 md:h-16 md:flex-row">
                 <p className="text-center text-sm leading-loose text-muted-foreground md:text-left">
                   Built with Next.js and shadcn/ui. © 2025 Advenoh
                 </p>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -13,7 +13,7 @@ export function SiteHeader() {
   return (
     <>
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container flex h-14 items-center justify-between">
+        <div className="container px-4 flex h-14 items-center justify-between">
           <div className="flex items-center gap-6">
             <Link href="/" className="font-bold text-xl">
               Frank's IT Blog


### PR DESCRIPTION
## 개요
헤더와 footer의 콘텐츠가 body 콘텐츠와 정렬되지 않는 문제를 수정했습니다.

## 변경 사항
- `components/site-header.tsx`: container에 `px-4` 패딩 추가
- `app/layout.tsx`: footer container에 `px-4` 패딩 추가
- 모든 페이지에서 일관된 16px 좌우 패딩 적용

## 영향 범위
- 헤더: "Frank's IT Blog" 로고 및 네비게이션 정렬
- Footer: 저작권 텍스트 정렬
- 모든 페이지(/, /series, /article/[slug])에서 일관된 정렬 유지

## 테스트 계획
- [ ] 데스크톱에서 헤더/body/footer 정렬 확인
- [ ] 태블릿 breakpoint (md) 정렬 확인
- [ ] 모바일 breakpoint 정렬 확인
- [ ] 다크 모드에서도 정렬 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)