### PR TITLE
[#50] 메인 페이지 Viewport 기반 Pagination 개선

### DIFF
--- a/components/home-content.tsx
+++ b/components/home-content.tsx
@@ -6,9 +6,10 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { formatDate } from '@/lib/utils';
-import { DEFAULT_ARTICLE_IMAGE } from '@/lib/constants';
+import { DEFAULT_ARTICLE_IMAGE, INITIAL_DISPLAY_COUNT } from '@/lib/constants';
 import { FeatureSection, CategoryInfo } from './feature';
 import { SearchDialog } from './search-dialog';
+import { useViewportSize } from '@/hooks/use-viewport-size';
 
 // Category를 제외한 article title만 추출 (클라이언트 안전 버전)
 function getArticleTitleFromSlug(fullSlug: string): string {
@@ -33,9 +34,10 @@ interface HomeContentProps {
 }
 
 export function HomeContent({ articles }: HomeContentProps) {
+  const viewportSize = useViewportSize();
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [displayCount, setDisplayCount] = useState(10);
+  const [displayCount, setDisplayCount] = useState(INITIAL_DISPLAY_COUNT[viewportSize]);
 
   // 카테고리 데이터 집계 (contents 폴더의 카테고리 사용)
   const categories = useMemo<CategoryInfo[]>(() => {
@@ -65,14 +67,19 @@ export function HomeContent({ articles }: HomeContentProps) {
     return filteredArticles.slice(0, displayCount);
   }, [filteredArticles, displayCount]);
 
+  // viewport 변경 시 pagination 리셋
+  useEffect(() => {
+    setDisplayCount(INITIAL_DISPLAY_COUNT[viewportSize]);
+  }, [viewportSize]);
+
   // 카테고리 변경 시 pagination 리셋
   useEffect(() => {
-    setDisplayCount(10);
-  }, [selectedCategory]);
+    setDisplayCount(INITIAL_DISPLAY_COUNT[viewportSize]);
+  }, [selectedCategory, viewportSize]);
 
   // "더 보기" 버튼 핸들러
   const handleLoadMore = () => {
-    setDisplayCount(prev => prev + 10);
+    setDisplayCount(prev => prev + INITIAL_DISPLAY_COUNT[viewportSize]);
   };
 
   return (

--- a/docs/start/1_main_pagination_todo.md
+++ b/docs/start/1_main_pagination_todo.md
@@ -3,22 +3,22 @@
 ## Phase 1: Custom Hook 생성
 
 ### `hooks/use-viewport-size.ts`
-- [ ] 파일 생성: `hooks/use-viewport-size.ts`
-- [ ] `"use client"` 지시어 추가
-- [ ] `ViewportSize` 타입 정의 (`'mobile' | 'tablet' | 'desktop'`)
-- [ ] `useViewportSize` hook 구현
-  - [ ] `useState` 초기화 (`'desktop'` 기본값)
-  - [ ] `useEffect`에서 `handleResize` 함수 정의
-  - [ ] Breakpoint 로직 구현 (768px, 1024px)
-  - [ ] `window.addEventListener('resize')` 등록
-  - [ ] Cleanup 함수에서 이벤트 리스너 제거
-  - [ ] 초기 실행 `handleResize()` 호출
-- [ ] Hook export
+- [x] 파일 생성: `hooks/use-viewport-size.ts`
+- [x] `"use client"` 지시어 추가
+- [x] `ViewportSize` 타입 정의 (`'mobile' | 'tablet' | 'desktop'`)
+- [x] `useViewportSize` hook 구현
+  - [x] `useState` 초기화 (`'desktop'` 기본값)
+  - [x] `useEffect`에서 `handleResize` 함수 정의
+  - [x] Breakpoint 로직 구현 (768px, 1024px)
+  - [x] `window.addEventListener('resize')` 등록
+  - [x] Cleanup 함수에서 이벤트 리스너 제거
+  - [x] 초기 실행 `handleResize()` 호출
+- [x] Hook export
 
 ## Phase 2: 상수 정의
 
 ### `lib/constants.ts`
-- [ ] `INITIAL_DISPLAY_COUNT` 객체 추가
+- [x] `INITIAL_DISPLAY_COUNT` 객체 추가
   ```typescript
   export const INITIAL_DISPLAY_COUNT = {
     mobile: 6,
@@ -26,25 +26,25 @@
     desktop: 12
   } as const;
   ```
-- [ ] Export 확인
+- [x] Export 확인
 
 ## Phase 3: HomeContent 컴포넌트 수정
 
 ### `components/home-content.tsx`
-- [ ] Import 추가
-  - [ ] `useViewportSize` from `@/hooks/use-viewport-size`
-  - [ ] `INITIAL_DISPLAY_COUNT` from `@/lib/constants`
-- [ ] Hook 호출
-  - [ ] `const viewportSize = useViewportSize();` 추가
-- [ ] State 초기화 변경
-  - [ ] `displayCount` 초기값을 `INITIAL_DISPLAY_COUNT[viewportSize]`로 변경
-- [ ] Viewport 변경 감지 추가
-  - [ ] `useEffect` 추가 (의존성: `[viewportSize]`)
-  - [ ] Effect 내에서 `setDisplayCount(INITIAL_DISPLAY_COUNT[viewportSize])`
-- [ ] 카테고리 변경 Effect 수정
-  - [ ] 기존 Effect 의존성에 `viewportSize` 추가
-- [ ] `handleLoadMore` 함수 수정
-  - [ ] 증가량을 `INITIAL_DISPLAY_COUNT[viewportSize]`로 변경
+- [x] Import 추가
+  - [x] `useViewportSize` from `@/hooks/use-viewport-size`
+  - [x] `INITIAL_DISPLAY_COUNT` from `@/lib/constants`
+- [x] Hook 호출
+  - [x] `const viewportSize = useViewportSize();` 추가
+- [x] State 초기화 변경
+  - [x] `displayCount` 초기값을 `INITIAL_DISPLAY_COUNT[viewportSize]`로 변경
+- [x] Viewport 변경 감지 추가
+  - [x] `useEffect` 추가 (의존성: `[viewportSize]`)
+  - [x] Effect 내에서 `setDisplayCount(INITIAL_DISPLAY_COUNT[viewportSize])`
+- [x] 카테고리 변경 Effect 수정
+  - [x] 기존 Effect 의존성에 `viewportSize` 추가
+- [x] `handleLoadMore` 함수 수정
+  - [x] 증가량을 `INITIAL_DISPLAY_COUNT[viewportSize]`로 변경
 
 ## Phase 4: 검증
 

--- a/hooks/use-viewport-size.ts
+++ b/hooks/use-viewport-size.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export type ViewportSize = "mobile" | "tablet" | "desktop";
+
+export function useViewportSize(): ViewportSize {
+  const [viewportSize, setViewportSize] = useState<ViewportSize>("desktop");
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth;
+
+      if (width < 768) {
+        setViewportSize("mobile");
+      } else if (width < 1024) {
+        setViewportSize("tablet");
+      } else {
+        setViewportSize("desktop");
+      }
+    };
+
+    // Initial call
+    handleResize();
+
+    // Add event listener
+    window.addEventListener("resize", handleResize);
+
+    // Cleanup
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return viewportSize;
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,4 +2,12 @@
  * Application constants
  */
 
+import { ViewportSize } from "@/hooks/use-viewport-size";
+
 export const DEFAULT_ARTICLE_IMAGE = '/images/default/default.png';
+
+export const INITIAL_DISPLAY_COUNT: Record<ViewportSize, number> = {
+  mobile: 6,
+  tablet: 8,
+  desktop: 12,
+} as const;


### PR DESCRIPTION
## 개요
메인 페이지에서 브라우저 viewport 크기에 따라 초기 표시 article 개수를 동적으로 조정하는 기능을 구현했습니다.

Closes #50

## 구현 내용

### 1. Custom Hook 생성 (`hooks/use-viewport-size.ts`)
- ViewportSize 타입 정의 (mobile/tablet/desktop)
- Window resize 이벤트 감지
- Breakpoints: 768px (모바일/태블릿), 1024px (태블릿/데스크톱)

### 2. 상수 정의 (`lib/constants.ts`)
```typescript
INITIAL_DISPLAY_COUNT = {
  mobile: 6,
  tablet: 8,
  desktop: 12
}
```

### 3. HomeContent 컴포넌트 수정 (`components/home-content.tsx`)
- useViewportSize hook 적용
- 초기 displayCount를 viewport별로 동적 설정
- Viewport 변경 시 자동 리셋 (useEffect)
- "더 보기" 버튼의 증가량을 viewport별로 조정

## 변경 사항

| Viewport | 초기 표시 | 증가량 | Before | After |
|---------|---------|--------|---------|-------|
| 모바일 (<768px) | 6개 | 6개 | 10행 스크롤 | ✅ 6행 스크롤 |
| 태블릿 (768-1023px) | 8개 | 8개 | 5행 | ✅ 4행 |
| 데스크톱 (≥1024px) | 12개 | 12개 | 3.33행 | ✅ 4행 |

## 기대 효과
- ✅ 모바일: 스크롤 부담 감소 (40% 감소)
- ✅ 태블릿: 적절한 정보량 유지
- ✅ 데스크톱: 화면 활용도 향상 (20% 증가)
- ✅ 사용자 경험 개선: 화면 크기에 최적화된 콘텐츠 제공

## 테스트 체크리스트
- [x] TypeScript 타입 체크 통과
- [ ] 모바일 viewport에서 6개 초기 표시 확인
- [ ] 태블릿 viewport에서 8개 초기 표시 확인
- [ ] 데스크톱 viewport에서 12개 초기 표시 확인
- [ ] Viewport 변경 시 자동 리셋 동작 확인
- [ ] "더 보기" 버튼 동작 확인 (viewport별 증가량)
- [ ] 카테고리 필터링과 통합 동작 확인

## 스크린샷
_테스트 후 추가 예정_

🤖 Generated with [Claude Code](https://claude.com/claude-code)