### PR TITLE
chore: docs/start 문서를 docs/done으로 이동

### DIFF
--- a/docs/done/1_go_125_implementation.md
+++ b/docs/done/1_go_125_implementation.md
@@ -1,0 +1,148 @@
+# Go 1.25 변경사항 블로그 - 구현 문서
+
+## 1. 샘플 코드 구현
+
+### 1.1 디렉토리 및 패키지
+
+- **경로**: `tutorials-go/golang/go1_25/`
+- **패키지명**: `go1_25`
+- **Go 버전**: go.mod의 go directive가 1.25 이상이어야 함
+- **테스트 프레임워크**: `github.com/stretchr/testify/assert`
+
+### 1.2 각 테스트 파일 구현 상세
+
+#### `gomaxprocs_test.go`
+```go
+// runtime.GOMAXPROCS(0)으로 현재 값 조회
+// runtime.SetDefaultGOMAXPROCS()로 기본값 복원
+// GOMAXPROCS 값이 양수인지 확인
+```
+
+#### `flight_recorder_test.go`
+```go
+// trace.NewFlightRecorder() 생성
+// recorder.Start() → goroutine 작업 수행 → recorder.WriteTo(buffer)
+// 스냅샷 데이터가 비어있지 않은지 확인
+```
+
+#### `nil_pointer_test.go`
+```go
+// 잘못된 패턴: 에러 확인 전 nil 포인터 메서드 호출 → panic 발생 확인
+// 올바른 패턴: 에러 확인 후 포인터 사용 → 정상 동작 확인
+// os.Open("nonExistentFile") 활용
+```
+
+#### `synctest_test.go`
+```go
+// synctest.Test() 내에서 time.After 또는 time.NewTimer 사용
+// synctest.Wait()로 goroutine 동기화
+// 가상 시간에서 타이머가 즉시 만료됨을 확인
+```
+
+#### `waitgroup_go_test.go`
+```go
+// 기존 방식: wg.Add(1) + go func() { defer wg.Done(); ... }()
+// 새 방식: wg.Go(func() { ... })
+// 두 방식 모두 동일한 결과 생성 확인
+// 슬라이스에 값 수집 후 비교
+```
+
+#### `reflect_type_assert_test.go`
+```go
+// reflect.ValueOf(42) → reflect.TypeAssert[int](v) 성공 확인
+// 잘못된 타입으로 TypeAssert → ok=false 확인
+// 기존 v.Interface().(int) 방식과 결과 동일 확인
+```
+
+#### `csrf_protection_test.go`
+```go
+// httptest.NewServer로 CrossOriginProtection 래핑된 핸들러 생성
+// 동일 Origin 요청 → 200 OK
+// 다른 Origin 요청 → 차단 확인
+// GET 요청은 통과, POST 크로스오리진은 차단
+```
+
+#### `testing_attr_test.go`
+```go
+// t.Attr("version", "1.25") 호출
+// t.Attr("category", "runtime") 호출
+// 테스트 통과 확인 (속성은 -json 출력에서만 확인 가능)
+```
+
+#### `vet_hostport_test.go`
+```go
+// 잘못된 방식: fmt.Sprintf("%s:%d", host, port) → IPv6에서 문제
+// 올바른 방식: net.JoinHostPort(host, strconv.Itoa(port))
+// IPv4, IPv6 모두 테스트
+// net.JoinHostPort가 IPv6 주소를 [::1]:8080 형태로 감싸는지 확인
+```
+
+### 1.3 Go 버전 요구사항
+
+- `tutorials-go/go.mod`의 `go` directive를 `1.25` 이상으로 업데이트 필요
+- `toolchain` directive도 `go1.25.0` 이상으로 설정
+- 기존 테스트가 깨지지 않는지 확인 필요
+
+---
+
+## 2. 블로그 포스트 구현
+
+### 2.1 파일 구조
+
+```
+blog-v2.advenoh.pe.kr/contents/go/go-1-25-변경사항-whats-new-in-go-1-25/
+└── index.md
+```
+
+### 2.2 Frontmatter
+
+```yaml
+---
+title: "Go 1.25 변경사항 총정리 (What's New in Go 1.25)"
+description: "Go 1.25의 주요 변경사항을 정리합니다. 컨테이너 인식 GOMAXPROCS, Green Tea GC, testing/synctest, sync.WaitGroup.Go(), encoding/json/v2, Flight Recorder 등 런타임, 표준 라이브러리, 도구 개선 사항을 샘플 코드와 함께 알아봅니다."
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - go1.25
+  - new
+  - green-tea-gc
+  - json-v2
+  - synctest
+  - flight-recorder
+  - runtime
+  - 고랭
+  - 새기능
+---
+```
+
+### 2.3 본문 구성 규칙
+
+- 각 섹션마다 **변경 배경 → 사용법 → 코드 예제** 순서로 작성
+- 코드 예제는 tutorials-go 테스트 파일 내용을 인라인으로 포함
+- 설명 위주 항목(GC, 컴파일러, crypto, 플랫폼 등)은 표나 목록으로 간결하게 정리
+- 마지막에 핵심 요약 표 포함
+
+### 2.4 코드 블록 형식
+
+```markdown
+```go
+// 코드 예제
+func example() {
+    // ...
+}
+`` `
+```
+
+- 언어 태그는 `go` 사용
+- 주석은 한국어로 작성
+- 기존 방식 vs 새로운 방식 비교 시 두 코드 블록을 나란히 배치
+
+---
+
+## 3. 인코딩 및 빌드 검증
+
+- 블로그 파일 작성 후 `file -I` 로 UTF-8 인코딩 확인
+- `tutorials-go/` 에서 `go test ./golang/go1_25/...` 실행
+- `blog-v2.advenoh.pe.kr/` 에서 `npm run build` 실행하여 빌드 성공 확인

--- a/docs/done/1_go_125_prd.md
+++ b/docs/done/1_go_125_prd.md
@@ -1,0 +1,232 @@
+# Go 1.25 변경사항 블로그 PRD
+
+## 개요
+
+Go 1.25의 주요 변경사항을 정리한 기술 블로그 포스트를 작성한다.
+샘플 코드는 `tutorials-go/golang/`에, 블로그 포스트는 `blog-v2.advenoh.pe.kr/contents/go/`에 작성한다.
+
+## 참고 자료
+
+- https://go.dev/doc/go1.25
+- https://go.dev/blog/go1.25
+
+---
+
+## 블로그 구성
+
+### 블로그 메타 정보
+
+- **폴더**: `blog-v2.advenoh.pe.kr/contents/go/go-1-25-변경사항-whats-new-in-go-1-25/index.md`
+- **제목**: "Go 1.25 변경사항 총정리 (What's New in Go 1.25)"
+- **태그**: golang, go, go1.25, new, green-tea-gc, json-v2, synctest, flight-recorder, runtime, 고랭, 새기능
+
+### 목차 구성
+
+#### 1. 개요
+- Go 1.25 릴리스 소개 (2025년 8월 12일)
+- 핵심 테마: 런타임 성능 대폭 개선 + 신규 패키지 + 실험적 기능 도입
+
+#### 2. 런타임 변경사항
+
+##### 2.1 컨테이너 인식 GOMAXPROCS
+- Linux cgroup CPU 대역폭 제한을 자동 감지하여 GOMAXPROCS 설정
+- Kubernetes 환경에서 CPU limit에 맞춤 (CPU requests는 미고려)
+- 주기적 업데이트: 모든 OS에서 CPU 가용성 변경 감지 및 자동 조정
+- `runtime.SetDefaultGOMAXPROCS()` 신규 함수
+- 비활성화: `GOMAXPROCS=8` 또는 `GODEBUG=containermaxprocs=0,updatemaxprocs=0`
+
+##### 2.2 실험적 Green Tea 가비지 컬렉터
+- 소형 객체 마킹/스캔 성능 개선
+- 지역성(locality) 및 CPU 확장성 향상
+- GC 오버헤드 10~40% 감소 예상
+- `GOEXPERIMENT=greenteagc go build`로 활성화
+
+##### 2.3 Flight Recorder (추적 비행 레코더)
+- 기존 `runtime/trace`는 크기가 크고 비용이 높아 드문 이벤트 디버깅에 부적합
+- `trace.NewFlightRecorder()`로 메모리 링 버퍼에 연속 기록
+- 중요 이벤트 발생 시 `WriteTo()`로 최근 몇 초만 스냅샷 저장
+- 프로덕션 환경에서 낮은 오버헤드로 트레이싱 가능
+
+##### 2.4 Panic 출력 변경
+- 기존: `panic: PANIC [recovered]` → `panic: PANIC`
+- 변경: `panic: PANIC [recovered, repanicked]`
+- 디버깅 시 recover/repanic 흐름 추적 용이
+
+##### 2.5 Linux VMA 이름 지정
+- 커널이 지원 시 메모리 영역에 `[anon: Go: heap]` 등 주석 추가
+- `/proc/PID/maps`에서 Go 메모리 영역 식별 가능
+- 비활성화: `GODEBUG=decoratemappings=0`
+
+#### 3. 컴파일러 개선
+
+##### 3.1 nil 포인터 버그 수정
+- Go 1.21~1.24에서 nil 포인터 사용 시 panic이 발생하지 않던 버그
+- Go 1.25에서 올바르게 nil 포인터 panic 발생
+- 코드 예제: 에러 확인 전 포인터 사용 → 수정 패턴
+
+##### 3.2 DWARF5 디버그 정보
+- 디버그 정보 크기 감소 및 링킹 시간 단축
+- 대형 바이너리에서 특히 효과적
+- 비활성화: `GOEXPERIMENT=nodwarf5`
+
+##### 3.3 스택 기반 슬라이스 할당 확대
+- 더 많은 상황에서 슬라이스 백킹 스토어를 스택에 할당
+- 힙 할당 감소로 GC 부담 완화
+
+#### 4. 표준 라이브러리 주요 변경
+
+##### 4.1 testing/synctest - 동시성 코드 테스팅 (신규 패키지)
+- `synctest.Test()`: 가상 시간에서 동시성 코드 실행
+- `synctest.Wait()`: 모든 goroutine이 블록될 때까지 대기
+- 시간을 건너뛰어 빠르고 결정적(deterministic) 테스트 가능
+- 코드 예제: 타이머 기반 동시성 코드 테스트
+
+##### 4.2 encoding/json/v2 (실험적)
+- `GOEXPERIMENT=jsonv2`로 활성화
+- 인코딩: 동등 성능, 디코딩: 상당히 빠름
+- 새 패키지: `encoding/json/v2`, `encoding/json/jsontext`
+- 호환성 테스트 권장: `GOEXPERIMENT=jsonv2 go test ./...`
+
+##### 4.3 sync.WaitGroup.Go() 메서드
+- 기존 `wg.Add(1)` + `go func() { defer wg.Done() ... }()` 패턴 간소화
+- `wg.Go(func() { ... })`로 goroutine 생성과 WaitGroup 관리 자동화
+- 코드 예제: 기존 방식 vs 새로운 방식 비교
+
+##### 4.4 reflect.TypeAssert - 제네릭 타입 단언
+- `reflect.TypeAssert[T](v)`: 메모리 할당 없는 타입 단언
+- 기존 `v.Interface().(T)` 대비 성능 향상
+
+##### 4.5 net/http.CrossOriginProtection - CSRF 보호
+- `http.CrossOriginProtection(handler)` 미들웨어
+- Origin 헤더 검사를 통한 CSRF 보호 내장
+
+##### 4.6 testing.T.Attr() - 테스트 속성
+- `t.Attr("key", "value")`로 테스트 메타데이터 기록
+- `-json` 플래그로 조회 가능
+
+##### 4.7 crypto 성능 대폭 개선
+- Ed25519 서명 (FIPS): 4배 빨라짐
+- RSA 키 생성: 3배 빨라짐
+- SHA-1 (SHA-NI 지원): 2배 빨라짐
+- SHA-3 (Apple M 프로세서): 2배 빨라짐
+- crypto/tls: SHA-1 서명 비허용 (RFC 9155)
+
+##### 4.8 unicode 카테고리 확대
+- `unicode.Cn` (미할당 코드포인트), `unicode.LC` (케이스 문자) 추가
+- `unicode.CategoryAliases` 별칭 맵 지원
+
+#### 5. 도구 변경사항
+
+##### 5.1 go.mod ignore 지시문
+- `ignore` 지시문으로 특정 디렉토리를 패턴 매칭(all, ./...)에서 제외
+- 모듈 zip 파일에는 포함됨
+
+##### 5.2 go doc -http
+- 브라우저에서 로컬 문서 서버 시작
+- 전체 프로젝트 API 문서를 웹에서 탐색
+
+##### 5.3 go version -m -json
+- BuildInfo를 JSON 형식으로 출력
+
+##### 5.4 Vet 신규 분석기
+- **waitgroup**: `sync.WaitGroup.Add`의 잘못된 호출 감지
+- **hostport**: IPv6 주소를 `fmt.Sprintf`로 잘못 연결하는 패턴 감지 → `net.JoinHostPort` 사용 권장
+
+##### 5.5 배포 바이너리 감소
+- 핵심 도구만 포함, 나머지는 `go tool` 실행 시 필요에 따라 빌드
+
+#### 6. 플랫폼 변경사항
+- macOS: 최소 macOS 12 Monterey 이상 (이전 버전 지원 중단)
+- Windows: `windows/arm` (32-bit) 마지막 지원 버전 (Go 1.26에서 제거 예정)
+- Windows: 비동기 I/O 지원, `File ↔ Network Connection` 변환
+- AMD64: `GOAMD64=v3` 이상에서 FMA 명령어 활용
+- Loong64: Race detector 지원, C traceback, 내부 링크 모드
+- RISC-V: plugin 빌드 모드, RVA23U64 프로필 지원
+
+#### 7. 정리
+- Go 1.25 핵심 요약 표
+- Go 1.26 예고
+
+---
+
+## 샘플 코드 구성
+
+### 디렉토리 구조
+
+```
+tutorials-go/golang/go1_25/
+├── gomaxprocs_test.go        # 2.1 컨테이너 인식 GOMAXPROCS
+├── flight_recorder_test.go   # 2.3 Flight Recorder
+├── nil_pointer_test.go       # 3.1 nil 포인터 버그 수정 패턴
+├── synctest_test.go          # 4.1 testing/synctest
+├── waitgroup_go_test.go      # 4.3 sync.WaitGroup.Go()
+├── reflect_type_assert_test.go # 4.4 reflect.TypeAssert
+├── csrf_protection_test.go   # 4.5 net/http.CrossOriginProtection
+├── testing_attr_test.go      # 4.6 testing.T.Attr()
+├── vet_hostport_test.go      # 5.4 Vet hostport 분석기 (올바른 vs 잘못된 사용)
+└── README.md                 # 예제 설명
+```
+
+> 참고: Green Tea GC(2.2), 컴파일러 개선(3.2~3.3), crypto(4.7), unicode(4.8), 도구(5.1~5.3, 5.5), 플랫폼(6장)은 코드 예제 없이 설명 위주로 작성한다.
+> encoding/json/v2(4.2)는 실험적 기능이므로 개념 코드만 블로그에 포함한다.
+
+### 각 테스트 파일 요구사항
+
+| 파일 | 핵심 내용 |
+|------|----------|
+| `gomaxprocs_test.go` | `runtime.GOMAXPROCS(0)` 조회, `runtime.SetDefaultGOMAXPROCS()` 호출 |
+| `flight_recorder_test.go` | `trace.NewFlightRecorder()` 생성, `WriteTo()` 스냅샷 저장 |
+| `nil_pointer_test.go` | 에러 확인 전 포인터 사용 (잘못된 패턴) vs 에러 확인 후 사용 (올바른 패턴) |
+| `synctest_test.go` | `synctest.Test()` + `synctest.Wait()` 사용, 가상 시간 기반 타이머 테스트 |
+| `waitgroup_go_test.go` | 기존 `Add/Done` 패턴 vs `wg.Go()` 패턴 비교 |
+| `reflect_type_assert_test.go` | `reflect.TypeAssert[int](v)` vs `v.Interface().(int)` 비교 |
+| `csrf_protection_test.go` | `http.CrossOriginProtection` 미들웨어 적용, 크로스 오리진 요청 차단 확인 |
+| `testing_attr_test.go` | `t.Attr("key", "value")` 사용하여 테스트 속성 기록 |
+| `vet_hostport_test.go` | `fmt.Sprintf("%s:%d", host, port)` (잘못된) vs `net.JoinHostPort` (올바른) |
+
+---
+
+## 작업 순서
+
+### Phase 1: 환경 준비
+1. `tutorials-go/golang/go1_25/` 디렉토리 생성
+2. Go 1.25 이상 환경 확인
+
+### Phase 2: 샘플 코드 작성
+3. 각 테스트 파일 작성 (위 테이블 순서대로)
+4. `go test ./golang/go1_25/...` 로 전체 테스트 통과 확인
+
+### Phase 3: 블로그 포스트 작성
+5. `blog-v2.advenoh.pe.kr/contents/go/go-1-25-변경사항-whats-new-in-go-1-25/index.md` 작성
+6. frontmatter 작성 (title, description, date, update, tags)
+7. 목차 순서대로 본문 작성
+8. 샘플 코드를 블로그 본문에 인라인으로 포함
+9. 인코딩 확인 (`file -I`)
+
+### Phase 4: 검증
+10. 블로그 빌드 확인 (`npm run build`)
+11. 튜토리얼 테스트 확인 (`go test ./golang/go1_25/...`)
+
+---
+
+## 참고: Go 1.25 핵심 변경사항 요약
+
+| 카테고리 | 변경사항 | 영향도 |
+|---------|---------|--------|
+| 런타임 | 컨테이너 인식 GOMAXPROCS | ★★★ |
+| 런타임 | Green Tea GC (실험적) | ★★★ |
+| 런타임 | Flight Recorder | ★★☆ |
+| 컴파일러 | nil 포인터 버그 수정 | ★★★ |
+| 컴파일러 | 스택 기반 슬라이스 할당 확대 | ★★☆ |
+| 표준 라이브러리 | `testing/synctest` 신규 패키지 | ★★★ |
+| 표준 라이브러리 | `encoding/json/v2` (실험적) | ★★★ |
+| 표준 라이브러리 | `sync.WaitGroup.Go()` | ★★★ |
+| 표준 라이브러리 | `reflect.TypeAssert[T]()` | ★★☆ |
+| 표준 라이브러리 | `net/http.CrossOriginProtection` | ★★☆ |
+| 성능 | Ed25519 서명 4배 향상 | ★★☆ |
+| 성능 | RSA 키 생성 3배 향상 | ★★☆ |
+| 성능 | SHA-1/SHA-3 2배 향상 | ★★☆ |
+| 도구 | `go.mod ignore` 지시문 | ★★☆ |
+| 도구 | Vet 신규 분석기 (waitgroup, hostport) | ★★☆ |
+| 플랫폼 | macOS 12 최소 요구 | ★★☆ |
+| 플랫폼 | Windows 비동기 I/O | ★★☆ |

