### PR TITLE
feat: 구글 검색 결과에 사이트 이름 표시 개선

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,15 +7,19 @@ import { SiteFooter } from '@/components/site-footer';
 
 export const metadata: Metadata = {
   title: {
-    default: 'Advenoh IT Blog',
-    template: '%s | Advenoh IT Blog',
+    default: "Frank's IT Blog",
+    template: "%s | Frank's IT Blog",
   },
-  description: 'IT 기술 블로그 - 개발, 클라우드, 데이터베이스',
+  description: '개발, 클라우드, 데이터베이스 관련 기술 블로그',
+  applicationName: "Frank's IT Blog",
+  appleWebApp: {
+    title: "Frank's IT Blog",
+  },
   openGraph: {
     type: 'website',
     locale: 'ko_KR',
-    url: 'https://advenoh.pe.kr',
-    siteName: 'Advenoh IT Blog',
+    url: 'https://blog.advenoh.pe.kr',
+    siteName: "Frank's IT Blog",
   },
   twitter: {
     card: 'summary_large_image',
@@ -32,6 +36,24 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko" suppressHydrationWarning>
+      {/* JSON-LD WebSite Schema */}
+      <Script
+        id="website-schema"
+        type="application/ld+json"
+        strategy="beforeInteractive"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebSite',
+            name: "Frank's IT Blog",
+            alternateName: '프랭크의 IT 블로그',
+            url: 'https://blog.advenoh.pe.kr',
+            description: '개발, 클라우드, 데이터베이스 관련 기술 블로그',
+            inLanguage: 'ko-KR',
+          }),
+        }}
+      />
+
       {/* Google AdSense */}
       <Script
         async

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,3 +1,8 @@
+export const metadata = {
+  title: '페이지를 찾을 수 없습니다',
+  description: '요청하신 페이지를 찾을 수 없습니다',
+};
+
 export default function NotFound() {
   return (
     <div className="container mx-auto px-4 py-8 text-center">

--- a/docs/chores/1_google_search_implementation.md
+++ b/docs/chores/1_google_search_implementation.md
@@ -1,0 +1,238 @@
+# 구글 검색 결과 사이트 이름 표시 개선 - 구현 가이드
+
+## 📦 구현 개요
+
+구글 검색에서 "Frank's IT Blog"가 사이트 이름으로 표시되도록 SEO 메타데이터 추가
+
+## 🏗️ 구현 상세
+
+### 1. SiteMetadata 컴포넌트 생성
+
+**파일**: `client/src/components/SiteMetadata.tsx`
+
+```tsx
+import { useEffect } from 'react';
+
+interface SiteMetadataProps {
+  title?: string;
+  description?: string;
+  type?: 'website' | 'article';
+  url?: string;
+}
+
+export function SiteMetadata({
+  title,
+  description = "개발, 클라우드, 데이터베이스 관련 기술 블로그",
+  type = "website",
+  url = "https://blog.advenoh.pe.kr"
+}: SiteMetadataProps) {
+  useEffect(() => {
+    // 동적으로 title 업데이트
+    if (title) {
+      document.title = `${title} | Frank's IT Blog`;
+    } else {
+      document.title = "Frank's IT Blog";
+    }
+
+    // JSON-LD schema 추가
+    const schema = {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Frank's IT Blog",
+      "alternateName": "프랭크의 IT 블로그",
+      "url": url,
+      "description": description,
+      "inLanguage": "ko-KR"
+    };
+
+    const scriptId = 'site-schema';
+    let scriptTag = document.getElementById(scriptId) as HTMLScriptElement;
+    
+    if (!scriptTag) {
+      scriptTag = document.createElement('script');
+      scriptTag.id = scriptId;
+      scriptTag.type = 'application/ld+json';
+      document.head.appendChild(scriptTag);
+    }
+    
+    scriptTag.textContent = JSON.stringify(schema);
+
+    // Open Graph 메타 태그 업데이트
+    updateMetaTag('property', 'og:site_name', "Frank's IT Blog");
+    updateMetaTag('property', 'og:type', type);
+    updateMetaTag('property', 'og:locale', 'ko_KR');
+    updateMetaTag('property', 'og:title', title || "Frank's IT Blog");
+    updateMetaTag('property', 'og:description', description);
+    updateMetaTag('property', 'og:url', url);
+
+    // 추가 메타 태그
+    updateMetaTag('name', 'application-name', "Frank's IT Blog");
+    updateMetaTag('name', 'apple-mobile-web-app-title', "Frank's IT Blog");
+    
+  }, [title, description, type, url]);
+
+  return null;
+}
+
+function updateMetaTag(attrName: string, attrValue: string, content: string) {
+  let meta = document.querySelector(`meta[${attrName}="${attrValue}"]`) as HTMLMetaElement;
+  
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.setAttribute(attrName, attrValue);
+    document.head.appendChild(meta);
+  }
+  
+  meta.setAttribute('content', content);
+}
+```
+
+### 2. 페이지별 적용
+
+#### Home.tsx
+```tsx
+import { SiteMetadata } from '@/components/SiteMetadata';
+
+export default function Home() {
+  return (
+    <>
+      <SiteMetadata 
+        description="개발, 클라우드, 데이터베이스 관련 기술 블로그"
+      />
+      {/* 기존 코드 */}
+    </>
+  );
+}
+```
+
+#### Article.tsx
+```tsx
+import { SiteMetadata } from '@/components/SiteMetadata';
+
+export default function Article() {
+  const article = /* article 로딩 로직 */;
+  
+  return (
+    <>
+      <SiteMetadata 
+        title={article.title}
+        description={article.excerpt}
+        type="article"
+        url={`https://blog.advenoh.pe.kr/article/${article.slug}`}
+      />
+      {/* 기존 코드 */}
+    </>
+  );
+}
+```
+
+#### SeriesPage.tsx
+```tsx
+import { SiteMetadata } from '@/components/SiteMetadata';
+
+export default function SeriesPage() {
+  return (
+    <>
+      <SiteMetadata 
+        title="시리즈"
+        description="주제별로 정리된 시리즈 글 모음"
+      />
+      {/* 기존 코드 */}
+    </>
+  );
+}
+```
+
+#### NotFound.tsx
+```tsx
+import { SiteMetadata } from '@/components/SiteMetadata';
+
+export default function NotFound() {
+  return (
+    <>
+      <SiteMetadata 
+        title="페이지를 찾을 수 없습니다"
+        description="요청하신 페이지를 찾을 수 없습니다"
+      />
+      {/* 기존 코드 */}
+    </>
+  );
+}
+```
+
+### 3. HTML 템플릿 기본 메타 태그
+
+**파일**: `client/index.html`
+
+`<head>` 섹션에 추가:
+
+```html
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  
+  <!-- 기본 메타 태그 (fallback) -->
+  <meta name="application-name" content="Frank's IT Blog" />
+  <meta name="apple-mobile-web-app-title" content="Frank's IT Blog" />
+  <meta property="og:site_name" content="Frank's IT Blog" />
+  
+  <title>Frank's IT Blog</title>
+  
+  <!-- 기존 코드 -->
+</head>
+```
+
+## 🔍 검증 방법
+
+### 1. 로컬 개발 환경
+
+```bash
+npm run dev
+```
+
+브라우저 개발자 도구 → Elements → `<head>` 태그 확인:
+- `<script type="application/ld+json">` 존재 여부
+- `<meta property="og:site_name">` 값 확인
+
+### 2. Rich Results Test
+
+배포 후:
+1. [Google Rich Results Test](https://search.google.com/test/rich-results) 접속
+2. 사이트 URL 입력
+3. WebSite schema 인식 확인
+
+### 3. Google Search Console
+
+1. [Search Console](https://search.google.com/search-console) 접속
+2. "향상" → "구조화된 데이터" 확인
+3. WebSite 항목 확인
+
+## ⚙️ 기술 노트
+
+### JSON-LD 동적 생성 이유
+- React 컴포넌트로 페이지별 메타데이터 동적 관리
+- SSR 없이 CSR 환경에서도 동작
+- Googlebot은 JavaScript 실행 후 크롤링하므로 문제없음
+
+### useEffect 사용
+- 컴포넌트 마운트 시 메타 태그 주입
+- 페이지 전환 시 자동 업데이트
+- 중복 방지 로직 포함
+
+### 중복 방지
+- `getElementById`로 기존 script 태그 재사용
+- `querySelector`로 기존 meta 태그 업데이트
+- 새 태그 생성은 존재하지 않을 때만
+
+## 📊 예상 결과
+
+**검색 결과 표시 변경**:
+```
+Before: advenoh.pe.kr
+        https://blog.advenoh.pe.kr › article › some-article
+        
+After:  Frank's IT Blog
+        https://blog.advenoh.pe.kr › article › some-article
+```
+
+**반영 시간**: 1-2주 (Google 크롤링 주기에 따라 변동)

--- a/docs/chores/1_google_search_prd.md
+++ b/docs/chores/1_google_search_prd.md
@@ -1,0 +1,96 @@
+# PRD: 구글 검색 결과에 사이트 이름 표시 개선
+
+## 📋 개요
+
+**목표**: 구글 검색 결과에서 "advenoh.pe.kr" 대신 "Frank's IT Blog"가 사이트 이름으로 표시되도록 개선
+
+**현재 상황**:
+- 구글 검색 시 각 결과 항목에 "advenoh.pe.kr" 도메인 이름이 표시됨
+- 브랜드 인지도 측면에서 "Frank's IT Blog"로 표시하는 것이 더 효과적
+
+**기대 결과**:
+```
+현재: advenoh.pe.kr → Frank's IT Blog - 글 제목
+변경: Frank's IT Blog → 글 제목
+```
+
+## 🎯 요구사항
+
+### 1. WebSite Schema (JSON-LD) 추가
+
+**우선순위**: 🔴 필수
+
+구글이 사이트 이름을 인식할 수 있도록 구조화된 데이터 추가
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Frank's IT Blog",
+  "alternateName": "프랭크의 IT 블로그",
+  "url": "https://blog.advenoh.pe.kr",
+  "description": "개발, 클라우드, 데이터베이스 관련 기술 블로그",
+  "inLanguage": "ko-KR"
+}
+```
+
+**구현 위치**: 모든 페이지의 `<head>` 섹션
+
+### 2. Open Graph 메타 태그 추가
+
+**우선순위**: 🟡 권장
+
+소셜 미디어 공유 및 검색 엔진 최적화
+
+```html
+<meta property="og:site_name" content="Frank's IT Blog" />
+<meta property="og:type" content="website" />
+<meta property="og:locale" content="ko_KR" />
+```
+
+### 3. 추가 메타 태그 최적화
+
+**우선순위**: 🟢 선택
+
+```html
+<meta name="application-name" content="Frank's IT Blog" />
+<meta name="apple-mobile-web-app-title" content="Frank's IT Blog" />
+```
+
+## 📊 기술 사양
+
+### JSON-LD Schema 필수 속성
+
+| 속성 | 값 | 설명 |
+|------|-----|------|
+| @type | WebSite | Schema.org 타입 |
+| name | Frank's IT Blog | 사이트 공식 이름 |
+| url | https://blog.advenoh.pe.kr | 사이트 URL |
+| description | (사이트 설명) | 사이트 요약 |
+
+### Open Graph 필수 속성
+
+| 속성 | 값 | 설명 |
+|------|-----|------|
+| og:site_name | Frank's IT Blog | 소셜/검색 표시 이름 |
+| og:type | website | 콘텐츠 타입 |
+| og:locale | ko_KR | 언어/지역 |
+
+## 🔍 참고 자료
+
+- [Google Search Central - Site Names](https://developers.google.com/search/docs/appearance/site-names)
+- [Schema.org - WebSite](https://schema.org/WebSite)
+- [Open Graph Protocol](https://ogp.me/)
+- [Rich Results Test](https://search.google.com/test/rich-results)
+
+## ⚠️ 주의사항
+
+1. **반영 시간**: 구글 검색 결과 반영까지 1-2주 소요 가능
+2. **일관성**: 모든 페이지에 동일한 사이트 이름 적용
+3. **우선순위**: JSON-LD WebSite schema가 가장 중요
+4. **중복 방지**: 동일한 schema가 여러 번 선언되지 않도록 주의
+
+## 📚 관련 문서
+
+- [구현 가이드](./1_google_search_implementation.md)
+- [작업 목록](./1_google_search_todo.md)

--- a/docs/chores/1_google_search_todo.md
+++ b/docs/chores/1_google_search_todo.md
@@ -1,0 +1,68 @@
+# 구글 검색 결과 사이트 이름 표시 개선 - Todo
+
+## 📋 구현 단계
+
+### 1단계: 메타데이터 수정 ✅
+
+- [x] `app/layout.tsx` - 메타데이터 수정
+  - [x] title.default를 "Frank's IT Blog"로 변경
+  - [x] og:site_name을 "Frank's IT Blog"로 변경
+  - [x] applicationName 추가
+  - [x] appleWebApp.title 추가
+- [x] JSON-LD WebSite schema 추가 (Script 컴포넌트 사용)
+
+### 2단계: 페이지별 메타데이터 확인 ✅
+
+- [x] `app/page.tsx` (Home) - 이미 "Frank's IT Blog" 사용 중
+- [x] `app/[slug]/page.tsx` (Article) - 이미 "Frank's IT Blog" 사용 중
+- [x] `app/series/page.tsx` (Series) - 이미 "Frank's IT Blog" 사용 중
+- [x] `app/not-found.tsx` - 메타데이터 추가
+
+### 3단계: 빌드 및 검증 ✅
+
+- [x] 타입 체크 (`npm run check`)
+- [x] 프로덕션 빌드 (`npm run build`)
+- [x] 빌드된 HTML에서 메타데이터 확인
+  - [x] JSON-LD script 태그 존재 확인
+  - [x] og:site_name 메타 태그 확인
+  - [x] application-name 메타 태그 확인
+  - [x] apple-mobile-web-app-title 메타 태그 확인
+
+### 4단계: 배포 후 검증 (배포 후 수행)
+
+- [ ] 프로덕션 배포
+- [ ] [Rich Results Test](https://search.google.com/test/rich-results) 통과 확인
+- [ ] HTML 유효성 검사 ([validator.w3.org](https://validator.w3.org/))
+- [ ] Google Search Console에서 구조화된 데이터 확인
+
+### 5단계: 모니터링 (장기)
+
+- [ ] 1-2주 후 실제 구글 검색 결과 확인
+- [ ] Search Console에서 WebSite schema 인식 여부 확인
+- [ ] 검색 결과에 "Frank's IT Blog" 표시 확인
+
+## ✅ 완료 체크리스트
+
+- [x] layout.tsx 메타데이터 수정 완료
+- [x] JSON-LD WebSite schema 추가 완료
+- [x] not-found.tsx 메타데이터 추가 완료
+- [x] 타입 체크 통과
+- [x] 프로덕션 빌드 성공
+- [x] 빌드된 HTML에서 메타데이터 확인 완료
+- [ ] 프로덕션 배포 완료
+- [ ] Google Search Console 등록 및 모니터링 설정
+
+## 📝 구현 요약
+
+**변경 파일**:
+1. `app/layout.tsx` - Metadata API 수정 + JSON-LD Schema 추가
+2. `app/not-found.tsx` - metadata export 추가
+
+**Next.js 특이사항**:
+- Next.js의 Metadata API를 사용하여 SEO 메타데이터 관리
+- JSON-LD는 Script 컴포넌트로 추가 (beforeInteractive strategy)
+- 별도의 SiteMetadata 컴포넌트 불필요 (Metadata API로 충분)
+
+**참고**:
+- 배포 후 검색 결과 반영까지 1-2주 소요 예상
+- Rich Results Test로 즉시 검증 가능


### PR DESCRIPTION
## 📋 개요

구글 검색 결과에서 "advenoh.pe.kr" 대신 "Frank's IT Blog"가 사이트 이름으로 표시되도록 SEO 메타데이터를 개선했습니다.

## 🔧 변경 사항

### 1. app/layout.tsx
- **Metadata API 수정**
  - `title.default`: "Frank's IT Blog"로 변경
  - `og:site_name`: "Frank's IT Blog"로 변경
  - `applicationName`: "Frank's IT Blog" 추가
  - `appleWebApp.title`: "Frank's IT Blog" 추가

- **JSON-LD WebSite Schema 추가**
  ```json
  {
    "@context": "https://schema.org",
    "@type": "WebSite",
    "name": "Frank's IT Blog",
    "alternateName": "프랭크의 IT 블로그",
    "url": "https://blog.advenoh.pe.kr",
    "description": "개발, 클라우드, 데이터베이스 관련 기술 블로그",
    "inLanguage": "ko-KR"
  }
  ```

### 2. app/not-found.tsx
- metadata export 추가 (title, description)

### 3. 문서화
- `docs/chores/1_google_search_prd.md`: 요구사항 정의
- `docs/chores/1_google_search_implementation.md`: 구현 가이드
- `docs/chores/1_google_search_todo.md`: 작업 체크리스트

## ✅ 검증 완료

### 빌드 검증
- [x] TypeScript 타입 체크 통과
- [x] 프로덕션 빌드 성공 (148 페이지 생성)
- [x] 빌드된 HTML에서 모든 메타데이터 확인

### Playwright 테스트 결과
- [x] Title: "Frank's IT Blog" ✅
- [x] og:site_name: "Frank's IT Blog" ✅
- [x] og:type: "website" ✅
- [x] og:locale: "ko_KR" ✅
- [x] applicationName: "Frank's IT Blog" ✅
- [x] appleWebAppTitle: "Frank's IT Blog" ✅
- [x] JSON-LD WebSite Schema 포함됨 ✅

## 📊 예상 결과

**검색 결과 표시 변경**:
```
현재: advenoh.pe.kr
      https://blog.advenoh.pe.kr › article › ...

변경: Frank's IT Blog
      https://blog.advenoh.pe.kr › article › ...
```

## 🔍 배포 후 확인 사항

1. [Rich Results Test](https://search.google.com/test/rich-results)로 JSON-LD 유효성 검증
2. [HTML Validator](https://validator.w3.org/)로 마크업 유효성 확인
3. Google Search Console에서 구조화된 데이터 확인
4. 1-2주 후 실제 구글 검색 결과에서 "Frank's IT Blog" 표시 확인

## 📝 참고

- **반영 시간**: 구글 검색 결과 반영까지 1-2주 소요 예상
- **Next.js 특이사항**: JSON-LD는 `self.__next_s` 배열을 통해 동적 주입됨
- **관련 문서**: [Google Search Central - Site Names](https://developers.google.com/search/docs/appearance/site-names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)