### PR TITLE
chore: 환경변수명 BLOGV2_CATEGORIZER_OPENAI_API_KEY → BLOGV2_OPENAI_API_KEY로 변경

### DIFF
--- a/.github/workflows/biweekly-news.yml
+++ b/.github/workflows/biweekly-news.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           BLOG_IT_NEWS_SUPABASE_URL: ${{ secrets.BLOG_IT_NEWS_SUPABASE_URL }}
           BLOG_IT_NEWS_SUPABASE_API_KEY: ${{ secrets.BLOG_IT_NEWS_SUPABASE_API_KEY }}
-          BLOGV2_CATEGORIZER_OPENAI_API_KEY: ${{ secrets.BLOGV2_CATEGORIZER_OPENAI_API_KEY }}
+          BLOGV2_OPENAI_API_KEY: ${{ secrets.BLOGV2_OPENAI_API_KEY }}
         run: python scripts/news/main.py
 
       - name: Create Pull Request

--- a/docs/done/3_category_llm_todo.md
+++ b/docs/done/3_category_llm_todo.md
@@ -4,8 +4,8 @@
 
 - [x] OpenAI API 키 발급 및 설정
   - [x] [OpenAI Platform](https://platform.openai.com/api-keys)에서 API 키 생성
-  - [x] `~/.zshrc`에 `BLOGV2_CATEGORIZER_OPENAI_API_KEY` 환경변수 추가
-  - [x] 환경변수 적용 확인: `echo $BLOGV2_CATEGORIZER_OPENAI_API_KEY`
+  - [x] `~/.zshrc`에 `BLOGV2_OPENAI_API_KEY` 환경변수 추가
+  - [x] 환경변수 적용 확인: `echo $BLOGV2_OPENAI_API_KEY`
 
 - [x] 의존성 추가
   - [x] `scripts/news/pyproject.toml`에 `openai>=1.0.0`, `pydantic>=2.0.0` 추가
@@ -82,13 +82,13 @@
 
 - [ ] GitHub Secrets 추가
   - [ ] Repository Settings → Secrets and variables → Actions
-  - [ ] `BLOGV2_CATEGORIZER_OPENAI_API_KEY` 시크릿 추가
+  - [ ] `BLOGV2_OPENAI_API_KEY` 시크릿 추가
 
 - [x] workflow 파일 수정
   - [x] `.github/workflows/biweekly-news.yml`에 환경변수 추가
   ```yaml
   env:
-    BLOGV2_CATEGORIZER_OPENAI_API_KEY: ${{ secrets.BLOGV2_CATEGORIZER_OPENAI_API_KEY }}
+    BLOGV2_OPENAI_API_KEY: ${{ secrets.BLOGV2_OPENAI_API_KEY }}
   ```
 
 ---

--- a/scripts/news/category/ai_categorizer.py
+++ b/scripts/news/category/ai_categorizer.py
@@ -14,7 +14,7 @@ BATCH_SIZE = 30
 TEMPERATURE = 0.1
 
 # 환경 변수 이름
-ENV_API_KEY = "BLOGV2_CATEGORIZER_OPENAI_API_KEY"
+ENV_API_KEY = "BLOGV2_OPENAI_API_KEY"
 
 # 카테고리 타입 정의
 CategoryType = Literal["Cloud & Infra", "AI / ML", "Development", "Security", "Misc"]


### PR DESCRIPTION
## Summary
- OpenAI API 키 환경변수명을 `BLOGV2_CATEGORIZER_OPENAI_API_KEY` → `BLOGV2_OPENAI_API_KEY`로 간소화
- 변경 파일: `ai_categorizer.py`, `biweekly-news.yml`, TODO 문서

## Test plan
- [ ] GitHub Repository Secrets에서 `BLOGV2_OPENAI_API_KEY`로 시크릿 이름 변경
- [ ] workflow 수동 실행하여 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)