### PR TITLE
chore: CLAUDE.md에 Mermaid 다이어그램 스타일 가이드 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,13 @@ Markdown content...
 3. `manifest.json`에 파일명 추가
 4. 브라우저에서 캐시 클리어 후 확인 (`clearArticlesCache()`)
 
+## Diagram Style
+
+**다이어그램은 반드시 Mermaid 형식으로 작성한다.**
+- ASCII art 다이어그램 사용 금지
+- 마크다운 코드블록에 ```mermaid 사용
+- flowchart, sequence, class, state 등 적절한 Mermaid 다이어그램 타입 선택
+
 ## Design System
 
 **Component Library:** shadcn/ui (Radix UI primitives)


### PR DESCRIPTION
## Summary
- CLAUDE.md에 Diagram Style 섹션 추가
- 블로그 콘텐츠 작성 시 다이어그램을 항상 Mermaid 형식으로 작성하도록 지침 명시
- ASCII art 다이어그램 사용 금지 규칙 추가

## Test plan
- [x] CLAUDE.md 파일 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)