--- a/docs/done/1_go_125_todo.md
+++ b/docs/done/1_go_125_todo.md
@@ -1,0 +1,38 @@
+# Go 1.25 변경사항 블로그 - Todo
+
+## Phase 1: 환경 준비
+
+- [x] `tutorials-go/golang/go1_25/` 디렉토리 생성
+- [x] `tutorials-go/go.mod` Go 버전 확인 및 필요 시 업데이트 (1.25 이상)
+- [x] Go 1.25 로컬 설치 확인 (`go version`)
+
+## Phase 2: 샘플 코드 작성
+
+- [x] `gomaxprocs_test.go` 작성 - GOMAXPROCS 조회 및 SetDefaultGOMAXPROCS
+- [x] `flight_recorder_test.go` 작성 - FlightRecorder 생성 및 WriteTo 스냅샷
+- [x] `nil_pointer_test.go` 작성 - 잘못된 패턴 vs 올바른 패턴
+- [x] `synctest_test.go` 작성 - synctest.Test + synctest.Wait 가상 시간 테스트
+- [x] `waitgroup_go_test.go` 작성 - 기존 Add/Done vs wg.Go() 비교
+- [x] `reflect_type_assert_test.go` 작성 - TypeAssert[T] vs Interface().(T)
+- [x] `csrf_protection_test.go` 작성 - CrossOriginProtection 미들웨어 테스트
+- [x] `testing_attr_test.go` 작성 - t.Attr() 속성 기록
+- [x] `vet_hostport_test.go` 작성 - Sprintf vs JoinHostPort 비교
+- [x] `go test ./golang/go1_25/...` 전체 테스트 통과 확인
+
+## Phase 3: 블로그 포스트 작성
+
+- [x] `blog-v2.advenoh.pe.kr/contents/go/go-1-25-변경사항-whats-new-in-go-1-25/` 디렉토리 생성
+- [x] `index.md` 파일 생성 및 frontmatter 작성
+- [x] 1장: 개요 작성
+- [x] 2장: 런타임 변경사항 작성 (GOMAXPROCS, Green Tea GC, Flight Recorder, Panic, VMA)
+- [x] 3장: 컴파일러 개선 작성 (nil 포인터, DWARF5, 스택 슬라이스)
+- [x] 4장: 표준 라이브러리 변경 작성 (synctest, json/v2, WaitGroup.Go, TypeAssert, CSRF, Attr, crypto, unicode)
+- [x] 5장: 도구 변경사항 작성 (ignore, doc -http, version -json, Vet)
+- [x] 6장: 플랫폼 변경사항 작성
+- [x] 7장: 정리 및 요약 표 작성
+- [x] 인코딩 확인 (`file -I index.md` → charset=utf-8)
+
+## Phase 4: 검증
+
+- [x] `tutorials-go/` 에서 `go test ./golang/go1_25/...` 최종 통과 확인
+- [x] `blog-v2.advenoh.pe.kr/` 에서 `npm run build` 빌드 성공 확인

--- a/docs/done/1_go_126_implementation.md
+++ b/docs/done/1_go_126_implementation.md
@@ -1,0 +1,192 @@
+# Go 1.26 변경사항 블로그 - 구현 문서
+
+## 1. 환경 준비
+
+### Go 버전 업데이트
+- `tutorials-go/go.mod`의 go directive를 `go 1.26`으로 변경
+- toolchain도 `go1.26.x`로 업데이트
+
+### 디렉토리 생성
+```
+tutorials-go/golang/go1_26/
+```
+
+---
+
+## 2. 샘플 코드 구현
+
+모든 파일은 `package go1_26_test`로 작성하며, 외부 의존성 없이 표준 라이브러리만 사용한다.
+
+### 2.1 new_expr_test.go
+```go
+// 기본 타입 포인터 생성
+p := new(42)           // *int
+s := new("hello")      // *string
+
+// 슬라이스 포인터
+ps := new([]int{1, 2, 3})
+
+// 구조체 필드에 활용
+type Config struct {
+    Timeout *int
+}
+c := Config{Timeout: new(30)}
+```
+
+### 2.2 recursive_generics_test.go
+```go
+type Ordered[T Ordered[T]] interface {
+    Less(T) bool
+}
+
+type MyInt int
+func (a MyInt) Less(b MyInt) bool { return a < b }
+
+// Tree, Min/Max 등 활용 예제
+```
+
+### 2.3 errors_astype_test.go
+```go
+type AppError struct {
+    Code    int
+    Message string
+}
+func (e *AppError) Error() string { return e.Message }
+
+// 기존: errors.As
+var target *AppError
+if errors.As(err, &target) { ... }
+
+// 신규: errors.AsType (타입 안전)
+if target, ok := errors.AsType[*AppError](err); ok { ... }
+```
+
+### 2.4 reflect_iter_test.go
+```go
+typ := reflect.TypeFor[http.Client]()
+for f := range typ.Fields() {
+    fmt.Println(f.Name, f.Type)
+}
+for m := range typ.Methods() {
+    fmt.Println(m.Name)
+}
+```
+
+### 2.5 buffer_peek_test.go
+```go
+buf := bytes.NewBufferString("hello world")
+peeked, _ := buf.Peek(5)
+// peeked == "hello", buf 위치 변경 없음
+assert(buf.Len() == 11)
+```
+
+### 2.6 slog_multi_test.go
+```go
+var buf1, buf2 bytes.Buffer
+h1 := slog.NewTextHandler(&buf1, nil)
+h2 := slog.NewJSONHandler(&buf2, nil)
+multi := slog.NewMultiHandler(h1, h2)
+logger := slog.New(multi)
+logger.Info("test message")
+// buf1, buf2 모두 로그 출력 확인
+```
+
+### 2.7 io_readall_bench_test.go
+```go
+func BenchmarkReadAll(b *testing.B) {
+    data := bytes.Repeat([]byte("x"), 1024*1024)
+    for b.Loop() {
+        io.ReadAll(bytes.NewReader(data))
+    }
+}
+```
+
+### 2.8 fmt_errorf_bench_test.go
+```go
+func BenchmarkErrorfNoFormat(b *testing.B) {
+    for b.Loop() {
+        _ = fmt.Errorf("simple error")
+    }
+}
+func BenchmarkErrorfWithFormat(b *testing.B) {
+    for b.Loop() {
+        _ = fmt.Errorf("error: %s", "detail")
+    }
+}
+```
+
+### 2.9 artifact_dir_test.go
+```go
+func TestArtifactDir(t *testing.T) {
+    dir := t.ArtifactDir()
+    os.WriteFile(filepath.Join(dir, "output.txt"), []byte("test result"), 0644)
+}
+```
+
+### 2.10 signal_context_test.go
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+defer stop()
+// context.Cause(ctx) 로 시그널 정보 확인
+```
+
+### 2.11 netip_compare_test.go
+```go
+prefixes := []netip.Prefix{
+    netip.MustParsePrefix("192.168.1.0/24"),
+    netip.MustParsePrefix("10.0.0.0/8"),
+    netip.MustParsePrefix("172.16.0.0/12"),
+}
+slices.SortFunc(prefixes, netip.Prefix.Compare)
+```
+
+---
+
+## 3. 블로그 포스트 구현
+
+### 파일 경로
+```
+blog-v2.advenoh.pe.kr/contents/go/go-1-26-변경사항-whats-new-in-go-1-26/index.md
+```
+
+### frontmatter
+```yaml
+---
+title: "Go 1.26 변경사항 총정리 (What's New in Go 1.26)"
+description: "Go 1.26 변경사항 총정리 (What's New in Go 1.26)"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - go1.26
+  - new
+  - green-tea-gc
+  - cgo
+  - simd
+  - hpke
+  - generics
+  - errors
+  - reflect
+  - 고랭
+  - 새기능
+---
+```
+
+### 본문 작성 규칙
+- 각 섹션에 코드 예제를 인라인으로 포함 (```go 코드블록)
+- 기존 방식 vs 새로운 방식 비교 형식 적극 활용
+- 성능 수치는 공식 문서 기반으로 정확히 기재
+- 실험적 기능은 `GOEXPERIMENT` 활성화 방법 명시
+- 참고 링크는 포스트 하단에 배치
+
+### 블로그 본문 구조
+1. **개요**: 릴리스 날짜, 핵심 테마 3줄 요약
+2. **언어 변경**: 코드 before/after 비교
+3. **표준 라이브러리**: 각 항목별 코드 예제 + 간단 설명
+4. **성능 개선**: 수치 중심 설명 (코드 없음, Green Tea GC 아키텍처 간략 설명)
+5. **보안/암호화**: crypto/hpke 사용 예시, API 변경 before/after
+6. **도구 개선**: `go fix` 사용법, modernizer 목록
+7. **실험적 기능**: GOEXPERIMENT 플래그 + pseudocode
+8. **기타**: 플랫폼별 변경 표
+9. **정리**: 핵심 요약 표 + Go 1.27 제거 예정 목록

