### PR TITLE
fix: MQTT v5 가이드 5편 코드 블록 언어 오류 수정 (404 해결)

### DIFF
--- a/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index.md
+++ b/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index.md
@@ -1000,7 +1000,7 @@ export function DeviceStatus() {
 
 `Mosquitto`는 `TCP`와 `WebSocket` 두 가지 프로토콜을 동시에 지원한다. 각각 다른 포트에서 리스닝하도록 설정한다.
 
-```conf
+```ini
 # mosquitto/config/mosquitto.conf
 listener 1883
 listener 9001
@@ -1022,7 +1022,7 @@ allow_anonymous true
 
 **프로덕션 환경에서는:**
 
-```conf
+```ini
 listener 1883
 listener 9001
 protocol websockets


### PR DESCRIPTION
## Summary
- MQTT v5 가이드 5편에서 코드 블록 언어 `conf`가 `rehype-prism-plus`에 미등록되어 빌드 시 페이지 생성 실패 → 404 발생
- `conf` → `ini`로 변경하여 빌드 오류 해결 (2곳)

## Test plan
- [x] `npm run build` 로컬 빌드 성공 확인
- [ ] 배포 후 https://blog.advenoh.pe.kr/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/ 접근 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)