### PR TITLE
chore: Node.js 버전 20 → 22로 업데이트

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,5 +9,5 @@
   status = 404
 
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
   NPM_FLAGS = "--legacy-peer-deps"


### PR DESCRIPTION
## Summary
- netlify.toml의 NODE_VERSION을 20 → 22로 변경
- Netlify 대시보드 설정(22.x)과 일치시킴

## Test plan
- [ ] 머지 후 production 빌드가 Node 22에서 정상 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)