--- a/docs/done/1_go_126_prd.md
+++ b/docs/done/1_go_126_prd.md
@@ -1,0 +1,213 @@
+# Go 1.26 변경사항 블로그 PRD
+
+## 개요
+
+Go 1.26의 주요 변경사항을 정리한 기술 블로그 포스트를 작성한다.
+샘플 코드는 `tutorials-go/golang/`에, 블로그 포스트는 `blog-v2.advenoh.pe.kr/contents/go/`에 작성한다.
+
+## 참고 자료
+
+- https://go.dev/doc/go1.26
+- https://go.dev/blog/go1.26
+- https://antonz.org/go-1-26/
+
+---
+
+## 블로그 구성
+
+### 블로그 메타 정보
+
+- **폴더**: `blog-v2.advenoh.pe.kr/contents/go/go-1-26-변경사항-whats-new-in-go-1-26/index.md`
+- **제목**: "Go 1.26 변경사항 총정리 (What's New in Go 1.26)"
+- **태그**: golang, go, go1.26, new, green-tea-gc, cgo, simd, hpke, generics, errors, reflect, 고랭, 새기능
+
+### 목차 구성
+
+#### 1. 개요
+- Go 1.26 릴리스 소개
+- 핵심 테마: 성능 최적화 + 언어 개선 + 보안 강화
+
+#### 2. 언어 변경사항
+
+##### 2.1 new() 함수 확장 - 초기값 지정 가능
+- 기존: `new(T)` → 제로값 포인터만 생성
+- 변경: `new(expr)` → 표현식으로 초기값 지정 가능
+- 코드 예제: 기존 방식 vs 새로운 방식 비교
+
+##### 2.2 제네릭 타입 자기참조 (Recursive Type Constraints)
+- 제네릭 타입이 자기 자신을 타입 파라미터로 참조 가능
+- 코드 예제: Ordered 인터페이스, Tree 구조체
+
+#### 3. 표준 라이브러리 주요 변경
+
+##### 3.1 errors.AsType - 타입 안전한 오류 검사
+- 기존 `errors.As()` vs 새로운 `errors.AsType[T]()`
+- 제네릭 기반으로 타입 안전성 향상
+
+##### 3.2 reflect 반복자 추가
+- `Type.Fields()`, `Type.Methods()` 반복자
+- range 루프로 필드/메서드 순회
+
+##### 3.3 bytes.Buffer.Peek() 메서드
+- 버퍼를 진행시키지 않고 다음 바이트 확인
+
+##### 3.4 slog.NewMultiHandler()
+- 여러 로그 핸들러 동시 사용
+
+##### 3.5 io.ReadAll() 성능 최적화
+- 2배 빠른 성능, 메모리 50% 감소
+
+##### 3.6 fmt.Errorf() 최적화
+- 포맷 없는 문자열의 할당 감소 (92% 빨라짐)
+
+##### 3.7 testing.ArtifactDir()
+- 테스트 아티팩트 저장 디렉토리
+
+##### 3.8 signal.NotifyContext와 Context Cause
+- 시그널 수신 정보를 컨텍스트 원인으로 포함
+
+##### 3.9 netip.Prefix.Compare
+- CIDR 표기법 서브넷 정렬 지원
+
+#### 4. 성능 개선
+
+##### 4.1 Green Tea 가비지 컬렉터 (기본 활성화)
+- Go 1.25 실험 → Go 1.26 기본값
+- GC 오버헤드 10-40% 감소
+- 최신 CPU에서 추가 10% 개선
+
+##### 4.2 cgo 호출 성능 30% 향상
+- 프로세서 상태 관리 단순화
+
+##### 4.3 소형 객체 메모리 할당 최적화
+- 1-512바이트 객체 할당 최대 30% 향상
+
+##### 4.4 스택 기반 슬라이스 할당 확대
+- 더 많은 상황에서 슬라이스 백킹 스토어를 스택에 할당
+
+#### 5. 보안 및 암호화
+
+##### 5.1 crypto/hpke 패키지 (신규)
+- RFC 9180 Hybrid Public Key Encryption
+
+##### 5.2 암호화 API 개선 - io.Reader 제거
+- `rand.Reader` 파라미터 불필요 → nil 전달 가능
+
+##### 5.3 힙 베이스 주소 무작위화
+- 64비트 플랫폼에서 메모리 주소 예측 방지
+
+#### 6. 도구 개선
+
+##### 6.1 go fix 재작성
+- 분석 프레임워크 기반 modernizers
+- `//go:fix inline` 지시자로 커스텀 마이그레이션
+
+#### 7. 실험적 기능
+
+##### 7.1 SIMD 연산 (simd/archsimd)
+- amd64 아키텍처 벡터화 연산
+- `GOEXPERIMENT=simd`로 활성화
+
+##### 7.2 고루틴 누수 프로필 (goroutineleak)
+- `GOEXPERIMENT=goroutineleakprofile`로 활성화
+- `/debug/pprof/goroutineleak` 엔드포인트
+
+##### 7.3 runtime/secret - 민감 데이터 안전 소거
+- `GOEXPERIMENT=runtimesecret`로 활성화
+
+#### 8. 기타 변경사항
+- macOS: Go 1.26이 Monterey 지원 마지막 버전
+- Windows: `windows/arm` (32비트) 제거
+- RISC-V: race detector 지원
+- net.Dialer: DialTCP, DialUDP 등 메서드 추가
+- httptest.Server: example.com 자동 리다이렉트
+
+#### 9. 정리
+- Go 1.26 핵심 요약 표
+- Go 1.27 예고 (제거 예정 GODEBUG 목록)
+
+---
+
+## 샘플 코드 구성
+
+### 디렉토리 구조
+
+```
+tutorials-go/golang/go1_26/
+├── new_expr_test.go           # 2.1 new() 함수 확장
+├── recursive_generics_test.go # 2.2 제네릭 자기참조
+├── errors_astype_test.go      # 3.1 errors.AsType
+├── reflect_iter_test.go       # 3.2 reflect 반복자
+├── buffer_peek_test.go        # 3.3 bytes.Buffer.Peek
+├── slog_multi_test.go         # 3.4 slog.NewMultiHandler
+├── io_readall_bench_test.go   # 3.5 io.ReadAll 벤치마크
+├── fmt_errorf_bench_test.go   # 3.6 fmt.Errorf 벤치마크
+├── artifact_dir_test.go       # 3.7 testing.ArtifactDir
+├── signal_context_test.go     # 3.8 signal.NotifyContext
+├── netip_compare_test.go      # 3.9 netip.Prefix.Compare
+└── README.md                  # 예제 설명
+```
+
+> 참고: 성능 개선(4장), 보안(5장), 도구(6장), 실험적 기능(7장)은 코드 예제 없이 설명 위주로 작성한다.
+> 단, SIMD(7.1)와 goroutine leak(7.2)은 개념 코드(pseudocode)만 블로그에 포함한다.
+
+### 각 테스트 파일 요구사항
+
+| 파일 | 핵심 내용 |
+|------|----------|
+| `new_expr_test.go` | `new(42)`, `new([]int{1,2,3})`, 구조체 필드에 `new(expr)` 활용 |
+| `recursive_generics_test.go` | `Ordered[T Ordered[T]]` 인터페이스, `Tree[T]` 구현 |
+| `errors_astype_test.go` | 커스텀 에러 정의, `errors.As` vs `errors.AsType` 비교 |
+| `reflect_iter_test.go` | `Type.Fields()`, `Type.Methods()` range 순회 |
+| `buffer_peek_test.go` | `Buffer.Peek()` 사용, 버퍼 위치 미변경 확인 |
+| `slog_multi_test.go` | `NewMultiHandler` 로 여러 핸들러에 동시 출력 |
+| `io_readall_bench_test.go` | `io.ReadAll` 벤치마크 |
+| `fmt_errorf_bench_test.go` | `fmt.Errorf` 할당 벤치마크 |
+| `artifact_dir_test.go` | `t.ArtifactDir()` 사용하여 테스트 산출물 저장 |
+| `signal_context_test.go` | `signal.NotifyContext` + `context.Cause` 확인 |
+| `netip_compare_test.go` | `netip.Prefix.Compare` 로 서브넷 정렬 |
+
+---
+
+## 작업 순서
+
+### Phase 1: 환경 준비
+1. `tutorials-go/go.mod`에서 Go 버전을 1.26으로 업데이트
+2. `tutorials-go/golang/go1_26/` 디렉토리 생성
+
+### Phase 2: 샘플 코드 작성
+3. 각 테스트 파일 작성 (위 테이블 순서대로)
+4. `go test ./golang/go1_26/...` 로 전체 테스트 통과 확인
+
+### Phase 3: 블로그 포스트 작성
+5. `blog-v2.advenoh.pe.kr/contents/go/go-1-26-변경사항-whats-new-in-go-1-26/index.md` 작성
+6. frontmatter 작성 (title, description, date, update, tags)
+7. 목차 순서대로 본문 작성
+8. 샘플 코드를 블로그 본문에 인라인으로 포함
+9. 인코딩 확인 (`file -I`)
+
+### Phase 4: 검증
+10. 블로그 빌드 확인 (`npm run build`)
+11. 튜토리얼 테스트 확인 (`go test ./golang/go1_26/...`)
+
+---
+
+## 참고: Go 1.26 핵심 변경사항 요약
+
+| 카테고리 | 변경사항 | 영향도 |
+|---------|---------|--------|
+| 언어 | `new(expr)` 초기값 지정 | ★★★ |
+| 언어 | 제네릭 자기참조 | ★★☆ |
+| 표준 라이브러리 | `errors.AsType[T]()` | ★★★ |
+| 표준 라이브러리 | reflect 반복자 | ★★☆ |
+| 표준 라이브러리 | `bytes.Buffer.Peek()` | ★★☆ |
+| 표준 라이브러리 | `slog.NewMultiHandler()` | ★★☆ |
+| 성능 | Green Tea GC 기본화 | ★★★ |
+| 성능 | cgo 30% 향상 | ★★★ |
+| 성능 | `io.ReadAll` 2배 빠름 | ★★☆ |
+| 성능 | `fmt.Errorf` 92% 빠름 | ★★☆ |
+| 보안 | `crypto/hpke` 신규 | ★★☆ |
+| 보안 | 힙 주소 무작위화 | ★★☆ |
+| 도구 | `go fix` 재작성 | ★★★ |
+| 실험 | SIMD 연산 | ★★☆ |
+| 실험 | 고루틴 누수 프로필 | ★★★ |

--- a/docs/done/1_go_126_todo.md
+++ b/docs/done/1_go_126_todo.md
@@ -1,0 +1,36 @@
+# Go 1.26 변경사항 블로그 - TODO
+
+## Phase 1: 환경 준비
+- [x] `tutorials-go/go.mod` Go 버전 1.26으로 업데이트
+- [x] `tutorials-go/golang/go1_26/` 디렉토리 생성
+
+## Phase 2: 샘플 코드 작성
+- [x] `new_expr_test.go` - new(expr) 초기값 지정 예제
+- [x] `recursive_generics_test.go` - 제네릭 자기참조 예제
+- [x] `errors_astype_test.go` - errors.AsType 비교 예제
+- [x] `reflect_iter_test.go` - reflect 반복자 예제
+- [x] `buffer_peek_test.go` - bytes.Buffer.Peek 예제
+- [x] `slog_multi_test.go` - slog.NewMultiHandler 예제
+- [x] `io_readall_bench_test.go` - io.ReadAll 벤치마크
+- [x] `fmt_errorf_bench_test.go` - fmt.Errorf 벤치마크
+- [x] `artifact_dir_test.go` - testing.ArtifactDir 예제
+- [x] `signal_context_test.go` - signal.NotifyContext + Cause 예제
+- [x] `netip_compare_test.go` - netip.Prefix.Compare 예제
+- [x] 전체 테스트 실행 확인 (`go test ./golang/go1_26/...`)
+
+## Phase 3: 블로그 포스트 작성
+- [x] 블로그 디렉토리 생성 (`go-1-26-변경사항-whats-new-in-go-1-26/`)
+- [x] index.md frontmatter 작성
+- [x] 1장: 언어 변경사항 작성 (new, 제네릭 자기참조)
+- [x] 2장: 성능 개선 작성 (Green Tea GC, cgo, io.ReadAll, fmt.Errorf, 메모리 할당)
+- [x] 3장: 표준 라이브러리 변경 작성 (7개 항목)
+- [x] 4장: 보안 및 암호화 작성 (crypto/hpke, API 개선, 힙 무작위화, TLS)
+- [x] 5장: 도구 개선 작성 (go fix, go mod init)
+- [x] 6장: 실험적 기능 작성 (SIMD, goroutine leak, secret)
+- [x] 7장: 기타 변경사항 작성
+- [x] 8장: 정리 작성 (요약표, Go 1.27 예고)
+- [x] UTF-8 인코딩 확인 (`file -I`)
+
+## Phase 4: 검증
+- [x] 튜토리얼 테스트 최종 확인 (`go test ./golang/go1_26/...`) - 30/30 PASS
+- [x] 블로그 빌드 확인 (`npm run build`) - 148 articles, 156 pages 성공

--- a/docs/done/2_chatgpt.md
+++ b/docs/done/2_chatgpt.md
@@ -1,0 +1,222 @@
+좋다 👍
+블로그로 정리하면서 공부한다면 개념 → 내부 동작 → 패턴 → 실전 → 성능/디버깅 흐름으로 가는 게 가장 좋다.
+특히 Golang concurrency는 “문법”보다 철학 + 설계 패턴 이해가 중요하다.
+
+아래는 **블로그 시리즈 기준 목차 (스터디 로드맵)**이다.
+
+⸻
+
+📘 Golang Concurrency 스터디 & 블로그 목차
+
+1. 개요
+   •	Concurrency vs Parallelism 차이
+   •	왜 Go는 concurrency에 강한가
+   •	Go concurrency 철학
+   •	“Do not communicate by sharing memory…”
+   •	언제 concurrency를 사용해야 하는가
+   •	언제 사용하면 안 되는가 (오버엔지니어링)
+
+⸻
+
+2. Goroutine 기초
+   •	goroutine 생성 방법
+   •	main goroutine과 lifecycle
+   •	goroutine scheduling 개념
+   •	runtime scheduler (M:N 모델)
+   •	goroutine 비용 (lightweight thread)
+   •	goroutine leak이란?
+
+👉 실습
+•	goroutine 실행 순서 확인
+•	sleep 없이 프로그램 종료되는 문제
+
+⸻
+
+3. Channel 기초
+   •	channel 생성 (make)
+   •	send / receive
+   •	blocking 동작 이해
+   •	unbuffered vs buffered channel
+   •	channel 방향 제한 (send-only / receive-only)
+   •	channel close 의미
+
+👉 실습
+•	producer / consumer
+•	buffered vs unbuffered 성능 비교
+
+⸻
+
+4. Channel 심화
+   •	range channel
+   •	select 문
+   •	default case
+   •	timeout 처리
+   •	fan-in / fan-out
+   •	nil channel 트릭
+
+👉 실습
+•	여러 worker 결과 모으기
+•	timeout 있는 API 호출
+
+⸻
+
+5. Synchronization primitives
+   •	왜 synchronization이 필요한가
+   •	race condition
+   •	sync.WaitGroup
+   •	sync.Mutex
+   •	sync.RWMutex
+   •	sync.Once
+   •	sync.Cond (optional advanced)
+
+👉 실습
+•	shared counter 보호
+•	singleton 구현
+
+⸻
+
+6. Context 패키지 (필수)
+   •	context 개념
+   •	cancellation
+   •	timeout / deadline
+   •	request scope
+   •	context value 사용 주의사항
+
+👉 실습
+•	goroutine cancel
+•	HTTP request timeout
+
+⸻
+
+7. Go Concurrency Patterns (핵심)
+
+이 부분이 실무에서 가장 중요
+•	Worker pool
+•	Pipeline
+•	Fan-out / Fan-in
+•	Semaphore pattern
+•	Rate limiting
+•	Pub/Sub
+•	Bounded concurrency
+
+👉 실습
+•	concurrent file processing
+•	parallel API crawler
+
+⸻
+
+8. Error handling in concurrency
+   •	goroutine에서 error 전달
+   •	error channel
+   •	multi-error 처리
+   •	errgroup 사용
+
+👉 실습
+•	parallel job error aggregation
+
+⸻
+
+9. Memory model & happens-before
+
+(중급 이상 핵심 개념)
+•	Go memory model
+•	happens-before 관계
+•	visibility 문제
+•	atomic operations
+•	sync/atomic 패키지
+
+👉 실습
+•	atomic counter vs mutex
+
+⸻
+
+10. Concurrency debugging & testing
+    •	race detector (-race)
+    •	goroutine dump
+    •	deadlock 분석
+    •	pprof로 분석
+    •	testing with concurrency
+
+👉 실습
+•	의도적으로 race 만들기
+•	deadlock 재현
+
+⸻
+
+11. 성능 최적화
+    •	goroutine 개수 tuning
+    •	worker 수 결정 전략
+    •	channel buffer size 결정
+    •	false sharing
+    •	scheduler 영향
+
+👉 실습
+•	worker 수별 throughput 측정
+
+⸻
+
+12. 실전 프로젝트 (추천)
+
+블로그 마지막 시리즈
+
+프로젝트 후보
+•	concurrent web crawler
+•	distributed task runner
+•	rate limited API client
+•	parallel image processor
+•	log processing pipeline
+•	realtime streaming processor
+
+⸻
+
+13. Best Practices
+    •	channel vs mutex 언제 쓰나
+    •	context 반드시 전달하기
+    •	goroutine leak 방지
+    •	channel close 책임
+    •	structured concurrency
+    •	graceful shutdown
+
+⸻
+
+14. Anti-pattern
+    •	global channel 남용
+    •	무한 goroutine 생성
+    •	context 안 쓰는 서버
+    •	channel close panic
+    •	select default 남용
+
+⸻
+
+15. 정리
+    •	핵심 개념 요약
+    •	실무 체크리스트
+    •	추천 라이브러리
+
+⸻
+
+⭐ 추천 블로그 시리즈 구성 (현실적인 분량)
+1.	concurrency 개요 + goroutine
+2.	channel 완전 정복
+3.	select & 패턴
+4.	sync 패키지
+5.	context
+6.	concurrency patterns
+7.	error handling
+8.	memory model
+9.	debugging / race detector
+10.	실전 프로젝트
+
+⸻
+
+원하면 다음 단계로 바로 만들어 줄 수 있다 👇
+
+✅ 각 목차별 블로그 초안 작성
+✅ golang 실습 코드 포함 버전
+✅ 실무 관점 설명 강화
+✅ 다이어그램 포함 설명
+✅ concurrency 패턴만 deep dive 시리즈
+✅ “면접 대비” 버전
+✅ 예제 프로젝트 하나 같이 구현
+
+어떤 방식으로 진행할까?

