### PR TITLE
chore: Supabase keepalive 실행 주기 2일로 변경

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -2,9 +2,9 @@ name: Supabase Keepalive
 
 on:
   schedule:
-    # 6일마다 실행 (00:00 UTC)
+    # 2일마다 실행 (00:00 UTC)
     # 7일 pause 정책보다 짧은 주기
-    - cron: '0 0 */6 * *'
+    - cron: '0 0 */2 * *'
   workflow_dispatch: # 수동 실행
 
 jobs:


### PR DESCRIPTION
## Summary
- Supabase keepalive GitHub Action 스케줄을 6일에서 2일로 변경
- cron 표현식: `0 0 */6 * *` → `0 0 */2 * *`

## Changes
- `.github/workflows/supabase-keepalive.yml`: cron 스케줄 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)