### PR TITLE
chore: HitCount 배지 제거 및 Netlify 배지 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![HitCount](http://hits.dwyl.io/kenshin579/advenohpekr.svg)](http://hits.dwyl.io/kenshin579/advenohpekr)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/31900f77-681f-4ace-8b3b-906936f57a60/deploy-status)](https://app.netlify.com/sites/advenoh/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/68c25f86-908d-419b-8b5c-925e22a2149d/deploy-status)](https://app.netlify.com/projects/blogv2-advenoh/deploys)
 
 # Frank's IT Blog - Table of Contents
 

--- a/scripts/generate_readme/Makefile
+++ b/scripts/generate_readme/Makefile
@@ -9,8 +9,7 @@ FULL_IMAGE := $(IMAGE_NAME):$(IMAGE_TAG)
 CONTENT_DIR ?= contents
 BLOG_URL ?= https://blog.advenoh.pe.kr
 PROJECT_TITLE ?= Frank's IT Blog
-HITCOUNT_PATH ?= kenshin579/advenohpekr
-NETLIFY_BADGE_ID ?= 31900f77-681f-4ace-8b3b-906936f57a60
+NETLIFY_BADGE_ID ?= 68c25f86-908d-419b-8b5c-925e22a2149d
 
 help:
 	@echo "Available targets:"
@@ -32,7 +31,6 @@ docker-run:
 	@echo "  CONTENT_DIR=$(CONTENT_DIR)"
 	@echo "  BLOG_URL=$(BLOG_URL)"
 	@echo "  PROJECT_TITLE=$(PROJECT_TITLE)"
-	@echo "  HITCOUNT_PATH=$(HITCOUNT_PATH)"
 	@echo "  NETLIFY_BADGE_ID=$(NETLIFY_BADGE_ID)"
 	docker run --rm \
 		-v $(PWD)/../..:/workspace \
@@ -40,7 +38,6 @@ docker-run:
 		-e CONTENT_DIR=$(CONTENT_DIR) \
 		-e BLOG_URL=$(BLOG_URL) \
 		-e PROJECT_TITLE="$(PROJECT_TITLE)" \
-		-e HITCOUNT_PATH=$(HITCOUNT_PATH) \
 		-e NETLIFY_BADGE_ID=$(NETLIFY_BADGE_ID) \
 		$(FULL_IMAGE)
 

--- a/scripts/generate_readme/data/HEADER.md
+++ b/scripts/generate_readme/data/HEADER.md
@@ -1,1 +1,3 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/{{NETLIFY_BADGE_ID}}/deploy-status)](https://app.netlify.com/projects/blogv2-advenoh/deploys)
+
 # {{PROJECT_TITLE}} - Table of Contents

--- a/scripts/generate_readme/generate_readme.py
+++ b/scripts/generate_readme/generate_readme.py
@@ -24,8 +24,7 @@ WORKSPACE_DIR = os.getenv('WORKSPACE_DIR', os.path.dirname(os.path.dirname(os.pa
 CONTENT_DIR = os.getenv('CONTENT_DIR', 'contents')
 BLOG_URL = os.getenv('BLOG_URL', 'https://blog.advenoh.pe.kr')
 PROJECT_TITLE = os.getenv('PROJECT_TITLE', "Frank's IT Blog")
-HITCOUNT_PATH = os.getenv('HITCOUNT_PATH', 'kenshin579/advenohpekr')
-NETLIFY_BADGE_ID = os.getenv('NETLIFY_BADGE_ID', '31900f77-681f-4ace-8b3b-906936f57a60')
+NETLIFY_BADGE_ID = os.getenv('NETLIFY_BADGE_ID', '68c25f86-908d-419b-8b5c-925e22a2149d')
 README_PATH = os.getenv('README_PATH', os.path.join(WORKSPACE_DIR, 'README.md'))
 HEADER_TEMPLATE = os.getenv('HEADER_TEMPLATE', 'data/HEADER.md')
 
@@ -76,8 +75,7 @@ class Generator:
             template = f.read()
 
         # Replace placeholders with environment variables
-        header = template.replace('{{HITCOUNT_PATH}}', HITCOUNT_PATH)
-        header = header.replace('{{NETLIFY_BADGE_ID}}', NETLIFY_BADGE_ID)
+        header = template.replace('{{NETLIFY_BADGE_ID}}', NETLIFY_BADGE_ID)
         header = header.replace('{{PROJECT_TITLE}}', PROJECT_TITLE)
 
         return header


### PR DESCRIPTION
## Summary
- HitCount 배지 제거 (hits.dwyl.io 서비스 미사용)
- Netlify 배지 ID를 새 프로젝트(blogv2-advenoh)로 업데이트
- `generate_readme` 스크립트에서 `HITCOUNT_PATH` 관련 코드 제거
- `HEADER.md` 템플릿에 Netlify 배지 추가

## 변경 파일
- `README.md` - 배지 교체
- `scripts/generate_readme/generate_readme.py` - HITCOUNT_PATH 변수/로직 제거, 배지 ID 업데이트
- `scripts/generate_readme/Makefile` - HITCOUNT_PATH 환경변수 제거, 배지 ID 업데이트
- `scripts/generate_readme/data/HEADER.md` - Netlify 배지 템플릿 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)