### PR TITLE
fix: README에서 깨진 배지 이미지 삭제

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -33,8 +33,6 @@ jobs:
           -e CONTENT_DIR=contents \
           -e BLOG_URL=https://blog.advenoh.pe.kr \
           -e PROJECT_TITLE="Frank's IT Blog" \
-          -e HITCOUNT_PATH=kenshin579/advenohpekr \
-          -e NETLIFY_BADGE_ID=31900f77-681f-4ace-8b3b-906936f57a60 \
           kenshin579/readme-generator:latest
     - name: Create commits
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![HitCount](http://hits.dwyl.io/kenshin579/advenohpekr.svg)](http://hits.dwyl.io/kenshin579/advenohpekr)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/31900f77-681f-4ace-8b3b-906936f57a60/deploy-status)](https://app.netlify.com/sites/advenoh/deploys)
-
 # Frank's IT Blog - Table of Contents
 
 Updated 2026-01-11

--- a/scripts/generate_readme/data/HEADER.md
+++ b/scripts/generate_readme/data/HEADER.md
@@ -1,4 +1,1 @@
-[![HitCount](http://hits.dwyl.io/{{HITCOUNT_PATH}}.svg)](http://hits.dwyl.io/{{HITCOUNT_PATH}})
-[![Netlify Status](https://api.netlify.com/api/v1/badges/{{NETLIFY_BADGE_ID}}/deploy-status)](https://app.netlify.com/sites/advenoh/deploys)
-
 # {{PROJECT_TITLE}} - Table of Contents


### PR DESCRIPTION
## Summary
- HitCount, Netlify Status 배지가 깨져서 표시되는 문제 해결
- README.md에서 배지 라인 삭제
- HEADER.md 템플릿에서 배지 템플릿 삭제
- generate-readme.yml에서 불필요한 환경 변수 삭제

## Test plan
- [ ] GitHub에서 README.md 미리보기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)