### PR TITLE
chore: deploy preview 빌드 스킵 설정 추가

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   command = "npm run build"
   publish = "out"
+  ignore = "/bin/bash -c '[[ \"$CONTEXT\" == \"deploy-preview\" ]] && exit 0 || exit 1'"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- netlify.toml에 `ignore` 커맨드 추가하여 deploy-preview 빌드 스킵
- PR 생성 시 preview 빌드가 실행되지 않아 무료 플랜 빌드 credit 절약
- main 머지 시 production 빌드는 정상 실행

## Test plan
- [ ] PR 생성 후 Netlify deploy preview 빌드가 스킵되는지 확인
- [ ] main 머지 후 production 빌드가 정상 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)