### PR TITLE
[#116] PR merge 후 미래 날짜 보정 caller 워크플로우 추가

### DIFF
--- a/.github/workflows/fix-future-date.yml
+++ b/.github/workflows/fix-future-date.yml
@@ -1,0 +1,13 @@
+name: Fix Future Date
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  fix-date:
+    if: github.event.pull_request.merged == true
+    uses: kenshin579/actions/.github/workflows/fix-future-date.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit


### PR DESCRIPTION
## 개요

PR이 merge될 때 `index.md`의 frontmatter `date`가 미래 날짜인 경우, 현재 날짜로 자동 보정하는 caller 워크플로우를 추가합니다.

## 변경 사항

- `fix-future-date.yml` caller 워크플로우 생성
- `pull_request: closed` 이벤트에서 merge된 경우만 실행
- `kenshin579/actions` 레포의 재사용 워크플로우 호출

Closes #116