### PR TITLE
chore: nanobanana MCP 서버 설정 추가

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "nanobanana": {
+      "command": "uvx",
+      "args": ["nanobanana-mcp-server@latest"],
+      "env": {
+        "GEMINI_API_KEY": "${NANOBANANA_MCP_GOOGLE_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Notion MCP 서버를 nanobanana MCP 서버(이미지 생성)로 변경
- API 키를 환경 변수(`NANOBANANA_MCP_GOOGLE_API_KEY`)로 참조하도록 설정

## Test plan
- [ ] `NANOBANANA_MCP_GOOGLE_API_KEY` 환경 변수 설정 후 MCP 서버 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)