### PR TITLE
[chores] 헤더 검색 버튼 위치를 맨 오른쪽으로 이동

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -37,6 +37,7 @@ export function SiteHeader() {
 
           <div className="flex items-center gap-2">
             <SocialLinks />
+            <ThemeToggle />
             <Button
               variant="outline"
               size="sm"
@@ -58,7 +59,6 @@ export function SiteHeader() {
             >
               <Search className="h-5 w-5" />
             </Button>
-            <ThemeToggle />
           </div>
         </div>
       </header>


### PR DESCRIPTION
## 변경 내용
헤더의 검색 버튼을 맨 오른쪽으로 이동하여 사용자 경험을 개선했습니다.

## 주요 변경사항
- 검색 버튼을 SocialLinks, ThemeToggle 다음으로 배치
- 데스크톱: "검색 ⌘K" 버튼이 맨 오른쪽에 위치
- 모바일: 검색 아이콘이 맨 오른쪽에 위치
- 기능 변경 없음, 순수 레이아웃 개선

## 테스트 완료
- [x] 데스크톱 뷰에서 검색 버튼 위치 확인
- [x] 모바일 뷰에서 검색 아이콘 위치 확인
- [x] 검색 기능 정상 동작 확인
- [x] 다크/라이트 모드 모두 정상 동작

## 관련 문서
- PRD: docs/chores/8_header_prd.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)