### PR TITLE
[#421] fix-future-date → fix-post-date 트리거 워크플로우 변경

### DIFF
--- a/.github/workflows/fix-post-date.yml
+++ b/.github/workflows/fix-post-date.yml
@@ -1,4 +1,4 @@
-name: Fix Future Date
+name: Fix Post Date
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fix-date:
     if: github.event.pull_request.merged == true
-    uses: kenshin579/actions/.github/workflows/fix-future-date.yml@main
+    uses: kenshin579/actions/.github/workflows/fix-post-date.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}
       content_dir: contents


### PR DESCRIPTION
## Summary
- 파일명/워크플로우명 변경: `fix-future-date` → `fix-post-date`
- 재사용 워크플로우 참조 경로 변경

## 의존성
- ⚠️ kenshin579/actions#35 가 먼저 merge되어야 함 (재사용 워크플로우)

## Test plan
- [ ] actions 리포 PR merge 후 이 PR merge
- [ ] GitHub Actions 탭에서 워크플로우 이름 `Fix Post Date` 확인

closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)