### PR TITLE
auto-merge 워크플로우 permissions 추가

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 22 * * *'  # 매일 오전 7시 실행 (UTC 기준: 한국시간으로는 7am으로 실행함)
   workflow_dispatch:  # 수동 실행 가능
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   auto-merge:
     uses: kenshin579/actions/.github/workflows/auto-merge-pr.yml@main


### PR DESCRIPTION
## Summary
- auto-merge 워크플로우에 `GITHUB_TOKEN` permissions 명시 추가
- `Resource not accessible by integration` 오류 해결

## 변경 사항
- `issues: write` - PR 댓글 작성 권한
- `pull-requests: write` - auto-merge 활성화 권한
- `contents: write` - squash merge 실행 권한

## Test plan
- [ ] actions 리포 PR 먼저 merge 후, `workflow_dispatch`로 auto-merge 수동 실행하여 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)