### PR TITLE
fix: TOC에서 HTML 엔티티 디코딩 문제 수정

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -83,6 +83,21 @@ function extractFirstImage(content: string): string | undefined {
 }
 
 /**
+ * HTML 엔티티 디코딩
+ */
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&#x26;/g, '&')
+    .replace(/&#38;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+/**
  * Table of Contents 추출
  */
 export function extractTOC(html: string): TOCItem[] {
@@ -93,7 +108,7 @@ export function extractTOC(html: string): TOCItem[] {
   while ((match = headingRegex.exec(html)) !== null) {
     toc.push({
       id: match[2],
-      text: match[3],
+      text: decodeHtmlEntities(match[3]),
       level: parseInt(match[1]),
     });
   }


### PR DESCRIPTION
## Summary
- 목차(TOC)에서 `&` 문자가 `&#x26;`로 표시되는 버그 수정
- `extractTOC` 함수에서 HTML 엔티티 디코딩 로직 추가

## 변경 내용
- `decodeHtmlEntities` 함수 추가: HTML 엔티티(`&amp;`, `&#x26;`, `&lt;` 등)를 원래 문자로 디코딩
- `extractTOC`에서 heading 텍스트 추출 시 디코딩 적용

## Test plan
- [ ] `npm run dev` 실행
- [ ] `/news-2026-01-01/` 페이지 접속
- [ ] 목차에서 "Cloud & Infra"가 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)