### PR TITLE
fix: GitHub Action에 쓰기 권한 추가

### DIFF
--- a/.github/workflows/biweekly-news.yml
+++ b/.github/workflows/biweekly-news.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 0 1,15 * *'
   workflow_dispatch: # 수동 실행
 
+permissions:
+  contents: write      # 브랜치 생성 및 push 권한
+  pull-requests: write # PR 생성 권한
+
 jobs:
   generate-news:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- GitHub Action 실행 시 403 권한 오류 수정
- `permissions` 블록 추가로 PR 생성 가능하도록 설정

## 변경 사항
```yaml
permissions:
  contents: write      # 브랜치 생성 및 push 권한
  pull-requests: write # PR 생성 권한
```

## 오류 메시지
```
remote: Permission to kenshin579/blog-v2.advenoh.pe.kr.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/kenshin579/blog-v2.advenoh.pe.kr/': The requested URL returned error: 403
```

## 추가 확인 사항
GitHub Repository Settings에서도 확인 필요:
1. Settings → Actions → General
2. "Workflow permissions" → "Read and write permissions" 선택

🤖 Generated with [Claude Code](https://claude.com/claude-code)