### PR TITLE
fix: RSS, sitemap의 article URL 경로 수정

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,4 +1,4 @@
-import { getAllArticles } from '@/lib/articles';
+import { getAllArticles, getArticleTitleFromSlug } from '@/lib/articles';
 
 export const dynamic = 'force-static';
 
@@ -23,8 +23,8 @@ export async function GET() {
         (article) => `
     <item>
       <title><![CDATA[${article.title}]]></title>
-      <link>${siteUrl}/article/${article.slug}</link>
-      <guid>${siteUrl}/article/${article.slug}</guid>
+      <link>${siteUrl}/${getArticleTitleFromSlug(article.slug)}</link>
+      <guid>${siteUrl}/${getArticleTitleFromSlug(article.slug)}</guid>
       <pubDate>${new Date(article.date).toUTCString()}</pubDate>
       <description><![CDATA[${article.excerpt || article.title}]]></description>
       <category>${article.category}</category>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next';
-import { getAllArticles } from '@/lib/articles';
+import { getAllArticles, getArticleTitleFromSlug } from '@/lib/articles';
 
 export const dynamic = 'force-static';
 
@@ -9,7 +9,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Article URLs
   const articleUrls = articles.map((article) => ({
-    url: `${siteUrl}/article/${article.slug}`,
+    url: `${siteUrl}/${getArticleTitleFromSlug(article.slug)}`,
     lastModified: new Date(article.date),
     changeFrequency: 'monthly' as const,
     priority: 0.7,

--- a/scripts/generators/rss.ts
+++ b/scripts/generators/rss.ts
@@ -65,8 +65,8 @@ export function generateRSS(manifestPath: string, outputPath: string): void {
     const item = channel.ele('item');
 
     item.ele('title').txt(article.title);
-    item.ele('link').txt(`${blogConfig.baseUrl}/article/${article.slug}`);
-    item.ele('guid', { isPermaLink: 'true' }).txt(`${blogConfig.baseUrl}/article/${article.slug}`);
+    item.ele('link').txt(`${blogConfig.baseUrl}/${article.slug.split('/').pop()}`);
+    item.ele('guid', { isPermaLink: 'true' }).txt(`${blogConfig.baseUrl}/${article.slug.split('/').pop()}`);
     item.ele('pubDate').txt(new Date(article.date).toUTCString());
 
     // Excerpt를 description으로 사용 (HTML escape 처리)


### PR DESCRIPTION
## Summary
- RSS, sitemap에서 article URL이 `/article/{category}/{slug}` 형식으로 잘못 생성되던 문제 수정
- 실제 라우팅 경로인 `/{title-slug}` 형식에 맞게 변경
- 수정 파일: `app/rss.xml/route.ts`, `app/sitemap.ts`, `scripts/generators/rss.ts`

## Test plan
- [ ] `npm run check` 타입 체크 통과 확인
- [ ] RSS 피드의 article 링크가 실제 페이지로 이동하는지 확인
- [ ] sitemap의 article URL이 올바른지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)