--- a/docs/done/3_ccplugin_prd.md
+++ b/docs/done/3_ccplugin_prd.md
@@ -1,0 +1,592 @@
+# Claude Code Plugin Sample - PRD
+
+## 1. 목표
+
+누구나 `Marketplace`로 추가하여 바로 설치·사용할 수 있는 **실용적인 Claude Code Plugin 모음**을 구축한다. 각 Plugin은 개발자가 실제로 필요로 하는 문제를 해결하며, 동시에 Plugin 개발의 best practice를 보여준다.
+
+```bash
+# 사용자가 이렇게 바로 설치할 수 있는 수준
+/plugin marketplace add kenshin579/claude-code-plugin-sample
+/plugin install safe-guard@cc-plugin-samples
+```
+
+## 2. 배경
+
+- Claude Code Plugin 시스템이 출시되었지만, 실전에서 참고할 만한 오픈소스 Plugin이 부족하다
+- 공식 Marketplace의 Plugin은 LSP 중심이며, Hooks·Skills·Agents를 활용한 워크플로우 Plugin 예시가 적다
+- Plugin을 만들려는 개발자에게 구조, 패턴, best practice를 보여줄 레퍼런스가 필요하다
+- `kenshin579/claude-code-plugin-sample` GitHub 레포가 이미 생성되어 있다
+
+## 3. 설계 원칙
+
+1. **즉시 사용 가능**: clone 후 `--plugin-dir`로 바로 테스트, Marketplace로 원격 설치 모두 지원
+2. **실용성 우선**: 데모가 아닌, 실제 개발 워크플로우에서 쓸 수 있는 Plugin
+3. **독립적**: 각 Plugin은 서로 의존성 없이 개별 설치·사용 가능
+4. **최소 외부 의존성**: 시스템 기본 도구(bash, jq)만 사용, 추가 설치 불필요
+5. **Best Practice 준수**: Plugin 구조, 네이밍, 환경변수, 에러 처리의 모범 사례
+
+## 4. 레포 구조
+
+```
+claude-code-plugin-sample/
+├── .claude-plugin/
+│   └── marketplace.json               # Marketplace 매니페스트
+├── README.md                          # 프로젝트 소개, 설치법, 각 Plugin 설명
+├── CLAUDE.md                          # Claude Code 프로젝트 가이드
+├── LICENSE
+│
+├── plugins/
+│   ├── safe-guard/                    # 위험 명령 차단 & 파일 보호
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json
+│   │   ├── hooks/
+│   │   │   ├── hooks.json
+│   │   │   ├── block-dangerous-commands.sh
+│   │   │   └── protect-sensitive-files.sh
+│   │   ├── commands/
+│   │   │   └── safeguard-status.md
+│   │   └── README.md
+│   │
+│   ├── code-quality/                  # 자동 린팅 & 코드 리뷰
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json
+│   │   ├── hooks/
+│   │   │   ├── hooks.json
+│   │   │   └── auto-lint.sh
+│   │   ├── skills/
+│   │   │   └── code-review/
+│   │   │       └── SKILL.md
+│   │   ├── agents/
+│   │   │   └── code-reviewer.md
+│   │   ├── commands/
+│   │   │   └── review.md
+│   │   ├── .mcp.json                  # MCP 서버 설정 (context7)
+│   │   └── README.md
+│   │
+│   ├── git-workflow/                  # Git 워크플로우 자동화
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json
+│   │   ├── skills/
+│   │   │   ├── commit-msg/
+│   │   │   │   └── SKILL.md
+│   │   │   └── pr-create/
+│   │   │       └── SKILL.md
+│   │   ├── commands/
+│   │   │   ├── commit.md
+│   │   │   ├── pr.md
+│   │   │   └── status.md
+│   │   ├── .mcp.json                  # MCP 서버 설정 (github)
+│   │   └── README.md
+│   │
+│   └── security-scanner/              # 보안 취약점 스캐너
+│       ├── .claude-plugin/
+│       │   └── plugin.json
+│       ├── agents/
+│       │   └── security-auditor.md
+│       ├── skills/
+│       │   └── security-scan/
+│       │       └── SKILL.md
+│       ├── hooks/
+│       │   ├── hooks.json
+│       │   └── check-secrets.sh
+│       ├── commands/
+│       │   └── scan.md
+│       └── README.md
+│
+└── docs/
+    └── CONTRIBUTING.md                # Plugin 기여 가이드
+```
+
+## 5. Marketplace 매니페스트
+
+```json
+{
+  "name": "cc-plugin-samples",
+  "owner": {
+    "name": "kenshin579",
+    "url": "https://github.com/kenshin579"
+  },
+  "metadata": {
+    "description": "실용적인 Claude Code Plugin 모음 - 보안, 코드 품질, Git 워크플로우, 보안 스캐너",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "safe-guard",
+      "source": "./plugins/safe-guard",
+      "description": "위험 명령 차단 및 민감 파일 보호 Plugin",
+      "version": "1.0.0",
+      "tags": ["security", "hooks", "protection"]
+    },
+    {
+      "name": "code-quality",
+      "source": "./plugins/code-quality",
+      "description": "자동 린팅 및 코드 리뷰 Plugin",
+      "version": "1.0.0",
+      "tags": ["lint", "review", "quality", "mcp"]
+    },
+    {
+      "name": "git-workflow",
+      "source": "./plugins/git-workflow",
+      "description": "Git 커밋, PR, 브랜치 워크플로우 자동화 Plugin",
+      "version": "1.0.0",
+      "tags": ["git", "workflow", "automation", "mcp"]
+    },
+    {
+      "name": "security-scanner",
+      "source": "./plugins/security-scanner",
+      "description": "보안 취약점 스캔 및 시크릿 탐지 Plugin",
+      "version": "1.0.0",
+      "tags": ["security", "audit", "scanner"]
+    }
+  ]
+}
+```
+
+사용자 설치 흐름:
+```bash
+# Marketplace 추가
+/plugin marketplace add kenshin579/claude-code-plugin-sample
+
+# 원하는 Plugin 개별 설치
+/plugin install safe-guard@cc-plugin-samples
+/plugin install code-quality@cc-plugin-samples
+
+# 로컬 테스트 (개발 중)
+claude --plugin-dir ./plugins/safe-guard
+```
+
+## 6. Plugin별 상세 요구사항
+
+### 6.1 safe-guard — 위험 명령 차단 & 파일 보호
+
+**해결하는 문제**: Claude가 실수로 위험한 명령을 실행하거나 민감한 파일을 수정하는 것을 방지
+
+**활용하는 기능**: Hooks (PreToolUse, command 핸들러)
+
+**plugin.json**:
+```json
+{
+  "name": "safe-guard",
+  "description": "위험 명령 차단 및 민감 파일 보호 - PreToolUse Hook으로 rm -rf, force push, DROP TABLE 등을 차단하고 .env, credentials 파일 수정을 방지",
+  "version": "1.0.0",
+  "author": { "name": "kenshin579", "url": "https://github.com/kenshin579" },
+  "repository": "https://github.com/kenshin579/claude-code-plugin-sample",
+  "license": "MIT"
+}
+```
+
+**hooks/hooks.json**:
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/block-dangerous-commands.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/protect-sensitive-files.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**hooks/block-dangerous-commands.sh**:
+- stdin JSON에서 `tool_input.command` 파싱
+- 차단 패턴:
+  - `rm -rf /` , `rm -rf ~` , `rm -rf .` (루트/홈/현재 디렉토리 삭제)
+  - `git push --force main|master` (메인 브랜치 force push)
+  - `git reset --hard` (커밋되지 않은 변경 삭제)
+  - `DROP TABLE|DROP DATABASE` (DB 파괴)
+  - `chmod 777` (과도한 권한 부여)
+  - `> /dev/sda` (디스크 직접 쓰기)
+- exit code 2 + stderr에 차단 사유 출력
+- best practice: 패턴을 배열로 관리, 로깅 포함
+
+**hooks/protect-sensitive-files.sh**:
+- stdin JSON에서 `tool_input.file_path` 파싱
+- 보호 대상 파턴:
+  - `.env`, `.env.*` (환경변수)
+  - `*credentials*`, `*secret*`, `*token*` (인증 파일)
+  - `id_rsa`, `*.pem`, `*.key` (SSH/인증서 키)
+  - `.git/config` (Git 설정)
+- exit code 2 + stderr에 보호 사유 출력
+
+**commands/safeguard-status.md**:
+- 현재 차단 패턴 목록 표시
+- 최근 차단 로그 요약 (`/tmp/safeguard-*.log`)
+
+### 6.2 code-quality — 자동 린팅 & 코드 리뷰
+
+**해결하는 문제**: 파일 수정 후 린팅을 잊어버리는 것을 방지하고, 코드 리뷰를 체계적으로 수행
+
+**활용하는 기능**: Hooks (PostToolUse), Skills, Agents, Commands, MCP (context7)
+
+**plugin.json**:
+```json
+{
+  "name": "code-quality",
+  "description": "파일 저장 후 자동 린팅, 코드 리뷰 Skill 및 리뷰 전문 Agent 제공",
+  "version": "1.0.0",
+  "author": { "name": "kenshin579", "url": "https://github.com/kenshin579" },
+  "repository": "https://github.com/kenshin579/claude-code-plugin-sample",
+  "license": "MIT"
+}
+```
+
+**hooks/hooks.json**:
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/auto-lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**hooks/auto-lint.sh**:
+- stdin JSON에서 `tool_input.file_path` 파싱
+- 파일 확장자별 린터 자동 선택:
+  - `.ts`, `.tsx`, `.js`, `.jsx` → `npx eslint --fix` (있으면) 또는 `npx prettier --write`
+  - `.py` → `ruff check --fix` (있으면) 또는 `python -m py_compile` (문법 검사)
+  - `.go` → `gofmt -w`
+  - `.json` → `python -m json.tool` (문법 검증)
+  - `.yaml`, `.yml` → `python -c "import yaml; yaml.safe_load(...)"`
+- 린터가 설치되지 않은 경우 graceful 스킵 (에러 없이 exit 0)
+- stdout으로 린트 결과 전달
+
+**skills/code-review/SKILL.md**:
+```yaml
+---
+name: code-review
+description: 변경된 코드에 대해 품질, 보안, 성능 관점의 체계적 리뷰를 수행한다. 코드 수정 후 자동으로 호출될 수 있다.
+allowed-tools: Read, Grep, Glob
+---
+```
+- 리뷰 관점 체크리스트:
+  - **보안**: 인젝션, XSS, 하드코딩된 시크릿, 부적절한 에러 노출
+  - **성능**: N+1 쿼리, 불필요한 루프, 메모리 누수 패턴
+  - **가독성**: 네이밍 컨벤션, 함수 길이, 매직 넘버
+  - **유지보수성**: 중복 코드, 결합도, 테스트 커버리지
+- 리뷰 결과 형식:
+  ```
+  ## 리뷰 결과
+  ### 🔴 Critical (즉시 수정 필요)
+  ### 🟡 Warning (개선 권장)
+  ### 🟢 Good (잘된 점)
+  ```
+
+**agents/code-reviewer.md**:
+```yaml
+---
+name: code-reviewer
+description: 코드의 품질, 보안 및 유지보수성을 적극적으로 검토하는 전문 에이전트. 코드 작성 또는 수정 후 사용한다.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+```
+- 변경된 파일을 자동 탐지 (`git diff --name-only`)
+- 파일별 심층 리뷰 수행
+- 요약 보고서 생성
+
+**commands/review.md**:
+- `/code-quality:review` 로 호출
+- `$ARGUMENTS` 로 특정 파일/디렉토리 지정 가능
+- 기본값: `git diff --name-only`로 변경된 파일 리뷰
+
+**.mcp.json** (코드 리뷰 시 라이브러리 문서 참조용):
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}
+```
+- **context7**: 코드 리뷰 중 사용된 라이브러리의 최신 문서를 참조할 수 있도록 Context7 MCP 서버 포함
+- 코드 리뷰 Agent가 API 사용법이 맞는지 공식 문서 기반으로 검증 가능
+
+### 6.3 git-workflow — Git 워크플로우 자동화
+
+**해결하는 문제**: 커밋 메시지 작성, PR 생성, 브랜치 상태 확인 등 반복적인 Git 작업 자동화
+
+**활용하는 기능**: Skills ($ARGUMENTS, 동적 컨텍스트 주입), Commands, MCP (github)
+
+**plugin.json**:
+```json
+{
+  "name": "git-workflow",
+  "description": "Git 커밋 메시지 생성, PR 생성, 브랜치 상태 확인 자동화 Plugin",
+  "version": "1.0.0",
+  "author": { "name": "kenshin579", "url": "https://github.com/kenshin579" },
+  "repository": "https://github.com/kenshin579/claude-code-plugin-sample",
+  "license": "MIT"
+}
+```
+
+**skills/commit-msg/SKILL.md**:
+```yaml
+---
+name: commit-msg
+description: 현재 staged 변경사항을 분석하여 Conventional Commits 형식의 커밋 메시지를 생성한다.
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "[type: feat|fix|docs|refactor|test|chore]"
+---
+```
+- `!`git diff --cached`` 로 staged 변경사항 주입
+- `!`git log --oneline -5`` 로 최근 커밋 스타일 참조
+- Conventional Commits 형식 생성 (`feat:`, `fix:`, `docs:` 등)
+- `$ARGUMENTS[0]` 으로 커밋 타입 힌트 전달 가능
+- 한국어 커밋 메시지 지원
+
+**skills/pr-create/SKILL.md**:
+```yaml
+---
+name: pr-create
+description: 현재 브랜치의 변경사항을 분석하여 PR 제목과 본문을 생성하고 PR을 생성한다.
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "[base-branch]"
+---
+```
+- `!`git log main..HEAD --oneline`` 로 커밋 히스토리 주입
+- `!`git diff main...HEAD --stat`` 로 변경 파일 요약 주입
+- PR 템플릿: Summary, Changes, Test Plan
+- `gh pr create` 로 PR 생성 (HEREDOC 사용)
+
+**commands/commit.md**:
+- `/git-workflow:commit` 으로 호출
+- staged 변경사항 분석 → 메시지 생성 → 커밋 실행
+- `$ARGUMENTS` 로 커밋 타입 지정 가능
+
+**commands/pr.md**:
+- `/git-workflow:pr` 로 호출
+- 현재 브랜치 vs base 브랜치 비교 → PR 생성
+- `$ARGUMENTS` 로 base 브랜치 지정 가능 (기본: main)
+
+**commands/status.md**:
+- `/git-workflow:status` 로 호출
+- 프로젝트 상태 종합 표시:
+  - 현재 브랜치, 최근 커밋 5개
+  - staged/unstaged/untracked 파일
+  - 원격 브랜치와의 차이 (ahead/behind)
+
+**.mcp.json** (GitHub API 연동):
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+- **github**: PR 생성, Issue 조회 등 GitHub API 연동
+- `GITHUB_TOKEN` 환경변수로 인증 (사용자가 사전 설정 필요)
+- PR Skill에서 GitHub MCP 도구를 활용하여 PR 생성, 라벨 설정, 리뷰어 지정 가능
+
+### 6.4 security-scanner — 보안 취약점 스캐너
+
+**해결하는 문제**: 코드에 하드코딩된 시크릿, 보안 취약점 패턴을 탐지
+
+**활용하는 기능**: Agents, Skills, Hooks (PreToolUse), Commands
+
+**plugin.json**:
+```json
+{
+  "name": "security-scanner",
+  "description": "코드베이스의 보안 취약점 스캔 - 시크릿 탐지, OWASP Top 10 검사, 의존성 보안 확인",
+  "version": "1.0.0",
+  "author": { "name": "kenshin579", "url": "https://github.com/kenshin579" },
+  "repository": "https://github.com/kenshin579/claude-code-plugin-sample",
+  "license": "MIT"
+}
+```
+
+**agents/security-auditor.md**:
+```yaml
+---
+name: security-auditor
+description: 보안 취약점을 전문적으로 분석하는 에이전트. 코드를 읽고 OWASP Top 10, 시크릿 노출, 의존성 취약점을 검사한다.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+```
+- 검사 항목:
+  - **시크릿 탐지**: API 키, 토큰, 비밀번호 패턴 (정규식 기반)
+  - **인젝션**: SQL 인젝션, Command 인젝션, XSS 패턴
+  - **인증/인가**: 하드코딩된 자격증명, 약한 해시 알고리즘 (MD5, SHA1)
+  - **의존성**: `package.json`, `go.mod`, `requirements.txt`에서 알려진 취약 버전
+- 보고서 형식:
+  ```
+  ## 보안 스캔 결과
+  ### 🔴 Critical
+  ### 🟠 High
+  ### 🟡 Medium
+  ### 🔵 Low
+  ### 📊 요약 통계
+  ```
+
+**skills/security-scan/SKILL.md**:
+```yaml
+---
+name: security-scan
+description: 프로젝트 전체 또는 특정 디렉토리의 보안 취약점을 스캔한다.
+context: fork
+agent: security-auditor
+argument-hint: "[target-path]"
+---
+```
+- `context: fork` + `agent: security-auditor` 로 서브에이전트에 위임
+- `$ARGUMENTS` 로 스캔 대상 경로 지정 (기본: 프로젝트 전체)
+
+**hooks/hooks.json**:
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-secrets.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**hooks/check-secrets.sh**:
+- 파일에 작성될 내용(`tool_input.content` 또는 `tool_input.new_string`)에서 시크릿 패턴 검사
+- 탐지 패턴:
+  - `AKIA[0-9A-Z]{16}` (AWS Access Key)
+  - `ghp_[a-zA-Z0-9]{36}` (GitHub Personal Token)
+  - `sk-[a-zA-Z0-9]{48}` (OpenAI API Key)
+  - `password\s*=\s*['"][^'"]+` (하드코딩된 비밀번호)
+  - `-----BEGIN (RSA|EC|DSA) PRIVATE KEY-----` (Private Key)
+- 탐지 시 exit code 2 + 경고 메시지
+
+**commands/scan.md**:
+- `/security-scanner:scan` 으로 호출
+- 전체 프로젝트 보안 스캔 실행
+- `$ARGUMENTS` 로 특정 경로 스캔 가능
+
+## 7. Best Practice 체크리스트
+
+각 Plugin이 준수해야 할 패턴:
+
+### 7.1 Plugin 구조
+- [ ] `.claude-plugin/plugin.json` 에 name, description, version 필수 포함
+- [ ] `README.md` 에 설치법, 사용법, 설정 옵션 문서화
+- [ ] 모든 경로에 `${CLAUDE_PLUGIN_ROOT}` 환경변수 사용 (절대경로 금지)
+
+### 7.2 Hook 스크립트
+- [ ] stdin JSON 파싱에 `jq` 사용, 필드 없을 때 `// empty` 로 안전 처리
+- [ ] exit code 규약 준수: 0=허용, 2=차단
+- [ ] stderr에 사용자 친화적 차단 메시지 출력
+- [ ] 외부 도구 미설치 시 graceful 스킵 (에러 없이 exit 0)
+- [ ] 스크립트 상단에 `#!/bin/bash` shebang + 주석으로 동작 설명
+- [ ] `set -euo pipefail` 로 안전한 스크립트 실행
+
+### 7.3 Skills
+- [ ] `description` 필드에 Claude가 자동 호출 판단할 수 있는 충분한 설명
+- [ ] `allowed-tools` 로 필요한 도구만 명시적 허용
+- [ ] `argument-hint` 로 사용자에게 인자 힌트 제공
+- [ ] 읽기 전용 작업은 `allowed-tools: Read, Grep, Glob` 으로 제한
+
+### 7.4 Agents
+- [ ] `description` 필드에 어떤 상황에서 사용되는지 명확히 기술
+- [ ] `tools` 필드로 최소 권한 원칙 적용
+- [ ] `model` 지정 (비용 최적화)
+- [ ] 구조화된 출력 형식 정의 (심각도, 위치, 제안)
+
+### 7.5 Commands
+- [ ] `$ARGUMENTS` 플레이스홀더로 사용자 입력 지원
+- [ ] 기본값 동작 정의 (인자 없이 호출해도 동작)
+
+## 8. 비기능 요구사항
+
+### 8.1 호환성
+- macOS, Linux 모두 동작 (bash, jq 기반)
+- 린터 등 외부 도구는 설치 여부를 확인 후 graceful 스킵
+- Claude Code v1.0.33 이상 대상
+
+### 8.2 보안
+- Hook 스크립트에서 사용자 입력(JSON)을 변수에 안전하게 할당
+- 경로 순회(`..`) 방어
+- 임시 파일 사용 시 `/tmp/` + 고유 prefix 사용
+
+### 8.3 문서화
+- 루트 `README.md`: 프로젝트 소개, Marketplace 추가 방법, 각 Plugin 요약
+- 각 Plugin `README.md`: 기능 설명, 설치, 사용법, 커스터마이징 방법
+- Hook 스크립트: 주석으로 동작 원리 설명
+- `docs/CONTRIBUTING.md`: 새 Plugin 기여 가이드
+
+## 9. 작업 계획
+
+### Phase 1: 프로젝트 초기 설정
+- [ ] 레포 초기화 (`README.md`, `CLAUDE.md`, `LICENSE`, `.gitignore`)
+- [ ] Marketplace 매니페스트 (`.claude-plugin/marketplace.json`) 생성
+- [ ] 디렉토리 구조 생성
+
+### Phase 2: Core Plugins 구현
+- [ ] `safe-guard` Plugin 구현 (Hooks 중심 — 가장 기본적이고 필수적)
+- [ ] `code-quality` Plugin 구현 (Hooks + Skills + Agents)
+- [ ] `git-workflow` Plugin 구현 (Skills + Commands)
+- [ ] `security-scanner` Plugin 구현 (Agents + Skills + Hooks)
+
+### Phase 3: 문서화 및 검증
+- [ ] 각 Plugin README.md 작성
+- [ ] 루트 README.md 완성
+- [ ] `docs/CONTRIBUTING.md` 작성
+- [ ] 각 Plugin `--plugin-dir` 로컬 테스트
+- [ ] Marketplace 설치 테스트
+- [ ] 인코딩 확인 (UTF-8)
+
+### Phase 4: 배포
+- [ ] feature 브랜치 생성 및 PR 작성
+- [ ] GitHub 레포 Push
+
+## 10. 참고 자료
+
+- [Claude Code Plugins 공식 문서](https://code.claude.com/docs/en/plugins)
+- [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
+- [Discover and Install Plugins](https://code.claude.com/docs/en/discover-plugins)
+- [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Claude Code Hooks Reference](https://code.claude.com/docs/en/hooks)
+- [Claude Code Hooks Guide](https://code.claude.com/docs/en/hooks-guide)
+- [Claude Code Skills](https://code.claude.com/docs/en/skills)
+- [Claude Code Sub-agents](https://code.claude.com/docs/en/sub-agents)
+- [PR #148: Claude Code Plugin & Hooks 완벽 가이드](https://github.com/kenshin579/blog-v2.advenoh.pe.kr/pull/148)

--- a/docs/done/3_golang_concurrenncy_implementation.md
+++ b/docs/done/3_golang_concurrenncy_implementation.md
@@ -1,0 +1,446 @@
+# Golang Concurrency 블로그 시리즈 - 구현 문서
+
+## 프로젝트 경로
+
+| 항목 | 경로 |
+|------|------|
+| 샘플 코드 | `tutorials-go/golang/concurrency/` |
+| 블로그 포스트 | `blog-v2.advenoh.pe.kr/contents/go/` |
+| 기존 concurrency 코드 | `tutorials-go/golang/concurrency/{mutex,waitgroup,once-do}/` |
+
+---
+
+## 편별 구현 상세
+
+### 1편: Concurrency 개요와 Goroutine
+
+**샘플 코드**: `tutorials-go/golang/concurrency/goroutine/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `basic_test.go` | `go func()` 으로 goroutine 생성, `runtime.NumGoroutine()` 확인, 실행 순서 비결정성 테스트 |
+| `lifecycle_test.go` | main 함수 종료 시 goroutine 미완료 문제, `sync.WaitGroup`으로 대기 |
+| `leak_test.go` | channel 대기로 인한 goroutine leak 예시, `runtime.NumGoroutine()` 으로 leak 탐지 |
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-1-goroutine-기초/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (1) - 개요와 Goroutine 기초"
+description: "Golang Concurrency (1) - 개요와 Goroutine 기초"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - goroutine
+  - parallelism
+  - scheduler
+  - lightweight-thread
+  - 고랭
+  - 동시성
+  - 고루틴
+series: "Golang Concurrency"
+seriesOrder: 1
+---
+```
+
+**블로그 본문 핵심 포인트**:
+- Concurrency vs Parallelism 다이어그램 (텍스트 기반 ASCII 또는 이미지)
+- CSP 모델 설명 + Go 철학 인용
+- GMP 모델 다이어그램 (Goroutine-Machine-Processor)
+- goroutine 비용: ~2KB 스택 vs OS thread ~1MB
+- `runtime.GOMAXPROCS` 설정 예제
+
+---
+
+### 2편: Channel 완전 정복
+
+**샘플 코드**: `tutorials-go/golang/concurrency/channel/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `basic_test.go` | `make(chan int)` 생성, send/receive, blocking 동작 확인 |
+| `buffered_test.go` | `make(chan int, N)` buffered channel, 버퍼 가득 찼을 때 blocking |
+| `direction_test.go` | `chan<- int` (send-only), `<-chan int` (receive-only) 함수 파라미터 |
+| `close_test.go` | `close(ch)`, 닫힌 채널 receive (zero value + false), `range ch` |
+| `bench_test.go` | `BenchmarkUnbuffered`, `BenchmarkBuffered` 성능 비교 |
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-2-channel-완전-정복/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (2) - Channel 완전 정복"
+description: "Golang Concurrency (2) - Channel 완전 정복"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - channel
+  - buffered
+  - unbuffered
+  - producer-consumer
+  - 고랭
+  - 동시성
+  - 채널
+series: "Golang Concurrency"
+seriesOrder: 2
+---
+```
+
+**블로그 본문 핵심 포인트**:
+- Unbuffered vs Buffered channel 동작 다이어그램
+- Producer/Consumer 패턴 전체 코드
+- close 규칙: sender만 close, receiver는 close 금지
+
+---
+
+### 3편: Select와 Channel 심화 패턴
+
+**샘플 코드**: `tutorials-go/golang/concurrency/select/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `basic_test.go` | `select` 여러 case, `default` case, 랜덤 선택 확인 |
+| `timeout_test.go` | `time.After` 타임아웃, `context.WithTimeout` 조합 |
+| `fanin_fanout_test.go` | fan-out: 입력을 N개 worker에 분배, fan-in: N개 결과를 하나로 merge |
+| `nil_channel_test.go` | nil channel 할당으로 select case 동적 비활성화 |
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-3-select와-channel-심화/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (3) - Select와 Channel 심화 패턴"
+description: "Golang Concurrency (3) - Select와 Channel 심화 패턴"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - select
+  - timeout
+  - fan-in
+  - fan-out
+  - nil-channel
+  - 고랭
+  - 동시성
+series: "Golang Concurrency"
+seriesOrder: 3
+---
+```
+
+---
+
+### 4편: Sync 패키지
+
+**샘플 코드**: `tutorials-go/golang/concurrency/sync-pkg/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `waitgroup_test.go` | `wg.Add(N)`, `wg.Done()`, `wg.Wait()` 기본 패턴 |
+| `mutex_test.go` | `sync.Mutex` 임계영역, `sync.RWMutex` 읽기 동시성, `BenchmarkMutex` vs `BenchmarkRWMutex` |
+| `once_test.go` | `sync.Once` 로 singleton 패턴, 여러 goroutine에서 호출해도 1회만 실행 |
+| `syncmap_test.go` | `sync.Map` 사용, `map+Mutex` 대비 벤치마크 |
+| `cond_test.go` | `sync.Cond` 로 producer-consumer 조건 대기 (선택 구현) |
+
+**기존 코드 참조**: `mutex/`, `waitgroup/`, `once-do/` 디렉토리의 기존 예제 활용
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-4-sync-패키지/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (4) - sync 패키지 완벽 가이드"
+description: "Golang Concurrency (4) - sync 패키지 완벽 가이드"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - sync
+  - mutex
+  - rwmutex
+  - waitgroup
+  - once
+  - race-condition
+  - 고랭
+  - 동시성
+  - 동기화
+series: "Golang Concurrency"
+seriesOrder: 4
+---
+```
+
+---
+
+### 5편: Context 패키지
+
+**샘플 코드**: `tutorials-go/golang/concurrency/context/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `cancel_test.go` | `context.WithCancel`, cancel 호출 시 `ctx.Done()` 수신 확인 |
+| `timeout_test.go` | `context.WithTimeout`, `context.WithDeadline`, 시간 초과 시 자동 취소 |
+| `value_test.go` | `context.WithValue`, key 타입 정의, 값 조회 |
+| `propagation_test.go` | parent → child context 전파, cancel 체인 동작 확인 |
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-5-context-패키지/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (5) - Context 패키지 필수 가이드"
+description: "Golang Concurrency (5) - Context 패키지 필수 가이드"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - context
+  - cancellation
+  - timeout
+  - deadline
+  - request-scope
+  - 고랭
+  - 동시성
+series: "Golang Concurrency"
+seriesOrder: 5
+---
+```
+
+---
+
+### 6편: Concurrency Patterns
+
+**샘플 코드**: `tutorials-go/golang/concurrency/patterns/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `worker_pool_test.go` | job channel → N개 worker → result channel, 고정 worker 수 |
+| `pipeline_test.go` | generator → square → print 스테이지 체이닝 |
+| `semaphore_test.go` | `make(chan struct{}, N)` 으로 동시 실행 수 제한 |
+| `rate_limit_test.go` | `time.Ticker` 기반 rate limiter, token bucket |
+| `pubsub_test.go` | channel 기반 이벤트 브로커, subscribe/publish/unsubscribe |
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-6-concurrency-patterns/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (6) - 실무 핵심 Concurrency Patterns"
+description: "Golang Concurrency (6) - 실무 핵심 Concurrency Patterns"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - worker-pool
+  - pipeline
+  - semaphore
+  - rate-limiting
+  - pub-sub
+  - pattern
+  - 고랭
+  - 동시성
+series: "Golang Concurrency"
+seriesOrder: 6
+---
+```
+
+---
+
+### 7편: Error Handling in Concurrency
+
+**샘플 코드**: `tutorials-go/golang/concurrency/errhandling/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `error_channel_test.go` | `Result{Value, Err}` struct 를 channel로 전달 |
+| `errgroup_test.go` | `errgroup.Group`, `errgroup.WithContext`, `SetLimit()` |
+| `multi_error_test.go` | 여러 goroutine 에러를 slice로 수집, `errors.Join` 활용 |
+
+**의존성 추가**: `golang.org/x/sync/errgroup`
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-7-error-handling/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (7) - 동시성 환경의 Error Handling"
+description: "Golang Concurrency (7) - 동시성 환경의 Error Handling"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - error
+  - errgroup
+  - error-channel
+  - multi-error
+  - 고랭
+  - 동시성
+  - 에러처리
+series: "Golang Concurrency"
+seriesOrder: 7
+---
+```
+
+---
+
+### 8편: Memory Model과 Atomic
+
+**샘플 코드**: `tutorials-go/golang/concurrency/memory-model/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `visibility_test.go` | 공유 변수 visibility 문제 재현 (컴파일러 최적화 영향) |
+| `atomic_test.go` | `atomic.Int64`, `atomic.Bool`, `atomic.Value`, Load/Store/CAS |
+| `bench_test.go` | `BenchmarkAtomicCounter`, `BenchmarkMutexCounter` 비교 |
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-8-memory-model/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (8) - Go Memory Model과 Atomic Operations"
+description: "Golang Concurrency (8) - Go Memory Model과 Atomic Operations"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - memory-model
+  - happens-before
+  - atomic
+  - visibility
+  - sync-atomic
+  - 고랭
+  - 동시성
+series: "Golang Concurrency"
+seriesOrder: 8
+---
+```
+
+---
+
+### 9편: Debugging과 Race Detector
+
+**샘플 코드**: `tutorials-go/golang/concurrency/debugging/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `race_test.go` | 의도적 race condition 코드 + 수정 버전, `-race` 플래그로 탐지 |
+| `deadlock_test.go` | unbuffered channel 양방향 대기 deadlock, 수정 패턴 |
+| `goroutine_dump_test.go` | `runtime.Stack()` 으로 goroutine 상태 덤프 |
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-9-debugging-race-detector/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (9) - Debugging과 Race Detector"
+description: "Golang Concurrency (9) - Debugging과 Race Detector"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - race-detector
+  - deadlock
+  - pprof
+  - goroutine-dump
+  - debugging
+  - 고랭
+  - 동시성
+  - 디버깅
+series: "Golang Concurrency"
+seriesOrder: 9
+---
+```
+
+---
+
+### 10편: 실전 프로젝트 + Best Practices
+
+**샘플 코드**: `tutorials-go/golang/concurrency/project/`
+
+| 파일 | 구현 내용 |
+|------|----------|
+| `crawler/crawler.go` | Crawler 구조체: URL 큐, visited map, Worker Pool, Rate Limiter |
+| `crawler/worker.go` | Worker: HTTP fetch, 링크 추출, 결과 전달 |
+| `crawler/crawler_test.go` | httptest.Server 로 테스트 서버 구성, 크롤링 결과 검증 |
+| `shutdown/server.go` | HTTP 서버 + `signal.NotifyContext` 기반 graceful shutdown |
+| `shutdown/server_test.go` | shutdown 시그널 전송 후 정상 종료 확인 |
+
+**Crawler 구현 핵심**:
+- `context.WithCancel` 로 전체 크롤링 취소
+- `make(chan struct{}, maxConcurrency)` 세마포어
+- `time.Ticker` rate limiting
+- `sync.Map` 으로 visited URL 관리
+- `errgroup` 으로 에러 수집
+
+**블로그**: `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-10-실전-프로젝트-best-practices/index.md`
+
+```yaml
+---
+title: "Golang Concurrency (10) - 실전 프로젝트와 Best Practices"
+description: "Golang Concurrency (10) - 실전 프로젝트와 Best Practices"
+date: 2026-02-14
+update: 2026-02-14
+tags:
+  - golang
+  - go
+  - concurrency
+  - best-practice
+  - anti-pattern
+  - graceful-shutdown
+  - project
+  - 고랭
+  - 동시성
+  - 실전
+series: "Golang Concurrency"
+seriesOrder: 10
+---
+```
+
+---
+
+## 테스트 실행 명령어
+
+```bash
+# 편별 테스트
+go test -v -race ./golang/concurrency/goroutine/...     # 1편
+go test -v -race ./golang/concurrency/channel/...       # 2편
+go test -v -race ./golang/concurrency/select/...        # 3편
+go test -v -race ./golang/concurrency/sync-pkg/...      # 4편
+go test -v -race ./golang/concurrency/context/...       # 5편
+go test -v -race ./golang/concurrency/patterns/...      # 6편
+go test -v -race ./golang/concurrency/errhandling/...   # 7편
+go test -v -race ./golang/concurrency/memory-model/...  # 8편
+go test -v -race ./golang/concurrency/debugging/...     # 9편
+go test -v -race ./golang/concurrency/project/...       # 10편
+
+# 전체 테스트
+go test -v -race ./golang/concurrency/...
+
+# 벤치마크
+go test -bench=. -benchmem ./golang/concurrency/channel/...
+go test -bench=. -benchmem ./golang/concurrency/sync-pkg/...
+go test -bench=. -benchmem ./golang/concurrency/memory-model/...
+```
+
+## 블로그 빌드 확인
+
+```bash
+cd blog-v2.advenoh.pe.kr && npm run build
+```
+
+## 인코딩 확인
+
+```bash
+file -I blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-*/index.md
+```

--- a/docs/done/3_golang_concurrenncy_prd.md
+++ b/docs/done/3_golang_concurrenncy_prd.md
@@ -1,0 +1,485 @@
+# Golang Concurrency 블로그 시리즈 PRD
+
+## 개요
+
+Go 언어의 Concurrency를 체계적으로 스터디하면서 블로그 시리즈로 정리한다.
+샘플 코드는 `tutorials-go/golang/concurrency/`에, 블로그 포스트는 `blog-v2.advenoh.pe.kr/contents/go/`에 작성한다.
+
+**시리즈 구성**: 총 10편 (개요부터 실전 프로젝트까지)
+
+## 참고 자료
+
+- [docs/start/2_chatgpt.md](./2_chatgpt.md) - ChatGPT 목차 초안
+- https://go.dev/doc/effective_go#concurrency
+- https://go.dev/blog/pipelines
+- https://go.dev/blog/context
+- https://go.dev/ref/mem (Go Memory Model)
+- https://gobyexample.com
+- 도서: "Concurrency in Go" (Katherine Cox-Buday, O'Reilly)
+
+---
+
+## 블로그 시리즈 구성
+
+### 공통 사항
+
+- **시리즈명**: `"Golang Concurrency"`
+- **태그 공통**: golang, go, concurrency, 고랭, 동시성
+- **카테고리 폴더**: `blog-v2.advenoh.pe.kr/contents/go/`
+- **frontmatter 형식**:
+  ```yaml
+  ---
+  title: "제목"
+  description: "설명"
+  date: YYYY-MM-DD
+  update: YYYY-MM-DD
+  tags:
+    - golang
+    - go
+    - concurrency
+    - (편별 추가 태그)
+  series: "Golang Concurrency"
+  seriesOrder: N
+  ---
+  ```
+
+---
+
+### 1편: Concurrency 개요와 Goroutine
+
+- **폴더**: `golang-concurrency-1-goroutine-기초/index.md`
+- **제목**: "Golang Concurrency (1) - 개요와 Goroutine 기초"
+- **추가 태그**: goroutine, parallelism, scheduler, lightweight-thread, 고루틴
+- **seriesOrder**: 1
+
+#### 목차
+
+1. Concurrency vs Parallelism 차이
+   - 개념 설명 + 다이어그램
+   - Go에서의 의미
+2. 왜 Go는 concurrency에 강한가
+   - CSP(Communicating Sequential Processes) 모델
+   - "Do not communicate by sharing memory; share memory by communicating"
+3. 언제 concurrency를 사용해야 하는가 / 사용하면 안 되는가
+4. Goroutine 기초
+   - goroutine 생성 방법 (`go` 키워드)
+   - main goroutine과 lifecycle
+   - goroutine 비용 (lightweight thread vs OS thread)
+5. Goroutine Scheduling 개념
+   - runtime scheduler (GMP 모델: Goroutine, Machine, Processor)
+   - `runtime.GOMAXPROCS`
+6. Goroutine Leak이란?
+   - 발생 원인과 예방
+7. 실습
+   - goroutine 실행 순서 확인
+   - sleep 없이 프로그램 종료되는 문제 재현
+
+---
+
+### 2편: Channel 완전 정복
+
+- **폴더**: `golang-concurrency-2-channel-완전-정복/index.md`
+- **제목**: "Golang Concurrency (2) - Channel 완전 정복"
+- **추가 태그**: channel, buffered, unbuffered, producer-consumer, 채널
+- **seriesOrder**: 2
+
+#### 목차
+
+1. Channel 개념과 생성 (`make(chan T)`)
+2. Send / Receive 동작
+3. Blocking 동작 이해
+4. Unbuffered vs Buffered Channel
+   - 동작 차이 + 다이어그램
+   - 성능 비교 벤치마크
+5. Channel 방향 제한 (send-only / receive-only)
+6. Channel close 의미와 규칙
+   - 닫힌 채널에서 receive
+   - close 책임 원칙 (sender가 close)
+7. Range over Channel
+8. 실습
+   - Producer / Consumer 패턴
+   - Buffered vs Unbuffered 성능 비교
+
+---
+
+### 3편: Select와 Channel 심화 패턴
+
+- **폴더**: `golang-concurrency-3-select와-channel-심화/index.md`
+- **제목**: "Golang Concurrency (3) - Select와 Channel 심화 패턴"
+- **추가 태그**: select, timeout, fan-in, fan-out, nil-channel
+- **seriesOrder**: 3
+
+#### 목차
+
+1. Select 문 기본
+   - 여러 channel 동시 대기
+   - 랜덤 선택 특성
+2. Default case 활용
+   - non-blocking send/receive
+3. Timeout 처리
+   - `time.After`
+   - `context.WithTimeout` (예고)
+4. Fan-in / Fan-out 패턴
+   - Fan-out: 하나의 입력을 여러 goroutine으로 분배
+   - Fan-in: 여러 goroutine의 결과를 하나로 모음
+5. Nil Channel 트릭
+   - 동적으로 channel 비활성화
+6. 실습
+   - 여러 worker 결과 모으기
+   - timeout 있는 API 호출 시뮬레이션
+
+---
+
+### 4편: Sync 패키지
+
+- **폴더**: `golang-concurrency-4-sync-패키지/index.md`
+- **제목**: "Golang Concurrency (4) - sync 패키지 완벽 가이드"
+- **추가 태그**: sync, mutex, rwmutex, waitgroup, once, race-condition, 동기화
+- **seriesOrder**: 4
+
+#### 목차
+
+1. 왜 Synchronization이 필요한가
+   - Race Condition 예시
+2. sync.WaitGroup
+   - Add / Done / Wait 패턴
+3. sync.Mutex
+   - 임계 영역(Critical Section) 보호
+4. sync.RWMutex
+   - 읽기 동시성 허용
+   - Mutex vs RWMutex 벤치마크
+5. sync.Once
+   - 한 번만 실행 보장 (singleton 패턴)
+6. sync.Map
+   - concurrent-safe map
+   - 일반 map + Mutex vs sync.Map 비교
+7. sync.Cond (선택)
+   - 조건 변수 기반 동기화
+8. 실습
+   - shared counter 보호 (Mutex vs atomic)
+   - singleton 구현
+
+---
+
+### 5편: Context 패키지
+
+- **폴더**: `golang-concurrency-5-context-패키지/index.md`
+- **제목**: "Golang Concurrency (5) - Context 패키지 필수 가이드"
+- **추가 태그**: context, cancellation, timeout, deadline, request-scope
+- **seriesOrder**: 5
+
+#### 목차
+
+1. Context 개념과 필요성
+   - goroutine 생명주기 관리
+   - 요청 범위(request scope) 전파
+2. context.Background() / context.TODO()
+3. context.WithCancel
+   - 명시적 취소 신호
+4. context.WithTimeout / context.WithDeadline
+   - 시간 제한 설정
+5. context.WithValue
+   - 값 전달 주의사항 (남용 금지)
+6. Context 전파 규칙
+   - 함수 첫 번째 파라미터로 전달
+   - `ctx.Done()` 채널 활용
+7. 실습
+   - goroutine cancel 체인
+   - HTTP request timeout 구현
+
+---
+
+### 6편: Concurrency Patterns (핵심)
+
+- **폴더**: `golang-concurrency-6-concurrency-patterns/index.md`
+- **제목**: "Golang Concurrency (6) - 실무 핵심 Concurrency Patterns"
+- **추가 태그**: worker-pool, pipeline, semaphore, rate-limiting, pub-sub, pattern
+- **seriesOrder**: 6
+
+#### 목차
+
+1. Worker Pool 패턴
+   - 고정 수의 worker goroutine
+   - job channel + result channel
+2. Pipeline 패턴
+   - 스테이지 체이닝
+   - 각 스테이지가 channel로 연결
+3. Fan-out / Fan-in (심화)
+   - Pipeline과 결합
+4. Semaphore 패턴
+   - buffered channel로 동시 실행 수 제한
+5. Rate Limiting
+   - `time.Ticker` 기반
+   - Token bucket 패턴
+6. Pub/Sub 패턴
+   - channel 기반 이벤트 브로커
+7. Bounded Concurrency
+   - 동시 goroutine 수 제한
+8. 실습
+   - concurrent file processing (Worker Pool)
+   - parallel API crawler (Pipeline + Fan-out)
+
+---
+
+### 7편: Error Handling in Concurrency
+
+- **폴더**: `golang-concurrency-7-error-handling/index.md`
+- **제목**: "Golang Concurrency (7) - 동시성 환경의 Error Handling"
+- **추가 태그**: error, errgroup, error-channel, multi-error, 에러처리
+- **seriesOrder**: 7
+
+#### 목차
+
+1. Goroutine에서의 Error 전달 문제
+   - goroutine 내부 panic은 어떻게 되나
+2. Error Channel 패턴
+   - 결과와 에러를 함께 전달하는 struct
+3. Multi-error 처리
+   - 여러 goroutine의 에러 수집
+4. errgroup 사용 (`golang.org/x/sync/errgroup`)
+   - `errgroup.Group`
+   - `errgroup.WithContext`
+   - 첫 번째 에러 시 전체 취소
+5. errgroup + Semaphore 조합
+   - `SetLimit()`로 동시성 제한
+6. 실습
+   - parallel job error aggregation
+
+---
+
+### 8편: Memory Model과 Atomic
+
+- **폴더**: `golang-concurrency-8-memory-model/index.md`
+- **제목**: "Golang Concurrency (8) - Go Memory Model과 Atomic Operations"
+- **추가 태그**: memory-model, happens-before, atomic, visibility, sync-atomic
+- **seriesOrder**: 8
+
+#### 목차
+
+1. Go Memory Model 개요
+   - 왜 메모리 모델을 알아야 하는가
+2. Happens-before 관계
+   - goroutine 생성, channel 통신, sync 패키지
+3. Visibility 문제
+   - 컴파일러/CPU 재정렬 (reordering)
+4. sync/atomic 패키지
+   - `atomic.Int64`, `atomic.Bool` (Go 1.19+)
+   - `atomic.Value`
+   - Load / Store / Swap / CompareAndSwap
+5. Atomic vs Mutex 비교
+   - 사용 시나리오별 가이드
+   - 벤치마크
+6. 실습
+   - atomic counter vs mutex counter 벤치마크
+
+---
+
+### 9편: Debugging과 Race Detector
+
+- **폴더**: `golang-concurrency-9-debugging-race-detector/index.md`
+- **제목**: "Golang Concurrency (9) - Debugging과 Race Detector"
+- **추가 태그**: race-detector, deadlock, pprof, goroutine-dump, debugging, 디버깅
+- **seriesOrder**: 9
+
+#### 목차
+
+1. Race Detector (`-race` 플래그)
+   - 사용법: `go test -race`, `go run -race`
+   - 출력 읽는 법
+2. Goroutine Dump
+   - `runtime.Stack()`
+   - SIGQUIT / pprof
+3. Deadlock 분석
+   - 일반적인 deadlock 패턴
+   - `fatal error: all goroutines are asleep - deadlock!`
+4. pprof로 분석
+   - goroutine 프로파일링
+   - `net/http/pprof`
+5. Testing with Concurrency
+   - `-count`, `-race` 조합
+   - `t.Parallel()`
+6. 실습
+   - 의도적으로 race condition 만들기 + 수정
+   - deadlock 재현 + 수정
+
+---
+
+### 10편: 실전 프로젝트 + Best Practices
+
+- **폴더**: `golang-concurrency-10-실전-프로젝트-best-practices/index.md`
+- **제목**: "Golang Concurrency (10) - 실전 프로젝트와 Best Practices"
+- **추가 태그**: best-practice, anti-pattern, graceful-shutdown, project, 실전
+- **seriesOrder**: 10
+
+#### 목차
+
+1. 실전 프로젝트: Concurrent Web Crawler
+   - Worker Pool + Rate Limiting + Context 조합
+   - Graceful Shutdown 구현
+2. Best Practices 정리
+   - Channel vs Mutex 언제 쓰나
+   - Context 반드시 전달하기
+   - Goroutine leak 방지 체크리스트
+   - Channel close 책임 원칙
+   - Structured concurrency
+   - Graceful shutdown 패턴
+3. Anti-patterns
+   - Global channel 남용
+   - 무한 goroutine 생성
+   - Context 안 쓰는 서버
+   - Channel close panic
+   - Select default 남용
+4. 핵심 개념 요약 + 실무 체크리스트
+5. 추천 라이브러리
+   - `golang.org/x/sync/errgroup`
+   - `golang.org/x/sync/semaphore`
+   - `golang.org/x/sync/singleflight`
+
+---
+
+## 샘플 코드 구성
+
+### 디렉토리 구조
+
+기존 `tutorials-go/golang/concurrency/` 디렉토리를 확장한다.
+
+```
+tutorials-go/golang/concurrency/
+├── goroutine/                    # 1편: Goroutine 기초
+│   ├── basic_test.go             # goroutine 생성, 실행 순서
+│   ├── lifecycle_test.go         # main 종료 시 goroutine 종료
+│   └── leak_test.go              # goroutine leak 예시
+│
+├── channel/                      # 2편: Channel
+│   ├── basic_test.go             # send/receive, blocking
+│   ├── buffered_test.go          # unbuffered vs buffered
+│   ├── direction_test.go         # send-only, receive-only
+│   ├── close_test.go             # close 동작, range
+│   └── bench_test.go             # buffered vs unbuffered 벤치마크
+│
+├── select/                       # 3편: Select & Channel 심화
+│   ├── basic_test.go             # select 기본, default
+│   ├── timeout_test.go           # time.After, timeout 처리
+│   ├── fanin_fanout_test.go      # fan-in / fan-out
+│   └── nil_channel_test.go       # nil channel 트릭
+│
+├── sync-pkg/                     # 4편: Sync 패키지
+│   ├── waitgroup_test.go         # WaitGroup
+│   ├── mutex_test.go             # Mutex, RWMutex (+ 벤치마크)
+│   ├── once_test.go              # Once (singleton)
+│   ├── syncmap_test.go           # sync.Map vs map+Mutex
+│   └── cond_test.go              # sync.Cond (선택)
+│
+├── context/                      # 5편: Context
+│   ├── cancel_test.go            # WithCancel
+│   ├── timeout_test.go           # WithTimeout, WithDeadline
+│   ├── value_test.go             # WithValue
+│   └── propagation_test.go       # Context 전파 체인
+│
+├── patterns/                     # 6편: Concurrency Patterns
+│   ├── worker_pool_test.go       # Worker Pool
+│   ├── pipeline_test.go          # Pipeline
+│   ├── semaphore_test.go         # Semaphore (buffered channel)
+│   ├── rate_limit_test.go        # Rate Limiting
+│   └── pubsub_test.go            # Pub/Sub
+│
+├── errhandling/                  # 7편: Error Handling
+│   ├── error_channel_test.go     # Error Channel 패턴
+│   ├── errgroup_test.go          # errgroup 사용
+│   └── multi_error_test.go       # Multi-error 수집
+│
+├── memory-model/                 # 8편: Memory Model & Atomic
+│   ├── visibility_test.go        # Visibility 문제 예시
+│   ├── atomic_test.go            # atomic 패키지 사용
+│   └── bench_test.go             # atomic vs mutex 벤치마크
+│
+├── debugging/                    # 9편: Debugging
+│   ├── race_test.go              # race condition 의도적 생성/수정
+│   ├── deadlock_test.go          # deadlock 재현/수정
+│   └── goroutine_dump_test.go    # goroutine dump
+│
+├── project/                      # 10편: 실전 프로젝트
+│   ├── crawler/                  # Concurrent Web Crawler
+│   │   ├── crawler.go
+│   │   ├── crawler_test.go
+│   │   └── worker.go
+│   └── shutdown/                 # Graceful Shutdown
+│       ├── server.go
+│       └── server_test.go
+│
+├── mutex/                        # (기존) 기존 mutex 예제
+├── waitgroup/                    # (기존) 기존 waitgroup 예제
+└── once-do/                      # (기존) 기존 once-do 예제
+```
+
+### 테스트 파일 공통 규칙
+
+- testify/suite 패턴 사용 (기존 코드 스타일 준수)
+- 한국어 주석으로 교육적 설명 포함
+- 벤치마크 테스트는 `bench_test.go` 또는 `*_bench_test.go`로 명명
+- `defer util.Timer()("functionName")` 패턴 활용 (성능 측정 시)
+
+### 각 편별 테스트 파일 요구사항
+
+| 편 | 디렉토리 | 핵심 테스트 내용 |
+|----|---------|-----------------|
+| 1편 | `goroutine/` | goroutine 생성, 실행 순서 비결정성, leak 예시 |
+| 2편 | `channel/` | unbuffered/buffered 차이, close 동작, producer-consumer |
+| 3편 | `select/` | select 멀티플렉싱, timeout, fan-in/fan-out |
+| 4편 | `sync-pkg/` | WaitGroup/Mutex/RWMutex/Once 사용, 벤치마크 |
+| 5편 | `context/` | Cancel/Timeout/Value, 전파 체인 |
+| 6편 | `patterns/` | Worker Pool, Pipeline, Semaphore, Rate Limiting |
+| 7편 | `errhandling/` | error channel, errgroup, multi-error 수집 |
+| 8편 | `memory-model/` | visibility 문제, atomic 연산, atomic vs mutex 벤치마크 |
+| 9편 | `debugging/` | race 의도적 생성, deadlock 재현, goroutine dump |
+| 10편 | `project/` | Concurrent Crawler 구현, Graceful Shutdown |
+
+---
+
+## 작업 순서 (편별)
+
+각 편은 독립적으로 아래 순서를 따른다.
+
+### Phase 1: 샘플 코드 작성
+1. `tutorials-go/golang/concurrency/{topic}/` 디렉토리 생성
+2. 테스트 파일 작성
+3. `go test -v -race ./golang/concurrency/{topic}/...` 로 테스트 통과 확인
+
+### Phase 2: 블로그 포스트 작성
+4. `blog-v2.advenoh.pe.kr/contents/go/{폴더명}/index.md` 생성
+5. frontmatter 작성 (series, seriesOrder 포함)
+6. 본문 작성 (개념 설명 + 코드 예제 인라인)
+7. 인코딩 확인 (`file -I`)
+
+### Phase 3: 검증
+8. 블로그 빌드 확인 (`npm run build`)
+9. 테스트 재확인 (`go test -race ./golang/concurrency/...`)
+
+### Phase 4: PR 생성
+10. feature 브랜치 생성 (편당 또는 묶어서)
+    - `feature/{issue-number}-golang-concurrency-{N}`
+11. PR 생성 및 리뷰 요청
+
+---
+
+## 진행 우선순위
+
+**필수 (Core)**: 1편 ~ 7편
+- 기초부터 실무 패턴까지 핵심 내용
+
+**심화 (Advanced)**: 8편 ~ 9편
+- Memory Model, Debugging은 중급 이상 내용
+
+**마무리 (Wrap-up)**: 10편
+- 실전 프로젝트로 전체 지식 통합
+
+---
+
+## 기존 코드 활용
+
+`tutorials-go/golang/concurrency/` 에 이미 존재하는 예제:
+- `mutex/` - Mutex 예제 → 4편에서 참조 또는 확장
+- `waitgroup/` - WaitGroup + 분산 락 예제 → 4편에서 참조
+- `once-do/` - sync.Once 예제 → 4편에서 참조
+
+기존 코드는 유지하면서, 새 디렉토리에 시리즈용 코드를 추가한다.

--- a/docs/done/3_golang_concurrenncy_todo.md
+++ b/docs/done/3_golang_concurrenncy_todo.md
@@ -1,0 +1,245 @@
+# Golang Concurrency 블로그 시리즈 - TODO
+
+---
+
+## 1편: Concurrency 개요와 Goroutine
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/goroutine/` 디렉토리 생성
+- [x] `basic_test.go` 작성 - goroutine 생성, 실행 순서 비결정성
+- [x] `lifecycle_test.go` 작성 - main 종료 시 goroutine 종료 문제
+- [x] `leak_test.go` 작성 - goroutine leak 예시
+- [x] `go test -v -race ./golang/concurrency/goroutine/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-1-goroutine-기초/index.md` 생성
+- [x] frontmatter 작성 (series: "Golang Concurrency", seriesOrder: 1)
+- [x] 본문 작성: Concurrency vs Parallelism, CSP 모델, GMP 스케줄러, goroutine 기초
+- [x] 인코딩 확인 (`file -I`)
+
+### Phase 3: 검증
+- [x] 블로그 빌드 확인 (`npm run build`)
+- [x] 테스트 재확인
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 2편: Channel 완전 정복
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/channel/` 디렉토리 생성
+- [x] `basic_test.go` 작성 - send/receive, blocking 동작
+- [x] `buffered_test.go` 작성 - unbuffered vs buffered channel
+- [x] `direction_test.go` 작성 - send-only, receive-only
+- [x] `close_test.go` 작성 - close 동작, range over channel
+- [x] `bench_test.go` 작성 - buffered vs unbuffered 벤치마크
+- [x] `go test -v -race ./golang/concurrency/channel/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-2-channel-완전-정복/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 2)
+- [x] 본문 작성: Channel 개념, blocking, buffered/unbuffered, close 규칙, producer-consumer
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 블로그 빌드 확인
+- [x] 테스트 재확인
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 3편: Select와 Channel 심화 패턴
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/select/` 디렉토리 생성
+- [x] `basic_test.go` 작성 - select 기본, default case
+- [x] `timeout_test.go` 작성 - time.After, context timeout
+- [x] `fanin_fanout_test.go` 작성 - fan-in / fan-out 패턴
+- [x] `nil_channel_test.go` 작성 - nil channel 트릭
+- [x] `go test -v -race ./golang/concurrency/select/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-3-select와-channel-심화/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 3)
+- [x] 본문 작성: select 멀티플렉싱, timeout, fan-in/fan-out, nil channel
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 블로그 빌드 확인
+- [x] 테스트 재확인
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 4편: Sync 패키지
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/sync-pkg/` 디렉토리 생성
+- [x] `waitgroup_test.go` 작성 - WaitGroup 패턴
+- [x] `mutex_test.go` 작성 - Mutex, RWMutex + 벤치마크
+- [x] `once_test.go` 작성 - sync.Once singleton
+- [x] `syncmap_test.go` 작성 - sync.Map vs map+Mutex
+- [x] ~~`cond_test.go` 작성 - sync.Cond (선택)~~ (스킵)
+- [x] 기존 코드 참조 확인 (mutex/, waitgroup/, once-do/)
+- [x] `go test -v -race ./golang/concurrency/sync-pkg/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-4-sync-패키지/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 4)
+- [x] 본문 작성: Race Condition, WaitGroup, Mutex, RWMutex, Once, sync.Map
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 블로그 빌드 확인
+- [x] 테스트 재확인 (벤치마크 포함)
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 5편: Context 패키지
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/context/` 디렉토리 생성
+- [x] `cancel_test.go` 작성 - WithCancel, Done() 채널
+- [x] `timeout_test.go` 작성 - WithTimeout, WithDeadline
+- [x] `value_test.go` 작성 - WithValue, key 타입 정의
+- [x] `propagation_test.go` 작성 - parent→child 전파 체인
+- [x] `go test -v -race ./golang/concurrency/context/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-5-context-완벽-가이드/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 5)
+- [x] 본문 작성: Context 개념, Cancel, Timeout, Value, 전파 규칙
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 테스트 재확인 (race detector 포함)
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 6편: Concurrency Patterns
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/patterns/` 디렉토리 생성
+- [x] `worker_pool_test.go` 작성 - Worker Pool (job → workers → result)
+- [x] `pipeline_test.go` 작성 - Pipeline 스테이지 체이닝
+- [x] `semaphore_test.go` 작성 - buffered channel 세마포어
+- [x] `rate_limit_test.go` 작성 - Ticker, token bucket
+- [x] `pubsub_test.go` 작성 - channel 기반 Pub/Sub
+- [x] `go test -v -race ./golang/concurrency/patterns/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-6-동시성-패턴-실전/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 6)
+- [x] 본문 작성: Worker Pool, Pipeline, Semaphore, Rate Limiting, Pub/Sub
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 테스트 재확인 (race detector 포함)
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 7편: Error Handling in Concurrency
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/errhandling/` 디렉토리 생성
+- [x] `error_channel_test.go` 작성 - Result{Value, Err} struct channel
+- [x] `errgroup_test.go` 작성 - errgroup.Group, WithContext, SetLimit
+- [x] `go test -v -race ./golang/concurrency/errhandling/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-7-에러-처리-전략/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 7)
+- [x] 본문 작성: Error 전달 문제, Error Channel, errgroup, Multi-error
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 테스트 재확인 (race detector 포함)
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 8편: Memory Model과 Atomic
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/memory-model/` 디렉토리 생성
+- [x] `visibility_test.go` 작성 - 공유 변수 visibility 문제
+- [x] `atomic_test.go` 작성 - atomic.Int64, Bool, Value, CAS
+- [x] `bench_test.go` 작성 - atomic vs mutex 벤치마크
+- [x] `go test -v -race ./golang/concurrency/memory-model/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-8-memory-model과-atomic/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 8)
+- [x] 본문 작성: Memory Model, Happens-before, Visibility, Atomic, 벤치마크
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 테스트 재확인 (벤치마크 포함)
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 9편: Debugging과 Race Detector
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/debugging/` 디렉토리 생성
+- [x] `race_test.go` 작성 - race condition 생성 + 수정 버전
+- [x] `deadlock_test.go` 작성 - deadlock 재현 + 수정 패턴
+- [x] `goroutine_dump_test.go` 작성 - runtime.Stack() 덤프
+- [x] `go test -v -race ./golang/concurrency/debugging/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-9-debugging과-race-detector/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 9)
+- [x] 본문 작성: Race Detector, Goroutine Dump, Deadlock, pprof
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 테스트 재확인
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성
+
+---
+
+## 10편: 실전 프로젝트 + Best Practices
+
+### Phase 1: 샘플 코드
+- [x] `tutorials-go/golang/concurrency/project/crawler/` 디렉토리 생성
+- [x] `crawler.go` 작성 - Crawler 구조체 (Worker Pool + Rate Limiter + Context)
+- [x] `crawler_test.go` 작성 - httptest.Server 기반 테스트
+- [x] `tutorials-go/golang/concurrency/project/shutdown/` 디렉토리 생성
+- [x] `server.go` 작성 - Graceful Shutdown 서버
+- [x] `server_test.go` 작성 - shutdown 테스트
+- [x] `go test -v -race ./golang/concurrency/project/...` 테스트 통과
+
+### Phase 2: 블로그 포스트
+- [x] `blog-v2.advenoh.pe.kr/contents/go/golang-concurrency-10-실전-프로젝트와-best-practices/index.md` 생성
+- [x] frontmatter 작성 (seriesOrder: 10)
+- [x] 본문 작성: Crawler 프로젝트, Graceful Shutdown, Best Practices
+- [x] 인코딩 확인
+
+### Phase 3: 검증
+- [x] 전체 concurrency 테스트 확인 (`go test -race ./golang/concurrency/...`)
+
+### Phase 4: PR
+- [ ] feature 브랜치 생성 및 PR 생성

--- a/docs/done/4_golang_generics_chatgpt.md
+++ b/docs/done/4_golang_generics_chatgpt.md
@@ -1,0 +1,175 @@
+좋다 👍
+스터디 + 블로그 작성용이라면 “개념 → 문법 → 실전 → 설계 관점 → 베스트 프랙티스” 흐름이 가장 이해가 잘 된다.
+특히 Go는 왜 generics가 늦게 도입되었는지까지 설명하면 글 완성도가 확 올라간다.
+
+아래는 실제 블로그 시리즈로 확장 가능한 구조로 설계한 목차다.
+
+⸻
+
+📘 Golang Generics 스터디 블로그 목차
+
+1. 개요
+   •	Generics란 무엇인가
+   •	왜 필요한가 (중복 코드 문제)
+   •	Go에서 Generics가 도입된 배경
+   •	기존 Go 철학과 Generics의 관계 (simplicity vs abstraction)
+
+⸻
+
+2. Generics 도입 전 Go의 한계
+   •	interface{} 기반 구현의 문제점
+   •	타입 안전성 부족
+   •	런타임 에러 가능
+   •	타입 캐스팅 비용
+   •	코드 중복 문제 예시
+   •	int / float / string 별 함수 중복
+
+⸻
+
+3. Generics 기본 문법
+   •	Type parameter 선언
+   •	함수에서 Generics 사용
+   •	Generic type 정의
+   •	타입 추론 (type inference)
+
+예제 중심 구성
+•	Generic 함수
+•	Generic struct
+•	Generic method
+
+⸻
+
+4. Type Constraint 이해하기 (핵심)
+   •	constraint 개념
+   •	any
+   •	comparable
+   •	interface 기반 constraint
+   •	union type constraint (| 사용)
+   •	~ (underlying type constraint)
+
+⸻
+
+5. 커스텀 Constraint 설계
+   •	직접 constraint 정의하기
+   •	숫자 타입 묶기
+   •	ordered 타입 만들기
+   •	재사용 가능한 constraint 설계 전략
+
+⸻
+
+6. 실전 예제 (핵심 파트)
+
+6.1 Generic Stack 구현
+
+6.2 Generic Queue 구현
+
+6.3 Generic Map helper
+
+6.4 Min / Max 함수 구현
+
+6.5 Slice 유틸 함수
+•	filter
+•	map
+•	reduce
+
+⸻
+
+7. Generics와 Interface 비교
+   •	언제 generics를 쓰고
+   •	언제 interface를 쓰는가
+
+비교 기준
+•	polymorphism
+•	성능
+•	타입 안정성
+•	설계 의도
+
+⸻
+
+8. Generics와 성능
+   •	컴파일 타임 vs 런타임
+   •	monomorphization 개념 (Go 내부 동작)
+   •	interface 대비 성능 차이
+   •	메모리 영향
+
+⸻
+
+9. 표준 라이브러리에서 Generics 활용
+   •	slices 패키지
+   •	maps 패키지
+   •	cmp 패키지
+
+사용 예제 중심 설명
+
+⸻
+
+10. 실무 설계 패턴
+    •	Generic repository 패턴
+    •	Generic utility 패키지
+    •	타입 안정 컬렉션
+    •	재사용 가능한 알고리즘 라이브러리
+
+⸻
+
+11. Generics 사용 시 주의사항
+    •	과도한 추상화
+    •	가독성 저하
+    •	constraint 남용
+    •	디버깅 어려움
+
+⸻
+
+12. 언제 Generics를 사용해야 하는가 (실무 판단 기준)
+
+체크리스트 형태 추천
+•	타입만 다른 동일 로직 반복?
+•	타입 안정성 필요한가?
+•	API 공개 라이브러리인가?
+•	interface로 충분한가?
+
+⸻
+
+13. Anti-pattern
+    •	unnecessary generic
+    •	interface + generic 혼합 남용
+    •	constraint 과설계
+
+⸻
+
+14. Generics 마이그레이션 전략
+    •	기존 코드 변환 방법
+    •	단계적 리팩토링
+    •	테스트 전략
+
+⸻
+
+15. 결론
+    •	Go에서 Generics의 역할
+    •	앞으로 활용 방향
+    •	추천 학습 순서
+
+⸻
+
+✨ 선택 추가 (고급자용)
+
+A. Go Generics 내부 구현 구조
+•	dictionary passing
+•	type erasure 여부
+•	컴파일 전략
+
+B. 다른 언어와 비교
+•	C++
+•	Java
+•	Rust
+
+⸻
+
+원하면 다음 단계 바로 도와줄 수 있다 👍
+
+1️⃣ 각 목차별 실제 블로그 초안 작성
+2️⃣ 실습 코드 전체 패키지 설계
+3️⃣ GitHub 예제 repo 구조 설계
+4️⃣ 인터페이스 vs 제네릭 결정 트리 만들기
+5️⃣ 시리즈형 블로그 (5편 구성)
+
+원하는 다음 단계 말해줘 🙂

--- a/docs/done/4_golang_generics_prd.md
+++ b/docs/done/4_golang_generics_prd.md
@@ -1,0 +1,309 @@
+# Golang Generics 블로그 시리즈 PRD
+
+## 개요
+
+Go 언어의 Generics(Go 1.18+)를 체계적으로 스터디하면서 블로그 시리즈로 정리한다.
+샘플 코드는 `tutorials-go/golang/generics/`에, 블로그 포스트는 `blog-v2.advenoh.pe.kr/contents/go/`에 작성한다.
+
+**시리즈 구성**: 총 5편 (개요부터 실무 활용까지)
+
+## 참고 자료
+
+- [docs/start/4_golang_generics_chatgpt.md](./4_golang_generics_chatgpt.md) - ChatGPT 목차 초안
+- https://go.dev/doc/tutorial/generics (공식 튜토리얼)
+- https://go.dev/blog/intro-generics (공식 소개 블로그)
+- https://go.dev/ref/spec#Type_parameter_declarations (스펙)
+- https://pkg.go.dev/golang.org/x/exp/constraints (constraints 패키지)
+- https://pkg.go.dev/slices (Go 1.21+ 표준 slices 패키지)
+- https://pkg.go.dev/maps (Go 1.21+ 표준 maps 패키지)
+- https://pkg.go.dev/cmp (Go 1.21+ 표준 cmp 패키지)
+
+---
+
+## 블로그 시리즈 구성
+
+### 공통 사항
+
+- **시리즈명**: `"Golang Generics"`
+- **태그 공통**: golang, go, generics, 제네릭, 고랭
+- **카테고리 폴더**: `blog-v2.advenoh.pe.kr/contents/go/`
+- **frontmatter 형식**:
+  ```yaml
+  ---
+  title: "제목"
+  description: "설명"
+  date: YYYY-MM-DD
+  update: YYYY-MM-DD
+  tags:
+    - golang
+    - go
+    - generics
+    - 제네릭
+    - (편별 추가 태그)
+  series: "Golang Generics"
+  seriesOrder: N
+  ---
+  ```
+
+---
+
+### 1편: Generics 개요와 기본 문법
+
+- **폴더**: `golang-generics-1-개요와-기본-문법/index.md`
+- **제목**: "Golang Generics (1) - 개요와 기본 문법"
+- **추가 태그**: type-parameter, interface, type-inference, 타입-파라미터, 타입-추론
+- **seriesOrder**: 1
+
+#### 목차
+
+1. Generics란 무엇인가
+   - 정의와 필요성
+   - 중복 코드 문제 (타입별 함수 반복)
+2. Go에서 Generics가 도입된 배경
+   - Go 철학과 Generics의 관계 (simplicity vs abstraction)
+   - Go 1.18 도입 과정
+3. Generics 도입 전 Go의 한계
+   - `interface{}` 기반 구현의 문제점
+   - 타입 안전성 부족 (런타임 에러, 타입 캐스팅 비용)
+   - 코드 예시: `interface{}` vs Generics 비교
+4. Generics 기본 문법
+   - Type parameter 선언 (`func name[T constraint](...)`)
+   - Generic 함수
+   - Generic struct
+   - Generic method
+5. 타입 추론 (Type Inference)
+   - 명시적 타입 지정 vs 추론
+   - 추론이 실패하는 경우
+
+---
+
+### 2편: Type Constraint 완벽 이해
+
+- **폴더**: `golang-generics-2-type-constraint-완벽-이해/index.md`
+- **제목**: "Golang Generics (2) - Type Constraint 완벽 이해"
+- **추가 태그**: constraint, any, comparable, union-type, tilde, 타입-제약
+- **seriesOrder**: 2
+
+#### 목차
+
+1. Constraint 개념
+   - 왜 constraint가 필요한가
+   - constraint = interface
+2. 내장 Constraint
+   - `any` (= `interface{}`)
+   - `comparable` (== / != 연산 가능한 타입)
+3. Union Type Constraint (`|` 연산자)
+   - 여러 타입 묶기
+   - 파이프 연산자로 타입 제한
+4. `~` (Underlying Type Constraint)
+   - tilde 문법 설명
+   - 커스텀 타입(`type MyInt int`) 지원
+5. 커스텀 Constraint 설계
+   - interface 키워드로 constraint 정의
+   - 숫자 타입 묶기 (Integer, Float)
+   - constraint 합성 (Nested Constraint)
+   - `constraints.Ordered` 활용 (`golang.org/x/exp/constraints`)
+6. 재사용 가능한 Constraint 설계 전략
+
+---
+
+### 3편: 실전 예제 모음
+
+- **폴더**: `golang-generics-3-실전-예제-모음/index.md`
+- **제목**: "Golang Generics (3) - 실전 예제 모음"
+- **추가 태그**: stack, queue, filter, map, reduce, data-structure, 자료구조
+- **seriesOrder**: 3
+
+#### 목차
+
+1. Generic 자료구조 구현
+   - Generic Stack
+   - Generic Queue
+2. Generic 유틸 함수
+   - Min / Max 함수
+   - Contains 함수
+3. Slice 유틸 함수 (함수형 패턴)
+   - Filter
+   - Map
+   - Reduce
+4. Generic Map 헬퍼
+   - Keys / Values 추출
+   - Merge
+5. 표준 라이브러리 활용 (Go 1.21+)
+   - `slices` 패키지 (`slices.Sort`, `slices.Contains`, `slices.Filter` 등)
+   - `maps` 패키지 (`maps.Keys`, `maps.Values`, `maps.Clone` 등)
+   - `cmp` 패키지 (`cmp.Or`, `cmp.Compare` 등)
+
+---
+
+### 4편: Generics vs Interface 비교와 성능
+
+- **폴더**: `golang-generics-4-interface-비교와-성능/index.md`
+- **제목**: "Golang Generics (4) - Generics vs Interface 비교와 성능"
+- **추가 태그**: interface, polymorphism, performance, benchmark, monomorphization, 다형성, 성능
+- **seriesOrder**: 4
+
+#### 목차
+
+1. Generics vs Interface 비교
+   - polymorphism 관점
+   - 타입 안전성 관점
+   - 설계 의도 관점
+   - 언제 generics를 쓰고, 언제 interface를 쓰는가 (결정 트리)
+2. Generics 내부 동작 원리
+   - 컴파일 타임 vs 런타임
+   - GCShape Stenciling + Dictionary 방식
+   - monomorphization과의 차이 (Rust와 비교)
+3. 성능 비교 벤치마크
+   - interface 기반 vs Generics 기반 벤치마크
+   - 메모리 할당 비교
+4. 다른 언어와의 비교 (간략)
+   - Java (Type Erasure)
+   - Rust (Monomorphization)
+   - C++ (Templates)
+
+---
+
+### 5편: 실무 패턴과 Best Practices
+
+- **폴더**: `golang-generics-5-실무-패턴과-best-practices/index.md`
+- **제목**: "Golang Generics (5) - 실무 패턴과 Best Practices"
+- **추가 태그**: repository-pattern, best-practice, anti-pattern, migration, 실무
+- **seriesOrder**: 5
+
+#### 목차
+
+1. 실무 설계 패턴
+   - Generic Repository 패턴
+   - Generic Utility 패키지
+   - 타입 안전 컬렉션
+2. 언제 Generics를 사용해야 하는가 (체크리스트)
+   - 타입만 다른 동일 로직 반복?
+   - 타입 안전성이 필요한가?
+   - API 공개 라이브러리인가?
+   - interface로 충분한가?
+3. Anti-patterns
+   - 과도한 추상화 (Unnecessary Generic)
+   - interface + generic 혼합 남용
+   - constraint 과설계
+   - 가독성 저하
+4. 기존 코드 마이그레이션 전략
+   - `interface{}` → Generics 변환 방법
+   - 단계적 리팩토링
+   - 테스트 전략
+5. 결론
+   - Go에서 Generics의 역할
+   - 추천 학습 순서
+
+---
+
+## 샘플 코드 구성
+
+### 디렉토리 구조
+
+`tutorials-go/golang/generics/` 단일 패키지 구조를 유지하면서 파일을 추가한다.
+(기존 코드가 하위 폴더 없이 flat 구조로 통합되었으므로 동일 패턴을 따른다)
+
+```
+tutorials-go/golang/generics/
+│
+│  # ── 기존 파일 (유지) ──────────────────────────────
+├── README.md
+├── basic_generics_test.go          # (기존) interface{} vs generic, no generics → generic 함수 → 타입 제한자 → 커스텀 constraint  → 1편, 2편 참조
+├── contraints_test.go              # (기존) constraints.Ordered, ~ tilde       → 2편 참조
+├── generic_struct_test.go          # (기존) generic struct (Node), Map 함수    → 1편, 3편 참조
+├── interface_constraint_test.go    # (기존) 인터페이스 기반 constraint + 타입 제한자 제약  → 2편 참조
+│
+│  # ── 추가 파일 (1편: 기본 문법) ─────────────────────
+├── type_inference_test.go          # 타입 추론 (명시적 vs 추론, 추론 실패 케이스)
+│
+│  # ── 추가 파일 (2편: Type Constraint) ───────────────
+├── comparable_test.go              # comparable 키워드 (== / != 연산)
+├── custom_constraint_test.go       # 커스텀 constraint 설계 (합성, 재사용 전략)
+│
+│  # ── 추가 파일 (3편: 실전 예제) ─────────────────────
+├── stack_test.go                   # Generic Stack 구현
+├── queue_test.go                   # Generic Queue 구현
+├── minmax_test.go                  # Min / Max / Contains 함수
+├── slice_utils_test.go             # Filter, Map, Reduce
+├── map_utils_test.go               # Keys, Values, Merge
+├── stdlib_test.go                  # slices, maps, cmp 표준 패키지 활용
+│
+│  # ── 추가 파일 (4편: Interface 비교와 성능) ─────────
+├── interface_vs_generic_test.go    # Generics vs Interface 기능 비교
+├── bench_test.go                   # interface vs generic 벤치마크
+│
+│  # ── 추가 파일 (5편: 실무 패턴) ─────────────────────
+├── repository_test.go              # Generic Repository 패턴
+├── utility_test.go                 # Generic Utility 함수
+└── migration_test.go               # interface{} → generics 마이그레이션 예시
+```
+
+### 테스트 파일 공통 규칙
+
+- testify/suite 패턴 사용 (기존 코드 스타일 준수)
+- 한국어 주석으로 교육적 설명 포함
+- 벤치마크 테스트는 `bench_test.go`로 명명
+- Example 함수 패턴 활용 (`func Example_XXX()`)
+
+### 각 편별 테스트 파일 요구사항
+
+| 편 | 파일 | 핵심 테스트 내용 |
+|----|------|-----------------|
+| 1편 | `basic_generics_test.go`, `generic_struct_test.go`, `type_inference_test.go` | interface{} vs generic, 타입별 중복 → generic 함수, struct/method, 타입 추론 |
+| 2편 | `contraints_test.go`, `interface_constraint_test.go`, `comparable_test.go`, `custom_constraint_test.go` | any, comparable, union, ~tilde, 인터페이스 기반 constraint, 커스텀 설계 |
+| 3편 | `stack_test.go`, `queue_test.go`, `minmax_test.go`, `slice_utils_test.go`, `map_utils_test.go`, `stdlib_test.go` | Stack, Queue, Min/Max, Filter/Map/Reduce, 표준 라이브러리 |
+| 4편 | `interface_vs_generic_test.go`, `bench_test.go` | interface vs generics 기능 비교, 벤치마크 |
+| 5편 | `repository_test.go`, `utility_test.go`, `migration_test.go` | Repository 패턴, 유틸리티, 마이그레이션 예시 |
+
+---
+
+## 작업 순서 (편별)
+
+각 편은 독립적으로 아래 순서를 따른다.
+
+### Phase 1: 샘플 코드 작성
+1. `tutorials-go/golang/generics/` 에 테스트 파일 추가 (단일 패키지 구조 유지)
+2. 기존 파일과 함수명/타입명 충돌 없는지 확인
+3. `go test -v ./golang/generics/...` 로 테스트 통과 확인
+
+### Phase 2: 블로그 포스트 작성
+4. `blog-v2.advenoh.pe.kr/contents/go/{폴더명}/index.md` 생성
+5. frontmatter 작성 (series, seriesOrder 포함)
+6. 본문 작성 (개념 설명 + 코드 예제 인라인)
+7. 인코딩 확인 (`file -I`)
+
+### Phase 3: 검증
+8. 블로그 빌드 확인 (`npm run build`)
+9. 테스트 재확인 (`go test ./golang/generics/...`)
+
+### Phase 4: PR 생성
+10. feature 브랜치 생성 (편당 또는 묶어서)
+    - `feature/{issue-number}-golang-generics-{N}`
+11. PR 생성 및 리뷰 요청
+
+---
+
+## 진행 우선순위
+
+**필수 (Core)**: 1편 ~ 3편
+- 기초 문법부터 실전 예제까지 핵심 내용
+- Generics를 처음 배우는 사람이 가장 필요로 하는 내용
+
+**심화 (Advanced)**: 4편
+- Interface 비교, 내부 동작, 성능 분석은 중급 이상 내용
+
+**마무리 (Wrap-up)**: 5편
+- 실무 패턴과 Best Practices로 전체 지식 통합
+
+---
+
+## 기존 코드 활용
+
+`tutorials-go/golang/generics/`에 이미 존재하는 예제 (단일 패키지 `go_generics`로 통합 완료):
+- `basic_generics_test.go` - `interface{}` vs generics 비교 (`foo1` vs `foo2`), 단계별 학습 (no generics → generic 함수 → 타입 제한자 → 커스텀 constraint 합성) → 1편, 2편에서 참조
+- `contraints_test.go` - `constraints.Ordered`, `~` tilde, `MyInt` 커스텀 타입 → 2편에서 참조
+- `generic_struct_test.go` - Generic struct (`Node[T]`), Generic `Map` 함수 → 1편, 3편에서 참조
+- `interface_constraint_test.go` - 인터페이스 기반 constraint, 타입 제한자 제약 (`Stringer`) → 2편에서 참조
+
+기존 코드는 유지하면서, 동일 패키지 내에 새 파일을 추가한다.


### PR DESCRIPTION
## Summary
- `docs/start`에 있던 완료된 문서 13개를 `docs/done`으로 이동
  - Go 125/126 PRD, 구현 계획, TODO
  - ChatGPT 관련 문서
  - Claude Code Plugin PRD
  - Golang Concurrency PRD, 구현 계획, TODO
  - Golang Generics ChatGPT, PRD

## Test plan
- [x] 파일 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)