### PR TITLE
fix: generate-readme 워크플로우 권한 오류 수정

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -16,8 +16,11 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write      # push 권한
+      pull-requests: write # PR 생성 권한
 
     steps:
     - uses: actions/checkout@v4
@@ -42,7 +45,7 @@ jobs:
           git add README.md
           git commit -am "update README file"
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v7
       with:
         commit-message: Update README file
         branch: readme-patches


### PR DESCRIPTION
## Summary
- `generate-readme` 워크플로우에서 `readme-patches` 브랜치로 push 시 403 권한 오류 수정
- `permissions` 블록 추가 (`contents: write`, `pull-requests: write`)
- `peter-evans/create-pull-request` 액션 버전 v3 → v7 업그레이드

## Test plan
- [ ] GitHub Actions에서 `generate-readme` 워크플로우 수동 실행
- [ ] PR이 정상적으로 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)