### PR TITLE
[#317] Go gRPC 서비스 구현 블로그 글 초안

### DIFF
--- a/docs/start/6_12_go_grpc/index.md
+++ b/docs/start/6_12_go_grpc/index.md
@@ -1,0 +1,353 @@
+---
+title: "Go gRPC 서비스 구현과 Protobuf 활용"
+description: "Go에서 gRPC 서비스를 구현하고 Protocol Buffers로 API를 정의하는 방법을 TodoList 예제로 알아봅니다. buf 도구, 인터셉터, gRPC-Gateway, Connect-Go까지 다룹니다."
+date: 2026-03-04
+update: 2026-03-04
+tags:
+  - golang
+  - go
+  - grpc
+  - protobuf
+  - grpc-gateway
+  - buf
+  - connect-go
+  - 고랭
+---
+
+REST API에 익숙한 개발자가 gRPC를 처음 접하면 "왜 JSON 대신 바이너리를 쓰는가?"라는 의문이 든다. 이 글에서는 Go로 **TodoList gRPC 서비스**를 구현하면서 Protobuf 정의부터 인터셉터, gRPC-Gateway까지 실전에 필요한 내용을 다룬다.
+
+> 이 글의 전체 샘플 코드는 [GitHub](https://github.com/kenshin579/tutorials-go/tree/master/grpc/todolist)에서 확인할 수 있다.
+
+# 1.gRPC란?
+
+gRPC는 Google이 만든 고성능 RPC(Remote Procedure Call) 프레임워크다. HTTP/2 기반으로 동작하며, Protocol Buffers(Protobuf)를 기본 직렬화 포맷으로 사용한다.
+
+| 항목 | REST API | gRPC |
+|---|---|---|
+| 프로토콜 | HTTP/1.1 | HTTP/2 |
+| 데이터 포맷 | JSON (텍스트) | Protobuf (바이너리) |
+| API 정의 | OpenAPI/Swagger (선택) | `.proto` 파일 (필수) |
+| 코드 생성 | 선택 | 자동 (서버/클라이언트) |
+| 스트리밍 | 제한적 (SSE, WebSocket) | 네이티브 지원 |
+| 브라우저 지원 | 네이티브 | gRPC-Web 필요 |
+
+**주요 활용 사례:**
+- 마이크로서비스 간 내부 통신 (낮은 지연, 높은 처리량)
+- 모바일/IoT 백엔드 (바이너리 직렬화로 대역폭 절약)
+- 실시간 스트리밍 서비스
+
+# 2.개발 환경 설정과 Protobuf 정의
+
+## 2.1 protoc 기반 설정
+
+전통적인 방식은 `protoc` 컴파일러와 Go 플러그인을 사용한다.
+
+```bash
+# protoc 설치 (macOS)
+brew install protobuf
+
+# Go 플러그인 설치
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+# 코드 생성
+protoc --go_out=. --go-grpc_out=. proto/todo/v1/todo.proto
+```
+
+## 2.2 buf 도구 소개
+
+**buf**는 protoc의 현대적 대안이다. 설정이 간편하고, 린팅과 Breaking Change 감지를 기본 제공한다.
+
+```bash
+# buf 설치
+brew install buf
+```
+
+| 항목 | protoc | buf |
+|---|---|---|
+| 설정 | CLI 플래그 (길고 복잡) | YAML 설정 파일 |
+| 린팅 | 없음 | 내장 (`buf lint`) |
+| Breaking Change 감지 | 없음 | 내장 (`buf breaking`) |
+| 의존성 관리 | 수동 (proto 파일 복사) | BSR (Buf Schema Registry) |
+
+**buf.yaml** - 모듈 설정:
+
+```yaml
+version: v2
+modules:
+  - path: proto
+deps:
+  - buf.build/googleapis/googleapis
+lint:
+  use:
+    - STANDARD
+```
+
+**buf.gen.yaml** - 코드 생성 설정:
+
+```yaml
+version: v2
+plugins:
+  - remote: buf.build/protocolbuffers/go
+    out: gen
+    opt: paths=source_relative
+  - remote: buf.build/grpc/go
+    out: gen
+    opt: paths=source_relative
+  - remote: buf.build/grpc-ecosystem/gateway
+    out: gen
+    opt: paths=source_relative
+```
+
+```bash
+# 의존성 업데이트 + 코드 생성
+buf dep update
+buf generate
+```
+
+## 2.3 Protobuf 문법과 TodoList 서비스 정의
+
+`.proto` 파일은 서비스 인터페이스와 메시지 타입을 정의한다. TodoList CRUD를 예로 보자.
+
+```protobuf
+syntax = "proto3";
+
+package todo.v1;
+
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
+
+// Todo 메시지 정의
+message Todo {
+  string id = 1;
+  string title = 2;
+  bool completed = 3;
+  google.protobuf.Timestamp created_at = 4;
+}
+
+// 서비스 정의 (5개 Unary RPC)
+service TodoService {
+  rpc CreateTodo(CreateTodoRequest) returns (CreateTodoResponse) {
+    option (google.api.http) = {
+      post: "/v1/todos"
+      body: "*"
+    };
+  }
+
+  rpc GetTodo(GetTodoRequest) returns (GetTodoResponse) {
+    option (google.api.http) = {
+      get: "/v1/todos/{id}"
+    };
+  }
+
+  rpc ListTodos(ListTodosRequest) returns (ListTodosResponse) {
+    option (google.api.http) = {
+      get: "/v1/todos"
+    };
+  }
+
+  rpc UpdateTodo(UpdateTodoRequest) returns (UpdateTodoResponse) {
+    option (google.api.http) = {
+      put: "/v1/todos/{id}"
+      body: "*"
+    };
+  }
+
+  rpc DeleteTodo(DeleteTodoRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/todos/{id}"
+    };
+  }
+}
+```
+
+`google.api.http` 어노테이션은 gRPC-Gateway에서 REST 엔드포인트를 자동 생성할 때 사용한다.
+
+`buf generate`를 실행하면 다음 파일이 생성된다:
+- `todo.pb.go` - 메시지 타입 (직렬화/역직렬화)
+- `todo_grpc.pb.go` - gRPC 서버/클라이언트 인터페이스
+- `todo.pb.gw.go` - gRPC-Gateway HTTP 핸들러
+
+# 3.TodoList 서비스 구현
+
+## 3.1 Unary RPC
+
+### 서버 구현
+
+자동 생성된 `TodoServiceServer` 인터페이스를 구현한다. 인메모리 저장소로 간단하게 만든다.
+
+```go
+type TodoService struct {
+    todopb.UnimplementedTodoServiceServer
+    mu    sync.Mutex
+    todos map[string]*todopb.Todo
+}
+
+func (s *TodoService) CreateTodo(ctx context.Context, req *todopb.CreateTodoRequest) (*todopb.CreateTodoResponse, error) {
+    if req.GetTitle() == "" {
+        return nil, status.Error(codes.InvalidArgument, "title is required")
+    }
+
+    s.mu.Lock()
+    defer s.mu.Unlock()
+
+    todo := &todopb.Todo{
+        Id:        uuid.New().String(),
+        Title:     req.GetTitle(),
+        Completed: false,
+        CreatedAt: timestamppb.New(time.Now()),
+    }
+    s.todos[todo.Id] = todo
+
+    return &todopb.CreateTodoResponse{Todo: todo}, nil
+}
+```
+
+`UnimplementedTodoServiceServer`를 임베딩하면 구현하지 않은 RPC는 `Unimplemented` 에러를 반환한다. 향후 proto에 새 RPC가 추가되어도 컴파일이 깨지지 않는다.
+
+에러 처리는 `status.Error()`에 gRPC 상태 코드를 사용한다. 주요 코드:
+- `codes.InvalidArgument` - 잘못된 요청
+- `codes.NotFound` - 리소스 없음
+- `codes.Internal` - 서버 내부 에러
+
+### 클라이언트 구현
+
+```go
+conn, err := grpc.NewClient("localhost:50051",
+    grpc.WithTransportCredentials(insecure.NewCredentials()),
+)
+defer conn.Close()
+
+client := todopb.NewTodoServiceClient(conn)
+
+// Create
+resp, err := client.CreateTodo(ctx, &todopb.CreateTodoRequest{Title: "Learn gRPC"})
+```
+
+`grpc.NewClient()`로 연결을 만들고, 자동 생성된 클라이언트로 RPC를 호출한다. 일반 함수 호출처럼 사용할 수 있다.
+
+## 3.2 인터셉터 (Middleware)
+
+gRPC 인터셉터는 HTTP 미들웨어와 같은 역할이다. 로깅 인터셉터 예제:
+
+```go
+func UnaryLogging() grpc.UnaryServerInterceptor {
+    return func(
+        ctx context.Context,
+        req interface{},
+        info *grpc.UnaryServerInfo,
+        handler grpc.UnaryHandler,
+    ) (interface{}, error) {
+        start := time.Now()
+        resp, err := handler(ctx, req)
+        st, _ := status.FromError(err)
+        log.Printf("method=%s duration=%s code=%s error=%v",
+            info.FullMethod, time.Since(start), st.Code(), err)
+        return resp, err
+    }
+}
+```
+
+서버에 체인으로 적용한다:
+
+```go
+s := grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        interceptor.UnaryLogging(),
+        // 추가 인터셉터...
+    ),
+)
+```
+
+## 3.3 테스트 (bufconn)
+
+`bufconn`은 실제 네트워크 없이 gRPC 서버를 테스트할 수 있게 해준다. 인메모리 리스너를 사용한다.
+
+```go
+var lis *bufconn.Listener
+
+func init() {
+    lis = bufconn.Listen(1024 * 1024)
+    s := grpc.NewServer()
+    todopb.RegisterTodoServiceServer(s, server.NewTodoService())
+    go s.Serve(lis)
+}
+
+func bufDialer(ctx context.Context, _ string) (net.Conn, error) {
+    return lis.DialContext(ctx)
+}
+
+func TestTodoService_CRUD(t *testing.T) {
+    conn, _ := grpc.NewClient("passthrough:///bufnet",
+        grpc.WithContextDialer(bufDialer),
+        grpc.WithTransportCredentials(insecure.NewCredentials()),
+    )
+    client := todopb.NewTodoServiceClient(conn)
+
+    // Create → Get → List → Update → Delete 흐름 테스트
+    createResp, err := client.CreateTodo(ctx, &todopb.CreateTodoRequest{Title: "Test Todo"})
+    require.NoError(t, err)
+    assert.Equal(t, "Test Todo", createResp.GetTodo().GetTitle())
+    // ...
+}
+```
+
+# 4.gRPC 생태계
+
+## 4.1 gRPC-Gateway
+
+gRPC-Gateway는 gRPC 서비스에서 **REST API를 자동 생성**해준다. proto 파일의 HTTP 어노테이션을 기반으로 HTTP ↔ gRPC 변환을 처리한다.
+
+```go
+func main() {
+    mux := runtime.NewServeMux()
+    opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+    todopb.RegisterTodoServiceHandlerFromEndpoint(ctx, mux, "localhost:50051", opts)
+    http.ListenAndServe(":8080", mux)
+}
+```
+
+gRPC 서버(`:50051`)와 Gateway(`:8080`)를 동시에 실행하면 동일한 서비스를 gRPC와 REST 양쪽으로 접근할 수 있다.
+
+```bash
+# REST로 Todo 생성
+curl -X POST http://localhost:8080/v1/todos \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Learn gRPC-Gateway"}'
+
+# REST로 Todo 목록 조회
+curl http://localhost:8080/v1/todos
+```
+
+## 4.2 Connect-Go 소개
+
+**Connect-Go**는 Buf 팀이 만든 gRPC 호환 프레임워크다. 기존 gRPC와 몇 가지 차이가 있다.
+
+| 항목 | gRPC-Go | Connect-Go |
+|---|---|---|
+| HTTP 호환성 | HTTP/2 전용 | HTTP/1.1 + HTTP/2 |
+| 프로토콜 | gRPC | gRPC, gRPC-Web, Connect |
+| 라우터 | 자체 서버 | 표준 `net/http` |
+| 브라우저 지원 | gRPC-Web 프록시 필요 | 네이티브 |
+
+Connect-Go는 `net/http`와 완전 호환되어 기존 HTTP 미들웨어를 그대로 사용할 수 있다. gRPC 클라이언트와도 호환되므로 점진적 마이그레이션이 가능하다.
+
+# 마무리
+
+이 글에서는 Go로 gRPC TodoList 서비스를 구현하면서 다음을 다뤘다:
+- **Protobuf** 정의와 **buf** 도구를 활용한 코드 생성
+- **Unary RPC** 서버/클라이언트 구현과 에러 처리
+- **인터셉터**로 로깅 미들웨어 구현
+- **gRPC-Gateway**로 REST API 자동 노출
+- **Connect-Go** 대안 프레임워크 소개
+
+다음 글에서는 **Streaming RPC** 패턴 (Server, Client, Bidirectional Streaming)을 다룰 예정이다.
+
+## 참고
+
+- [gRPC 공식 문서](https://grpc.io/docs/languages/go/)
+- [Protocol Buffers 공식 문서](https://protobuf.dev/)
+- [buf 공식 문서](https://buf.build/docs/)
+- [gRPC-Gateway](https://grpc-ecosystem.github.io/grpc-gateway/)
+- [Connect-Go](https://connectrpc.com/docs/go/getting-started/)

--- a/docs/start/6_12_go_grpc_implementation.md
+++ b/docs/start/6_12_go_grpc_implementation.md
@@ -1,0 +1,172 @@
+# gRPC 서비스 구현과 Protobuf 활용 - 구현 계획서
+
+> PRD: `6_12_go_grpc_prd.md`
+
+---
+
+## 1. 샘플 코드 작성 (tutorials-go)
+
+**위치**: `tutorials-go/grpc/todolist/`
+
+### 1.1 프로젝트 초기 설정
+
+| 파일 | 내용 |
+|---|---|
+| `go.mod` | 모듈 초기화 (`tutorials-go/grpc/todolist`) |
+| `buf.yaml` | buf 모듈 설정 (name, lint, breaking 룰) |
+| `buf.gen.yaml` | 코드 생성 플러그인 설정 (protoc-gen-go, protoc-gen-go-grpc, grpc-gateway) |
+| `Makefile` | `buf generate`, 서버/클라이언트/게이트웨이 실행 타겟 |
+
+### 1.2 Protobuf 정의
+
+**`proto/todo/v1/todo.proto`**
+- TodoService 정의 (5개 Unary RPC)
+  - `CreateTodo(CreateTodoRequest) returns (CreateTodoResponse)`
+  - `GetTodo(GetTodoRequest) returns (GetTodoResponse)`
+  - `ListTodos(ListTodosRequest) returns (ListTodosResponse)`
+  - `UpdateTodo(UpdateTodoRequest) returns (UpdateTodoResponse)`
+  - `DeleteTodo(DeleteTodoRequest) returns (DeleteTodoResponse)`
+- Message 정의: `Todo` (id, title, completed, created_at)
+- gRPC-Gateway용 HTTP 어노테이션 포함
+
+```protobuf
+import "google/api/annotations.proto";
+
+service TodoService {
+  rpc CreateTodo(CreateTodoRequest) returns (CreateTodoResponse) {
+    option (google.api.http) = {
+      post: "/v1/todos"
+      body: "*"
+    };
+  }
+  rpc GetTodo(GetTodoRequest) returns (GetTodoResponse) {
+    option (google.api.http) = {
+      get: "/v1/todos/{id}"
+    };
+  }
+  // ...
+}
+```
+
+### 1.3 서버 구현
+
+**`server/main.go`**
+- gRPC 서버 생성 + TCP 리스너 (`:50051`)
+- TodoService 등록
+- 로깅 인터셉터 체인
+
+**`server/service.go`**
+- `TodoServiceServer` 인터페이스 구현
+- 인메모리 저장소 (`sync.Mutex` + `map[string]*todopb.Todo`)
+- CRUD 로직 + gRPC 상태 코드 에러 처리 (`codes.NotFound`, `codes.InvalidArgument`)
+
+### 1.4 클라이언트 구현
+
+**`client/main.go`**
+- `grpc.NewClient()` 연결
+- CreateTodo → ListTodos → UpdateTodo → GetTodo → DeleteTodo 시나리오 실행
+
+### 1.5 인터셉터
+
+**`interceptor/logging.go`**
+- `grpc.UnaryServerInterceptor` 구현
+- 요청 메서드명, 처리 시간, 에러 여부 로깅
+
+### 1.6 gRPC-Gateway
+
+**`gateway/main.go`**
+- `runtime.NewServeMux()` + `RegisterTodoServiceHandlerFromEndpoint()`
+- HTTP `:8080` → gRPC `:50051` 프록시
+- JSON ↔ Protobuf 자동 변환
+
+### 1.7 테스트
+
+**`server_test.go`**
+- `bufconn` 기반 인메모리 gRPC 연결
+- CRUD 흐름 통합 테스트: Create → Get → List → Update → Delete
+- 에러 케이스: 존재하지 않는 Todo 조회 → `codes.NotFound`
+
+---
+
+## 2. 블로그 글 작성
+
+**위치**: `blog-v2.advenoh.pe.kr/docs/start/6_12_go_grpc/index.md`
+
+### 2.1 글 구조
+
+```
+1. gRPC란?
+   - REST vs gRPC 비교 표
+   - HTTP/2 + Protobuf 장점
+
+2. 개발 환경 설정과 Protobuf 정의
+   2.1 protoc 기반 설정
+   2.2 buf 도구 소개 (protoc vs buf 비교)
+   2.3 Protobuf 문법 + TodoList 서비스 정의
+
+3. TodoList 서비스 구현
+   3.1 Unary RPC (서버 + 클라이언트 + 에러 처리)
+   3.2 인터셉터 (로깅 미들웨어)
+   3.3 테스트 (bufconn)
+
+4. gRPC 생태계
+   4.1 gRPC-Gateway (REST 자동 노출)
+   4.2 Connect-Go 소개 (간단 비교)
+```
+
+### 2.2 Frontmatter
+
+```yaml
+title: "Go gRPC 서비스 구현과 Protobuf 활용"
+description: "Go에서 gRPC 서비스를 구현하고 Protocol Buffers로 API를 정의하는 방법을 TodoList 예제로 알아봅니다. buf 도구, 인터셉터, gRPC-Gateway, Connect-Go까지 다룹니다."
+date: 2026-03-XX
+tags:
+  - golang
+  - go
+  - grpc
+  - protobuf
+  - grpc-gateway
+  - buf
+  - connect-go
+series: "Golang 시리즈"
+```
+
+### 2.3 코드 블록 규칙
+- 블로그 내 코드는 핵심 부분만 인라인으로 포함
+- 전체 코드는 GitHub 저장소 링크로 참조
+- 링크 형식: `github.com/kenshin579/tutorials-go/grpc/todolist/`
+
+---
+
+## 3. 핵심 구현 포인트
+
+### bufconn 테스트 패턴
+```go
+func bufDialer(context.Context, string) (net.Conn, error) {
+    return lis.DialContext(context.Background())
+}
+
+func TestTodoService_CRUD(t *testing.T) {
+    lis = bufconn.Listen(bufSize)
+    s := grpc.NewServer()
+    todopb.RegisterTodoServiceServer(s, NewTodoService())
+    go s.Serve(lis)
+
+    conn, _ := grpc.NewClient("passthrough:///bufnet",
+        grpc.WithContextDialer(bufDialer),
+        grpc.WithTransportCredentials(insecure.NewCredentials()),
+    )
+    client := todopb.NewTodoServiceClient(conn)
+    // CRUD 테스트...
+}
+```
+
+### gRPC-Gateway 프록시 패턴
+```go
+func main() {
+    mux := runtime.NewServeMux()
+    opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+    todopb.RegisterTodoServiceHandlerFromEndpoint(ctx, mux, "localhost:50051", opts)
+    http.ListenAndServe(":8080", mux)
+}
+```

--- a/docs/start/6_12_go_grpc_prd.md
+++ b/docs/start/6_12_go_grpc_prd.md
@@ -7,11 +7,12 @@
 
 ## 1. 개요
 
-Go에서 gRPC 서비스를 구현하고 Protocol Buffers(Protobuf)로 API를 정의하는 방법. REST API와의 차이점, Unary/Streaming RPC 패턴, 인터셉터를 활용한 미들웨어 패턴까지 다룬다.
+Go에서 gRPC 서비스를 구현하고 Protocol Buffers(Protobuf)로 API를 정의하는 방법. REST API와의 차이점, Unary RPC, 인터셉터, gRPC-Gateway를 다룬다. Streaming RPC는 별도 글로 분리한다.
 
 **대상 독자**: REST API 경험이 있고 gRPC를 처음 접하는 개발자
 **난이도**: 중급
-**예제 코드**: 신규 작성 필요 (`tutorials-go/grpc/` 예정)
+**예제 코드**: 신규 작성 필요 (`tutorials-go/grpc/todolist/` 예정)
+**예상 작업량**: 샘플 코드 ~750줄 (10개 파일), 블로그 글 ~1500단어
 
 ---
 
@@ -23,65 +24,86 @@ Go에서 gRPC 서비스를 구현하고 Protocol Buffers(Protobuf)로 API를 정
 - REST vs gRPC 비교 (JSON vs Binary, HTTP/1.1 vs HTTP/2)
 - 활용 사례: 마이크로서비스 간 통신, 모바일 백엔드
 
-### 2.2 Protobuf 정의
-- `.proto` 파일 기본 문법 (syntax, package, message, service)
-- 스칼라 타입, 반복 필드, 중첩 메시지
+### 2.2 개발 환경 설정과 Protobuf 정의
+
+#### protoc 기반 설정
 - `protoc` 컴파일러 설치 및 Go 코드 생성
 - `protoc-gen-go`, `protoc-gen-go-grpc` 플러그인
 
-### 2.3 Unary RPC 구현
+#### buf 도구 소개
+- protoc의 대안: 더 간편한 설정, 린팅, Breaking Change 감지
+- `buf.yaml`, `buf.gen.yaml` 설정
+- `buf generate` 명령어로 코드 생성
+- protoc vs buf 비교
+
+#### Protobuf 문법
+- `.proto` 파일 기본 문법 (syntax, package, message, service)
+- 스칼라 타입, 반복 필드, 중첩 메시지
+- TodoList 서비스 정의 예제
+
+### 2.3 TodoList 서비스 구현
+
+#### Unary RPC
 - 서버 구현: `RegisterXxxServer()`, 인터페이스 구현
-- 클라이언트 구현: `grpc.Dial()`, 자동 생성된 클라이언트 사용
+- TodoList CRUD: CreateTodo, GetTodo, ListTodos, UpdateTodo, DeleteTodo
+- 클라이언트 구현: `grpc.NewClient()`, 자동 생성된 클라이언트 사용
 - 에러 처리: `status.Error()`, gRPC 상태 코드
 
-### 2.4 Streaming RPC
-- **Server Streaming**: 서버가 여러 응답 전송
-- **Client Streaming**: 클라이언트가 여러 요청 전송
-- **Bidirectional Streaming**: 양방향 스트림
-- 각 패턴의 활용 사례
-
-### 2.5 인터셉터 (Middleware)
-- Unary Interceptor: 로깅, 인증, 에러 핸들링
-- Stream Interceptor
+#### 인터셉터 (Middleware)
+- Unary Interceptor: 로깅 인터셉터 예제
 - 체인 인터셉터: 여러 인터셉터 조합
 
-### 2.6 gRPC-Gateway (선택)
-- REST API 자동 생성: gRPC 서비스에서 REST 엔드포인트 노출
-- Swagger/OpenAPI 문서 자동 생성
-
-### 2.7 테스트
+#### 테스트
 - `bufconn`: 네트워크 없이 gRPC 테스트
-- Mock 서비스 구현
+- 서비스 로직 단위 테스트
+
+### 2.4 gRPC 생태계
+
+#### gRPC-Gateway
+- REST API 자동 생성: gRPC 서비스에서 REST 엔드포인트 노출
+- proto 파일에 HTTP 어노테이션 추가 (`google.api.http`)
+- Gateway 서버 구현
+- curl로 REST API 호출 테스트
+
+#### Connect-Go 소개
+- Buf 팀이 만든 gRPC 호환 프레임워크
+- 표준 `net/http`와 호환, HTTP/1.1 지원
+- gRPC, gRPC-Web, Connect 프로토콜 동시 지원
+- 기존 gRPC와의 차이점 간단 비교 (별도 글 가능)
 
 ---
 
 ## 3. 샘플 코드 계획
 
-신규 작성 필요. 예상 구조:
+신규 작성 필요. 기존 레포에 `golang/third-party/grpc/helloworld/`, `grpc/route_guide/` 예제 참고 가능.
 
 ```
-tutorials-go/grpc/
+tutorials-go/grpc/todolist/
 ├── proto/
-│   └── greeter.proto          # 서비스 정의
+│   └── todo.proto             # TodoList 서비스 정의 (+ HTTP 어노테이션)
+├── buf.yaml                    # buf 설정
+├── buf.gen.yaml                # buf 코드 생성 설정
 ├── gen/
-│   └── greeter/               # 자동 생성 코드
+│   └── todopb/                # 자동 생성 코드 (pb.go, grpc.pb.go, gw.pb.go)
 ├── server/
-│   └── main.go               # gRPC 서버
+│   └── main.go               # gRPC 서버 + 서비스 구현
 ├── client/
 │   └── main.go               # gRPC 클라이언트
 ├── interceptor/
-│   └── logging.go            # 인터셉터 예제
-├── Makefile                    # protoc 빌드
-└── README.md
+│   └── logging.go            # 로깅 인터셉터
+├── gateway/
+│   └── main.go               # gRPC-Gateway REST 서버
+├── Makefile                    # buf generate, 서버 실행
+└── server_test.go             # bufconn 테스트
 ```
 
 ---
 
-## 4. 논의 사항
+## 4. 논의 사항 (리뷰 완료)
 
-- [ ] 예제 서비스 주제: Greeter(간단) vs TodoList(실용적) vs ArticleService(기존 코드 연계)
-- [ ] gRPC-Gateway까지 다룰지, 순수 gRPC만 다룰지
-- [ ] Streaming RPC를 모두 다루면 글이 길어짐 → Unary만 다루고 Streaming은 별도 글로?
-- [ ] Connect-Go (gRPC 대안) 언급 여부
-- [ ] buf 도구 (protoc 대안) 소개 여부
-- [ ] 코드 신규 작성이 필요하므로 작업량 확인
+- [x] 예제 서비스 주제 → **TodoList** (실용적, CRUD 패턴 보여주기 좋음)
+- [x] gRPC-Gateway → **포함** (2.5절에 추가)
+- [x] Streaming RPC → **별도 글로 분리** (`6_13_go_grpc_streaming_prd.md` 생성)
+- [x] Connect-Go → **소개 섹션 추가** (2.6절, 간단 비교)
+- [x] buf 도구 → **포함** (2.2절에서 protoc과 비교하며 소개)
+- [x] 작업량 → 샘플 코드 ~750줄 (10개 파일), 블로그 ~1500단어. 기존 helloworld/route_guide 예제 참고 가능

--- a/docs/start/6_12_go_grpc_todo.md
+++ b/docs/start/6_12_go_grpc_todo.md
@@ -1,0 +1,65 @@
+# gRPC 서비스 구현과 Protobuf 활용 - TODO
+
+> PRD: `6_12_go_grpc_prd.md`
+> 구현 계획서: `6_12_go_grpc_implementation.md`
+
+---
+
+## 1단계: 프로젝트 초기 설정
+
+- [x] `tutorials-go/grpc/todolist/` 디렉토리 생성
+- [x] `go.mod` 초기화
+- [x] `buf.yaml` 작성
+- [x] `buf.gen.yaml` 작성 (protoc-gen-go, protoc-gen-go-grpc, grpc-gateway)
+- [x] `Makefile` 작성 (buf generate, 실행 타겟)
+
+## 2단계: Protobuf 정의 및 코드 생성
+
+- [x] `proto/todo/v1/todo.proto` 작성 (TodoService CRUD 5개 + HTTP 어노테이션)
+- [x] `buf generate` 실행하여 Go 코드 자동 생성
+- [x] `gen/` 디렉토리에 생성된 코드 확인 (todo.pb.go, todo_grpc.pb.go, todo.pb.gw.go)
+
+## 3단계: 서버 구현
+
+- [x] `server/service.go` 작성 - TodoServiceServer 구현 (인메모리 저장소)
+- [x] `server/run.go` 작성 - gRPC 서버 + TCP 리스너 (`:50051`)
+- [x] 에러 처리: `codes.NotFound`, `codes.InvalidArgument` 적용
+
+## 4단계: 클라이언트 구현
+
+- [x] `cmd/client/main.go` 작성 - CRUD 시나리오 실행
+
+## 5단계: 인터셉터
+
+- [x] `interceptor/logging.go` 작성 - 로깅 Unary 인터셉터
+- [x] 서버에 인터셉터 체인 적용 (`grpc.ChainUnaryInterceptor`)
+
+## 6단계: gRPC-Gateway
+
+- [x] `cmd/gateway/main.go` 작성 - REST 프록시 서버 (`:8080`)
+- [x] gRPC 서버 + Gateway 동시 실행 확인
+- [x] curl로 REST API 호출 테스트 (POST, GET, PUT, DELETE)
+
+## 7단계: 테스트
+
+- [x] `server_test.go` 작성 - bufconn 기반 통합 테스트
+- [x] CRUD 흐름 테스트 통과 확인
+- [x] 에러 케이스 테스트 (NotFound, InvalidArgument)
+- [x] `go test -v ./...` 전체 테스트 통과 (3/3 PASS)
+
+## 8단계: 블로그 글 작성
+
+- [x] `docs/start/6_12_go_grpc/index.md` 초안 작성
+- [x] Frontmatter 작성 (title, description, date, tags, series)
+- [x] 2.1 gRPC란? (REST vs gRPC 비교 표)
+- [x] 2.2 개발 환경 설정과 Protobuf 정의 (protoc, buf, 문법)
+- [x] 2.3 TodoList 서비스 구현 (Unary RPC, 인터셉터, 테스트)
+- [x] 2.4 gRPC 생태계 (Gateway, Connect-Go)
+- [x] GitHub 저장소 코드 링크 추가
+- [x] UTF-8 인코딩 확인 (`file -I`) → charset=utf-8 ✅
+
+## 9단계: 최종 검증
+
+- [x] 글 전체 읽기 흐름 확인
+- [x] 코드 블록 문법 하이라이팅 확인
+- [x] 샘플 코드 ↔ 블로그 내용 일치 확인 (인터셉터 로그 포맷 수정 완료)

--- a/docs/start/6_13_go_grpc_streaming_prd.md
+++ b/docs/start/6_13_go_grpc_streaming_prd.md
@@ -1,0 +1,122 @@
+# gRPC Streaming RPC 패턴 PRD
+
+> 시리즈: Golang 블로그 주제 Phase 5 - 신규 주제 (2/3)
+> 참조: `6_12_go_grpc_prd.md` (선행 글)
+
+---
+
+## 1. 개요
+
+gRPC의 3가지 Streaming RPC 패턴 (Server Streaming, Client Streaming, Bidirectional Streaming)을 실전 예제와 함께 다룬다. 선행 글(`6_12`)에서 구현한 TodoList Unary RPC를 기반으로, 별도 프로젝트(`todolist-streaming/`)에서 Streaming으로 확장한다.
+
+**대상 독자**: gRPC Unary RPC를 이해한 개발자 (6_12 글 읽은 독자)
+**난이도**: 중급~고급
+**예제 코드**: `tutorials-go/grpc/todolist-streaming/` (별도 프로젝트, TodoList 도메인 확장)
+
+---
+
+## 2. 블로그 구조
+
+### 2.1 Streaming RPC 개요
+- Unary vs Streaming 비교 다이어그램
+- 4가지 RPC 패턴 개요 (Unary, Server Streaming, Client Streaming, Bidirectional)
+- 각 패턴별 실전 활용 사례 정리
+
+### 2.2 3가지 Streaming 패턴 구현
+
+#### 2.2.1 Server Streaming
+- proto 정의: `rpc ListTodos(ListTodosRequest) returns (stream Todo)`
+- 서버 구현: `Send()` 메서드로 필터링된 Todo를 하나씩 전송
+- 클라이언트 구현: `Recv()` 루프로 스트림 수신, `io.EOF` 처리
+- 활용 사례: 대량 데이터 페이징, 실시간 피드, 로그 테일링
+
+#### 2.2.2 Client Streaming
+- proto 정의: `rpc BatchCreateTodos(stream CreateTodoRequest) returns (BatchCreateResponse)`
+- 클라이언트: `Send()`로 여러 Todo 전송 + `CloseAndRecv()`로 결과 수신
+- 서버: `Recv()` 루프로 수신 + `SendAndClose()`로 집계 결과 응답
+- 활용 사례: 파일 업로드, 배치 데이터 전송, 센서 데이터 수집
+
+#### 2.2.3 Bidirectional Streaming
+- proto 정의: `rpc TodoUpdates(stream TodoAction) returns (stream TodoEvent)`
+- 양방향 동시 스트림 처리: 클라이언트가 Todo 작업을 보내면 서버가 실시간 이벤트 응답
+- 활용 사례: 채팅, 실시간 협업, 주식 시세 구독
+
+### 2.3 Bidirectional Streaming 고루틴 패턴
+- **Send/Recv 고루틴 분리**: 양방향 스트림을 독립적으로 처리
+- **Directional Channel 활용**: `chan<-` / `<-chan`으로 send/recv 간 데이터 흐름 제어
+- **고루틴 종료 관리**: `errgroup` 또는 `sync.WaitGroup`으로 안전한 종료
+- **클라이언트 측 패턴**: send 고루틴 + recv 고루틴, 한쪽 종료 시 다른 쪽 정리
+- **서버 측 파이프라인 패턴**: recv 루프 → channel → 처리 → send 루프
+
+### 2.4 에러 처리, 취소, 인터셉터
+
+#### 2.4.1 에러 처리와 취소
+- `io.EOF` 처리 패턴 (정상 스트림 종료)
+- `context.WithTimeout()`으로 스트림 타임아웃
+- 클라이언트/서버 측 스트림 취소
+- graceful shutdown: 스트림 종료 시 리소스 정리
+
+#### 2.4.2 Stream 인터셉터
+- `StreamServerInterceptor` 구현
+- Unary Interceptor와의 차이점
+- 스트림 래퍼 패턴: `grpc.ServerStream` 인터페이스 래핑
+- 로깅, 메트릭 수집 인터셉터 예제
+
+### 2.5 성능 비교: Unary 반복 호출 vs Streaming
+- **벤치마크 시나리오**: 100/1000/10000개 Todo 항목 처리
+- **Unary 반복 호출**: 매 요청마다 HTTP/2 프레임 오버헤드
+- **Server Streaming**: 단일 연결에서 연속 전송, 헤더 오버헤드 최소화
+- **Client Streaming**: 배치 전송 vs 개별 CreateTodo 반복 호출
+- **비교 항목**: 총 소요시간, 네트워크 왕복 횟수, 메모리 사용량
+- **벤치마크 코드**: `benchmark_test.go`에 `testing.B` 활용
+- **결론**: 언제 Unary로 충분하고, 언제 Streaming이 필요한지 가이드라인
+
+---
+
+## 3. 샘플 코드 계획
+
+기존 `tutorials-go/grpc/todolist/`의 TodoList 도메인을 확장하되, **별도 프로젝트로 분리**하여 작성.
+기존 `tutorials-go/golang/third-party/grpc/route_guide/` 스트리밍 패턴 참고.
+
+```
+tutorials-go/grpc/todolist-streaming/
+├── proto/
+│   └── todo_streaming.proto       # 3가지 Streaming RPC 정의
+├── buf.yaml
+├── buf.gen.yaml
+├── gen/
+│   └── todopb/                    # 자동 생성 코드
+├── server/
+│   └── main.go                    # Streaming 서버 구현
+├── client/
+│   └── main.go                    # Streaming 클라이언트 (고루틴 패턴 포함)
+├── interceptor/
+│   └── stream_logging.go          # Stream 인터셉터
+├── server_test.go                 # bufconn 기반 Streaming 테스트
+├── benchmark_test.go              # Unary vs Streaming 성능 비교
+└── Makefile                       # buf generate, 서버/클라이언트 실행
+```
+
+### proto 정의 요약
+
+```protobuf
+service TodoStreaming {
+  // Server Streaming: 필터 조건으로 Todo 목록 스트림
+  rpc ListTodos(ListTodosRequest) returns (stream Todo);
+
+  // Client Streaming: 여러 Todo를 배치로 생성
+  rpc BatchCreateTodos(stream CreateTodoRequest) returns (BatchCreateResponse);
+
+  // Bidirectional Streaming: 실시간 Todo 작업 & 이벤트
+  rpc TodoUpdates(stream TodoAction) returns (stream TodoEvent);
+}
+```
+
+---
+
+## 4. 논의 사항 (리뷰 완료)
+
+- [x] 기존 TodoList 예제 확장 vs 별도 예제 → **별도 프로젝트** (`todolist-streaming/`)로 분리, TodoList 도메인 확장
+- [x] 3가지 Streaming을 모두 다룰지 → **3가지 모두** 상세히 다룸
+- [x] Bidirectional Streaming 고루틴 패턴 깊이 → **directional channel + errgroup 패턴** 포함
+- [x] 성능 비교 포함 여부 → **2.7절에 벤치마크 포함** (Unary 반복 vs Streaming)


### PR DESCRIPTION
## Summary
- Go gRPC 서비스 구현 블로그 글 초안 작성
- PRD 리뷰 반영: TodoList 예제, buf 도구, Gateway, Connect-Go, 목차 그룹핑
- Streaming gRPC 별도 PRD 신규 생성 (6_13)
- 구현 계획서 및 TODO 체크리스트

## 블로그 글 구조
1. gRPC란? (REST vs gRPC 비교)
2. 개발 환경 설정과 Protobuf 정의 (protoc, buf, 문법)
3. TodoList 서비스 구현 (Unary RPC, 인터셉터, 테스트)
4. gRPC 생태계 (Gateway, Connect-Go)

## Test plan
- [x] 샘플 코드 전체 테스트 PASS (tutorials-go)
- [x] UTF-8 인코딩 확인
- [x] 블로그 ↔ 샘플 코드 일치 검증

## 참조
- 샘플 코드 PR: kenshin579/tutorials-go#671
- PRD: `docs/start/6_12_go_grpc_prd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)