### PR TITLE
[fix] fix-future-date 워크플로우에 content_dir 지정

### DIFF
--- a/.github/workflows/fix-future-date.yml
+++ b/.github/workflows/fix-future-date.yml
@@ -14,4 +14,5 @@ jobs:
     uses: kenshin579/actions/.github/workflows/fix-future-date.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}
+      content_dir: contents
     secrets: inherit


### PR DESCRIPTION
## Summary
- `fix-future-date` 워크플로우 호출 시 `content_dir: contents` 파라미터 추가
- `contents/` 폴더 내 `index.md`만 미래 날짜 보정 대상으로 제한
- `docs/` 폴더의 초안 글은 날짜 보정에서 제외

## 배경
- PR #133에서 `docs/start/webrtc/.../index.md`가 보정 대상에 포함되는 문제 발생
- 의존: kenshin579/actions#32 머지 필요

## Test plan
- [ ] `contents/` 폴더 내 미래 날짜 md 파일만 보정되는지 확인
- [ ] `docs/` 폴더의 md 파일은 스킵되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)