### PR TITLE
[docs] contents 디렉토리 마크다운 파일 스펠링 및 오타 수정

### DIFF
--- a/contents/ai/맥에서-직접-ai-모델-돌려보자-ollama로-llm-서버-구축하기/index.md
+++ b/contents/ai/맥에서-직접-ai-모델-돌려보자-ollama로-llm-서버-구축하기/index.md
@@ -104,7 +104,7 @@ Ollama는 API를 제공하므로, curl을 사용하여 직접 호출할 수도 �
 
 ### 3.3 Python으로 호출해보기
 
-Python 에서는 langchain library를 제공하고 있어서 이걸 이요해서 `LLM`을 사용할 수 있다.
+Python 에서는 langchain library를 제공하고 있어서 이걸 이용해서 `LLM`을 사용할 수 있다.
 
 ```python
 from unittest import TestCase
@@ -132,7 +132,7 @@ class Test(TestCase):
 
 ## 4. Ollama 명령어 모음
 
-`ollama` 명령어는 다양한 명령어를 제공하고 자주 사용하는 명령어은 다음과 같다.
+`ollama` 명령어는 다양한 명령어를 제공하고 자주 사용하는 명령어는 다음과 같다.
 
 - 모델 리스트 확인
 

--- a/contents/cloud/argo-cd/index.md
+++ b/contents/cloud/argo-cd/index.md
@@ -28,7 +28,7 @@ Argo CD는 GitOps 기반의 CD 도구이고 다음과 같은 여러 기능을 �
 - 타겟 환경(Git 저장소에 지정된 대로)에 application 자동 배포 지원
 - 쿠버네티스 manifest 파일을 생성해주는 여러 템플릿 포맷을 지원
     - `Kustomize, Helm charts, plain-YAML, Ksonnet, Jsonnet`
-- Pull deployment 방식를 지원
+- Pull deployment 방식을 지원
     - Argo CD는 k8s manifest의 변경을 pull하는 방식
 - 여러 클러스터를 관리하고 배포하는 기능
 - SSO 통합 인증 지원 (OIDC, OAuth2, LDAP, SAML 2.0, GitHub, GitLab, Microsoft, LinkedIn)
@@ -67,7 +67,7 @@ Argo CD는 **3가지 컨포넌트**로 이루어져 있다. Argo CD가 하는 �
 
 ## When?
 
-- CD (Continuous Delivery) 도구로써 쿠너베티스 환경에 application을 자동 배포하는데 적합한 도구이다
+- CD (Continuous Delivery) 도구로서 쿠버네티스 환경에 application을 자동 배포하는데 적합한 도구이다
 
 ## Why?
 
@@ -121,7 +121,7 @@ $ kubectl port-forward svc/argocd-server -n argocd 8080:443
 
 ![Argo CD Web](image-20220306144129359.png)
 
-admin 계정의 초기 암호는 자동으로 생성되어 `argocd-initial-admin-secret` 시크린에서 base64 값으로 저장되어 있다. `kubectl` 명령어 사용하여 간단하게 암호를 확인한다.
+admin 계정의 초기 암호는 자동으로 생성되어 `argocd-initial-admin-secret` 시크릿에서 base64 값으로 저장되어 있다. `kubectl` 명령어 사용하여 간단하게 암호를 확인한다.
 
 ```bash
 kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d; echo
@@ -167,9 +167,9 @@ $ argocd app create guestbook --port-forward-namespace argocd --repo https://git
 - path
     - Repository에서 path로 application directory를 지정한다
 - dest-server
-    - 대상이 되는 쿠버네티이스 클러스터 URL를 지정한다
+    - 대상이 되는 쿠버네티스 클러스터 URL를 지정한다
 - dest-namespace
-    - application을 생성할 대상 네이스페이스를 지정한다
+    - application을 생성할 대상 네임스페이스를 지정한다
 
 
 

--- a/contents/java/lombok-기본-사용법-익히기/index.md
+++ b/contents/java/lombok-기본-사용법-익히기/index.md
@@ -275,7 +275,7 @@ equals()와 hashCode()를 자동 생성해주는 어노테이션입니다.
 - 제외시킬 필드 지정
     - @EqualsAndHashCode.Exclude
 
-바닐라 자바 코드가 너무 길어서 간출렸습니다. 실제 코드는 컴파일된 클래스 파일으로 확인해보세요.
+바닐라 자바 코드가 너무 길어서 생략했습니다. 실제 코드는 컴파일된 클래스 파일으로 확인해보세요.
 
 ```java
 //Ex1 - Lombok
@@ -347,13 +347,13 @@ public class PersonExclude {
 }
 ```
 
-### @NoArgsConstructor, @AllArgsConstructor, @RequiredArgsContructor
+### @NoArgsConstructor, @AllArgsConstructor, @RequiredArgsConstructor
 
 생성자를 자동으로 생성해주는 어노테이션입니다. 필드 선언순서에 따라 생성자 인자가 정해집니다. 나중에 리펙토링을 하게 되면 인자 순서가 변경될 수 있다는 점을 기억하면 좋을 것 같습니다.
 
 - NoArgsConstructor : 인자 없는 생성자
 - AllArgsConstructor : 모든 필드를 인자로 받는 생성자
-- RequiredArgsContructor(staticName=“of") : static factory 메서드를 생성함
+- RequiredArgsConstructor(staticName=“of") : static factory 메서드를 생성함
 
 ```java
 //Ex1 - Lombok
@@ -568,7 +568,7 @@ public class Car {
             return this;
         }
 
-        public Car build() {]
+        public Car build() {
             return new Car(this.wheels, this.color);
         }
 


### PR DESCRIPTION
## 📝 Summary

PRD 문서([docs/start/1_spelling_prd.md](docs/start/1_spelling_prd.md))를 기반으로 Phase 1: 긴급 수정 작업을 완료했습니다.

## ✅ 수정 내역

### 1️⃣ AI 관련 문서
**파일**: `contents/ai/맥에서-직접-ai-모델-돌려보자-ollama로-llm-서버-구축하기/index.md`
- 107줄: `이요해서` → `이용해서` (오타)
- 135줄: `명령어은` → `명령어는` (조사 오류)

### 2️⃣ Argo CD 문서  
**파일**: `contents/cloud/argo-cd/index.md`
- 31줄: `방식를` → `방식을` (조사 오류)
- 70줄: `쿠너베티스` → `쿠버네티스` (오타)
- 70줄: `도구로써` → `도구로서` (조사 오류)
- 124줄: `시크린에서` → `시크릿에서` (오타)
- 170줄: `쿠버네티이스` → `쿠버네티스` (오타)
- 172줄: `네이스페이스를` → `네임스페이스를` (오타)

### 3️⃣ Lombok 문서
**파일**: `contents/java/lombok-기본-사용법-익히기/index.md`
- 278줄: `간출렸습니다` → `생략했습니다` (부적절한 표현)
- 350, 356줄: `RequiredArgsContructor` → `RequiredArgsConstructor` (스펠링 오류, 2곳)
- 571줄: `{]` → `{` (코드 블록 오류)

## 📊 통계
- **수정된 파일**: 3개
- **수정된 오류**: 11개
  - 오타: 8개
  - 조사 오류: 2개
  - 코드 블록 오류: 1개

## 🔗 관련 이슈
PRD 문서 참조: docs/start/1_spelling_prd.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)