### PR TITLE
docs: Go + xterm.js 웹 기반 SSH 터미널 블로그 초안

### DIFF
--- a/docs/done/12_ssh_implementation.md
+++ b/docs/done/12_ssh_implementation.md
@@ -1,0 +1,318 @@
+# 웹 기반 SSH 로봇 관리 시스템 - 구현 문서
+
+## 1. 산출물
+
+| 산출물 | 위치 | 설명 |
+|--------|------|------|
+| Go 백엔드 | `tutorials-go/web-ssh-terminal/backend/` | Echo v4 + WebSocket + SSH 브릿지 |
+| React 프론트엔드 | `tutorials-go/web-ssh-terminal/frontend/` | Vite + xterm.js + React Router |
+| Docker Compose | `tutorials-go/web-ssh-terminal/docker-compose.yaml` | 테스트용 SSH 서버 |
+| 블로그 글 (Draft) | `docs/start/go-web-ssh-터미널-로봇-관리/index.md` | 한국어, 1편 통합 |
+
+## 2. Go 백엔드 구현
+
+### 2.1 프로젝트 구조
+
+```
+backend/
+├── go.mod
+├── go.sum
+├── main.go                         # Echo 서버 + 라우트 등록
+├── config.yaml                     # 로봇 목록 설정
+├── .env                            # SSH 비밀번호 (gitignore)
+└── internal/
+    ├── config/
+    │   └── config.go               # YAML 설정 로더
+    ├── handler/
+    │   ├── robot.go                # GET /api/robots
+    │   └── terminal.go             # GET /ws/terminal (WebSocket + SSH)
+    └── model/
+        └── robot.go                # Robot 구조체
+```
+
+### 2.2 의존성
+
+```
+module web-ssh-terminal
+
+go 1.25
+
+require (
+    github.com/gorilla/websocket v1.5.3
+    github.com/labstack/echo/v4 v4.13.3
+    golang.org/x/crypto v0.32.0
+    gopkg.in/yaml.v3 v3.0.1
+)
+```
+
+### 2.3 API 엔드포인트
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/robots` | 로봇 목록 + 온라인 상태 (TCP 포트 체크) |
+| GET | `/ws/terminal?robotId=xxx` | WebSocket → SSH 브릿지 |
+| GET | `/` (Static) | React 빌드 정적 파일 서빙 (프로덕션) |
+
+### 2.4 핵심 로직: WebSocket + SSH 브릿지 (`handler/terminal.go`)
+
+처리 흐름:
+
+```mermaid
+flowchart TD
+    A["WebSocket 연결 수신"] --> B["robotId로 설정 조회"]
+    B --> C["SSH ClientConfig 생성 (비밀번호/키)"]
+    C --> D["ssh.Dial로 로봇 연결"]
+    D --> E["session.RequestPty (xterm-256color)"]
+    E --> F["session.Shell 시작"]
+    F --> G["goroutine 2개 시작"]
+    G --> H["SSH stdout → ws.WriteMessage"]
+    G --> I["ws.ReadMessage → SSH stdin"]
+    I --> J{"JSON 파싱 시도"}
+    J -->|resize 메시지| K["session.WindowChange"]
+    J -->|일반 입력| L["sshIn.Write"]
+    H --> M["done 채널 대기 → 종료"]
+```
+
+구현 핵심:
+- `gorilla/websocket.Upgrader`로 HTTP → WebSocket 업그레이드
+- `ssh.Dial("tcp", addr, config)`로 SSH 연결
+- `session.RequestPty("xterm-256color", rows, cols, modes)` → `session.Shell()`
+- 2개 goroutine으로 양방향 파이프: SSH stdout → WebSocket, WebSocket → SSH stdin
+- 리사이즈: JSON `{"type":"resize","cols":N,"rows":N}` 메시지 감지 → `session.WindowChange()`
+- `done` 채널로 SSH 세션 종료 대기
+
+### 2.5 SSH 인증 방식
+
+| 방식 | 설정 | 구현 |
+|------|------|------|
+| 비밀번호 | config.yaml: `authType: password` | 환경변수 `ROBOT_{ID}_PASSWORD`에서 로드 → `ssh.Password()` |
+| 공개키 | config.yaml: `authType: privateKey` | `ssh.privateKeyPath`에서 PEM 읽기 → `ssh.ParsePrivateKey()` → `ssh.PublicKeys()` |
+
+### 2.6 로봇 상태 체크 (`handler/robot.go`)
+
+- `net.DialTimeout("tcp", addr, 2s)`로 SSH 포트(22) 접속 가능 여부 확인
+- 응답 시 `isOnline` 필드에 결과 포함
+
+### 2.7 CORS 설정
+
+- 개발: `AllowOrigins: ["http://localhost:5173"]` (Vite dev server)
+- 프로덕션: React 빌드를 Go 서버가 직접 서빙하므로 CORS 불필요
+
+## 3. React 프론트엔드 구현
+
+### 3.1 프로젝트 구조
+
+```
+frontend/
+├── package.json
+├── vite.config.ts
+├── index.html
+├── tsconfig.json
+└── src/
+    ├── main.tsx
+    ├── App.tsx                     # React Router (/, /terminal/:robotId)
+    ├── api/
+    │   └── robots.ts               # fetch /api/robots
+    ├── components/
+    │   ├── RobotCard.tsx           # 로봇 카드 (상태 뱃지, Connect 버튼)
+    │   ├── RobotList.tsx           # 로봇 목록 그리드
+    │   ├── Terminal.tsx            # xterm.js 래퍼
+    │   └── StatusBadge.tsx         # Online/Offline 뱃지
+    └── pages/
+        ├── HomePage.tsx            # GET /api/robots → 카드 목록
+        └── TerminalPage.tsx        # useParams(robotId) → Terminal 컴포넌트
+```
+
+### 3.2 의존성
+
+```json
+{
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0",
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^6.0.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+### 3.3 라우팅
+
+| Path | 컴포넌트 | 설명 |
+|------|---------|------|
+| `/` | `HomePage` | 로봇 카드 목록, 온라인 상태 표시 |
+| `/terminal/:robotId` | `TerminalPage` | xterm.js 터미널 + 헤더 바 + 상태 바 |
+
+### 3.4 핵심 로직: Terminal 컴포넌트
+
+처리 흐름:
+1. 마운트 시 `new XTerm()` 생성 + `FitAddon` 로드
+2. WebSocket 연결: `ws://localhost:8080/ws/terminal?robotId=xxx`
+3. `ws.onmessage` → JSON 상태 메시지이면 상태 표시, 아니면 `term.write(data)`
+4. `term.onData(data)` → `ws.send(data)` (키 입력 전송)
+5. `window.resize` 이벤트 → `fitAddon.fit()` + resize JSON 메시지 전송
+6. 언마운트 시 WebSocket close + xterm dispose
+
+### 3.5 Vite 프록시 설정
+
+개발 환경에서 Go 백엔드로 API/WebSocket 프록시:
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+      '/ws': {
+        target: 'http://localhost:8080',
+        ws: true,
+      },
+    },
+  },
+});
+```
+
+> Vite 프록시 사용 시 Terminal 컴포넌트에서 별도 호스트 분기 불필요.
+
+## 4. 테스트 환경
+
+### 4.1 Docker Compose
+
+```yaml
+# docker-compose.yaml
+services:
+  robot-1:
+    image: lscr.io/linuxserver/openssh-server:latest
+    ports:
+      - "2222:22"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=testpass
+      - USER_NAME=ubuntu
+
+  robot-2:
+    image: lscr.io/linuxserver/openssh-server:latest
+    ports:
+      - "2223:22"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=testpass
+      - USER_NAME=ubuntu
+```
+
+### 4.2 테스트용 config.yaml
+
+```yaml
+server:
+  port: 8080
+
+ssh:
+  privateKeyPath: ~/.ssh/id_rsa
+
+robots:
+  - id: robot-1
+    name: Test Robot A
+    host: localhost
+    port: 2222
+    username: ubuntu
+    authType: password
+    description: 테스트 로봇 A
+
+  - id: robot-2
+    name: Test Robot B
+    host: localhost
+    port: 2223
+    username: ubuntu
+    authType: password
+    description: 테스트 로봇 B
+```
+
+### 4.3 테스트용 .env
+
+```
+ROBOT_ROBOT-1_PASSWORD=testpass
+ROBOT_ROBOT-2_PASSWORD=testpass
+```
+
+## 5. 실행 순서
+
+```bash
+# 1. 테스트 SSH 서버 실행
+cd web-ssh-terminal
+docker compose up -d
+
+# 2. Go 백엔드 실행
+cd backend
+go run main.go
+
+# 3. React 프론트엔드 실행 (별도 터미널)
+cd frontend
+npm install
+npm run dev
+
+# 4. 브라우저에서 확인
+# http://localhost:5173
+```
+
+## 6. 블로그 글 구성
+
+### 6.1 위치 및 구조
+
+```
+docs/start/go-web-ssh-터미널-로봇-관리/
+├── index.md          # 블로그 본문
+└── cover.png         # 커버 이미지
+```
+
+### 6.2 frontmatter
+
+```yaml
+---
+title: "Go + xterm.js로 웹 기반 SSH 터미널 만들기"
+description: "Go 백엔드(Echo + x/crypto/ssh)와 React 프론트엔드(xterm.js)로 브라우저에서 SSH 접속하는 로봇 관리 시스템 구축하기"
+date: 2026-04-XX
+update: 2026-04-XX
+tags:
+  - Go
+  - SSH
+  - WebSocket
+  - xterm.js
+  - React
+  - Echo
+---
+```
+
+### 6.3 목차
+
+```
+1. 소개 — 왜 웹 기반 SSH 터미널인가?
+2. 아키텍처 — Browser ↔ WebSocket ↔ SSH ↔ Robot
+3. 프로젝트 셋업 — Go 백엔드 + React 프론트엔드
+4. Go 백엔드 구현 — WebSocket + SSH 브릿지, 로봇 API
+5. React 프론트엔드 구현 — xterm.js 터미널, 로봇 목록
+6. 실행 및 데모 — Docker Compose + 접속 테스트
+7. 개선 아이디어
+8. 정리 + 참고 자료
+```
+
+## 7. 작성 규칙
+
+- 샘플 코드는 `tutorials-go/web-ssh-terminal/`에 작성
+- 블로그 글에서 GitHub 코드 참조/링크
+- 코드를 먼저 작성하고, 동작 확인 후 블로그 글 작성
+- 다이어그램은 Mermaid 형식 (ASCII art 금지)
+- UTF-8 인코딩 확인 필수 (`file -I`)
+- Draft는 `docs/start/`에 작성, `contents/`에 직접 넣지 않음
+- 테스트는 MCP Playwright로 웹 UI 동작 검증

--- a/docs/done/12_ssh_prd.md
+++ b/docs/done/12_ssh_prd.md
@@ -1,0 +1,963 @@
+# 웹 기반 SSH 로봇 관리 시스템 PRD — 샘플 코드 및 블로그 작성
+
+## 1. 배경
+
+로봇(Ubuntu 기반)을 원격으로 관리할 때 보통 터미널에서 직접 `ssh user@robot-ip`로 접속한다. 로봇이 1~2대면 문제없지만, 여러 대의 로봇을 관리해야 하는 환경에서는 다음과 같은 불편함이 있다:
+
+- 매번 IP와 인증 정보를 기억하거나 찾아야 함
+- 여러 터미널 창을 열어 각 로봇에 접속해야 함
+- 로봇의 상태(온라인/오프라인)를 한눈에 파악하기 어려움
+- 비개발자(운영자)가 터미널에 직접 접근하기 부담스러움
+
+**목표**: 웹 브라우저에서 등록된 로봇 목록을 보고, 클릭 한 번으로 SSH 터미널을 열어 명령어를 실행하고 결과를 확인할 수 있는 시스템을 구축한다. 이를 실습하고 블로그 포스트로 정리한다.
+
+---
+
+## 2. 시스템 아키텍처
+
+### 2.1 전체 흐름
+
+```
+┌─────────────┐     WebSocket      ┌─────────────────┐      SSH       ┌───────────┐
+│   Browser   │ ◄──────────────► │  Backend Server  │ ◄───────────► │  Robot    │
+│  (xterm.js) │                    │  (Go + Echo)     │               │  (Ubuntu) │
+└─────────────┘                    └─────────────────┘               └───────────┘
+       │                                   │
+       │  HTTP REST                        │  Config (robot 목록/인증정보)
+       │ (로봇 목록 CRUD)                    │
+       └───────────────────────────────────┘
+```
+
+### 2.2 핵심 컴포넌트
+
+| 컴포넌트 | 역할 | 기술 |
+|---------|------|------|
+| **Web Terminal** | 브라우저에서 터미널 UI 렌더링 | xterm.js + xterm-addon-fit |
+| **WebSocket 서버** | 브라우저 ↔ 서버 간 실시간 데이터 전송 | gorilla/websocket (Go) |
+| **SSH 클라이언트** | 서버 → 로봇 SSH 연결 | golang.org/x/crypto/ssh |
+| **로봇 관리 API** | 로봇 목록 CRUD, 상태 확인 | Echo v4 (Go) |
+| **프론트엔드** | 로봇 목록 UI, 터미널 탭 관리 | React 19 + Vite + Tailwind CSS |
+
+### 2.3 데이터 흐름 (터미널 세션)
+
+```mermaid
+sequenceDiagram
+    participant B as Browser (xterm.js)
+    participant W as WebSocket Server
+    participant S as SSH Client (x/crypto/ssh)
+    participant R as Robot (Ubuntu)
+
+    B->>W: WebSocket 연결 요청 (robotId)
+    W->>S: SSH 연결 생성 (host, port, username, key)
+    S->>R: SSH handshake
+    R-->>S: Shell stream 반환
+    S-->>W: SSH 연결 성공
+    W-->>B: WebSocket 연결 확인
+
+    loop 터미널 입출력
+        B->>W: 키 입력 (stdin)
+        W->>S: SSH stream.write()
+        S->>R: 명령 전달
+        R-->>S: 출력 (stdout/stderr)
+        S-->>W: stream data 이벤트
+        W-->>B: 터미널 출력 전송
+    end
+
+    B->>W: 연결 종료
+    W->>S: SSH stream.close()
+    S->>R: SSH 세션 종료
+```
+
+---
+
+## 3. 핵심 기술 스택
+
+### 3.1 xterm.js — 브라우저 터미널 에뮬레이터
+
+| 항목 | 내용 |
+|------|------|
+| 저장소 | [xtermjs/xterm.js](https://github.com/xtermjs/xterm.js) |
+| 라이선스 | MIT |
+| 용도 | 브라우저에서 완전한 터미널 에뮬레이션 제공 |
+| 주요 기능 | ANSI 이스케이프 코드 해석, 컬러 출력, 복사/붙여넣기, 리사이즈 |
+| 핵심 Addon | `xterm-addon-fit` (컨테이너 크기 자동 맞춤), `xterm-addon-web-links` (URL 클릭) |
+
+**왜 xterm.js인가?**
+- VS Code 내장 터미널, GitHub Codespaces, Jupyter 등에서 사용하는 사실상 표준
+- 성능이 뛰어남 (Canvas/WebGL 렌더링)
+- 다양한 addon 생태계
+
+### 3.2 golang.org/x/crypto/ssh — Go SSH 클라이언트
+
+| 항목 | 내용 |
+|------|------|
+| 패키지 | [golang.org/x/crypto/ssh](https://pkg.go.dev/golang.org/x/crypto/ssh) |
+| 용도 | Go 표준 확장 라이브러리의 SSH 프로토콜 구현 |
+| 인증 방식 | 비밀번호, 공개키(PEM), SSH Agent |
+| 핵심 메서드 | `session.RequestPty()` + `session.Shell()` — interactive shell 세션 생성 |
+| 특징 | Go 표준 라이브러리 확장으로 안정성 보장, 순수 Go 구현 |
+
+### 3.3 gorilla/websocket — Go WebSocket 라이브러리
+
+| 항목 | 내용 |
+|------|------|
+| 패키지 | [github.com/gorilla/websocket](https://github.com/gorilla/websocket) |
+| 용도 | 브라우저 ↔ Go 서버 간 양방향 실시간 통신 |
+| 선택 이유 | 터미널 입출력은 지속적인 양방향 스트림이므로 HTTP polling으로는 부적합 |
+| 특징 | Go 생태계에서 가장 널리 쓰이는 WebSocket 구현, Echo v4와 자연스럽게 통합 |
+
+### 3.4 Echo v4 — Go 웹 프레임워크
+
+| 항목 | 내용 |
+|------|------|
+| 패키지 | [github.com/labstack/echo/v4](https://echo.labstack.com/) |
+| 용도 | REST API 서빙 + 정적 파일(React 빌드) 서빙 + WebSocket 엔드포인트 |
+| 선택 이유 | 경량, 고성능, 미들웨어 생태계 풍부, WebSocket 핸들러 내장 지원 |
+
+---
+
+## 4. 구현 범위
+
+### 4.1 MVP (블로그 + 샘플 코드)
+
+| 기능 | 설명 | 우선순위 |
+|------|------|---------|
+| 로봇 목록 표시 | 등록된 로봇을 카드/리스트로 표시 | P0 |
+| 온라인 상태 표시 | SSH 포트(22) ping으로 접속 가능 여부 표시 | P0 |
+| 웹 터미널 열기 | 로봇 클릭 → xterm.js 터미널 팝업/탭 | P0 |
+| SSH 연결/해제 | WebSocket → x/crypto/ssh로 셸 세션 관리 | P0 |
+| 터미널 리사이즈 | 브라우저 창 크기 변경 시 터미널 자동 조절 | P1 |
+| 다중 터미널 탭 | 여러 로봇에 동시 접속, 탭으로 전환 | P1 |
+| 비밀번호/키 인증 | 비밀번호 또는 SSH 키 파일로 인증 | P0 |
+
+### 4.2 범위 제외 (블로그에서는 다루지 않음)
+
+- 로봇 등록/수정/삭제 UI (하드코딩된 목록 사용)
+- 사용자 인증/권한 관리 (로그인 시스템)
+- SSH 키 관리 UI
+- 파일 전송 (SCP/SFTP)
+- 세션 녹화/재생
+
+---
+
+## 5. UI 구성
+
+### 5.1 전체 화면 구성
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  🤖 Robot Manager                               [Dark Mode] │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  페이지 1: 로봇 목록 (/)                                       │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │  🔍 Search robots...                                    │ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
+│  │ 🟢 Online    │  │ 🟢 Online    │  │ 🔴 Offline   │       │
+│  │              │  │              │  │              │       │
+│  │ Assembly     │  │ Inspection   │  │ Delivery     │       │
+│  │ Robot A      │  │ Robot B      │  │ Robot C      │       │
+│  │              │  │              │  │              │       │
+│  │ 192.168.1.101│  │ 192.168.1.102│  │ 192.168.1.103│       │
+│  │ 조립 라인 1번  │  │ 품질 검사     │  │ 배송 로봇 3호기│       │
+│  │              │  │              │  │              │       │
+│  │ [Connect]    │  │ [Connect]    │  │ [Disabled]   │       │
+│  └──────────────┘  └──────────────┘  └──────────────┘       │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 터미널 페이지
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  🤖 Robot Manager    ← Back to List                         │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  페이지 2: 터미널 (/terminal/:robotId)                         │
+│                                                              │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │ 🟢 Assembly Robot A (192.168.1.101)     [Disconnect]    │ │
+│  ├─────────────────────────────────────────────────────────┤ │
+│  │                                                         │ │
+│  │  ubuntu@robot-1:~$ ls -la                               │ │
+│  │  total 32                                               │ │
+│  │  drwxr-xr-x  5 ubuntu ubuntu 4096 Apr 11 09:00 .       │ │
+│  │  drwxr-xr-x  3 root   root   4096 Apr 10 15:30 ..      │ │
+│  │  -rw-r--r--  1 ubuntu ubuntu  220 Apr 10 15:30 .bash..  │ │
+│  │  drwxr-xr-x  2 ubuntu ubuntu 4096 Apr 11 09:00 logs    │ │
+│  │  -rwxr-xr-x  1 ubuntu ubuntu 8192 Apr 10 16:00 robot.. │ │
+│  │  ubuntu@robot-1:~$ █                                    │ │
+│  │                                                         │ │
+│  │                                                         │ │
+│  │                                                         │ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │ ℹ️  SSH: ubuntu@192.168.1.101:22 | Session: 00:05:23    │ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 5.3 UI 컴포넌트 상세
+
+#### 로봇 카드 (RobotCard)
+
+| 요소 | 설명 |
+|------|------|
+| 상태 뱃지 | 🟢 Online (초록) / 🔴 Offline (빨강) — TCP 포트 체크 결과 |
+| 로봇 이름 | 카드 제목, 굵은 글씨 |
+| IP 주소 | 모노스페이스 폰트, 회색 |
+| 설명 | 로봇 용도 한 줄 설명 |
+| Connect 버튼 | Online → 클릭 가능 (파랑), Offline → 비활성화 (회색) |
+| 호버 효과 | 카드 그림자 확대, 경계선 색상 변경 |
+
+#### 터미널 영역 (Terminal)
+
+| 요소 | 설명 |
+|------|------|
+| 헤더 바 | 로봇 이름 + IP + 연결 상태 + Disconnect 버튼 |
+| 터미널 본체 | xterm.js 렌더링 영역, 어두운 배경 (Catppuccin Mocha 테마) |
+| 상태 바 | SSH 접속 정보 + 세션 경과 시간 표시 |
+| 리사이즈 | 브라우저 창 크기에 맞춰 터미널 자동 조절 (FitAddon) |
+
+#### 화면 전환 흐름
+
+```mermaid
+flowchart LR
+    A["/ (로봇 목록)"] -->|카드 클릭| B["/terminal/:robotId"]
+    B -->|← Back 클릭| A
+    B -->|Disconnect 클릭| A
+    B -->|SSH 연결 끊김| C["재연결 안내 표시"]
+    C -->|Reconnect 클릭| B
+```
+
+---
+
+## 6. 샘플 코드 구조
+
+### 6.1 프로젝트 구조
+
+```
+web-ssh-terminal/
+├── backend/                        # Go 백엔드
+│   ├── go.mod
+│   ├── go.sum
+│   ├── main.go                     # 엔트리포인트
+│   ├── config.yaml                 # 로봇 설정 파일
+│   ├── .env                        # SSH 비밀번호 등 (gitignore)
+│   └── internal/
+│       ├── config/
+│       │   └── config.go           # 설정 로드 (YAML + 환경변수)
+│       ├── handler/
+│       │   ├── robot.go            # GET /api/robots — 로봇 목록 API
+│       │   └── terminal.go         # GET /ws/terminal — WebSocket + SSH 브릿지
+│       └── model/
+│           └── robot.go            # Robot 구조체
+├── frontend/                       # React 프론트엔드
+│   ├── package.json
+│   ├── vite.config.ts
+│   ├── index.html
+│   └── src/
+│       ├── main.tsx
+│       ├── App.tsx                 # React Router 라우팅
+│       ├── api/
+│       │   └── robots.ts           # API 호출 유틸리티
+│       ├── components/
+│       │   ├── RobotCard.tsx       # 로봇 카드 컴포넌트
+│       │   ├── RobotList.tsx       # 로봇 목록 컴포넌트
+│       │   ├── Terminal.tsx        # xterm.js 래퍼 컴포넌트
+│       │   └── StatusBadge.tsx     # 온라인/오프라인 뱃지
+│       └── pages/
+│           ├── HomePage.tsx        # 로봇 목록 페이지
+│           └── TerminalPage.tsx    # 터미널 페이지
+├── docker-compose.yaml             # 테스트용 SSH 서버 컨테이너
+└── README.md
+```
+
+### 6.2 핵심 코드 미리보기
+
+#### (1) 로봇 모델 정의 — `backend/internal/model/robot.go`
+
+```go
+package model
+
+type AuthType string
+
+const (
+	AuthPassword   AuthType = "password"
+	AuthPrivateKey AuthType = "privateKey"
+)
+
+type Robot struct {
+	ID          string   `json:"id" yaml:"id"`
+	Name        string   `json:"name" yaml:"name"`
+	Host        string   `json:"host" yaml:"host"`
+	Port        int      `json:"port" yaml:"port"`
+	Username    string   `json:"username" yaml:"username"`
+	AuthType    AuthType `json:"authType" yaml:"authType"`
+	Description string   `json:"description,omitempty" yaml:"description"`
+	IsOnline    bool     `json:"isOnline" yaml:"-"`
+}
+```
+
+#### (2) 설정 로드 — `backend/internal/config/config.go`
+
+```go
+package config
+
+import (
+	"os"
+
+	"web-ssh-terminal/internal/model"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Server ServerConfig  `yaml:"server"`
+	SSH    SSHConfig     `yaml:"ssh"`
+	Robots []model.Robot `yaml:"robots"`
+}
+
+type ServerConfig struct {
+	Port int `yaml:"port"`
+}
+
+type SSHConfig struct {
+	PrivateKeyPath string `yaml:"privateKeyPath"`
+}
+
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	if cfg.Server.Port == 0 {
+		cfg.Server.Port = 8080
+	}
+
+	return &cfg, nil
+}
+```
+
+#### (3) config.yaml — 로봇 목록 설정
+
+```yaml
+server:
+  port: 8080
+
+ssh:
+  privateKeyPath: ~/.ssh/id_rsa
+
+robots:
+  - id: robot-1
+    name: Assembly Robot A
+    host: 192.168.1.101
+    port: 22
+    username: ubuntu
+    authType: privateKey
+    description: 조립 라인 1번 로봇
+
+  - id: robot-2
+    name: Inspection Robot B
+    host: 192.168.1.102
+    port: 22
+    username: ubuntu
+    authType: password
+    description: 품질 검사 로봇
+
+  - id: robot-3
+    name: Delivery Robot C
+    host: 192.168.1.103
+    port: 22
+    username: ubuntu
+    authType: privateKey
+    description: 배송 로봇 3호기
+```
+
+#### (4) WebSocket + SSH 브릿지 핸들러 — `backend/internal/handler/terminal.go`
+
+```go
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"web-ssh-terminal/internal/config"
+	"web-ssh-terminal/internal/model"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"golang.org/x/crypto/ssh"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true }, // 개발용: 모든 origin 허용
+}
+
+type resizeMessage struct {
+	Type string `json:"type"`
+	Cols int    `json:"cols"`
+	Rows int    `json:"rows"`
+}
+
+type TerminalHandler struct {
+	cfg *config.Config
+}
+
+func NewTerminalHandler(cfg *config.Config) *TerminalHandler {
+	return &TerminalHandler{cfg: cfg}
+}
+
+// HandleTerminal — GET /ws/terminal?robotId=xxx
+func (h *TerminalHandler) HandleTerminal(c echo.Context) error {
+	robotID := c.QueryParam("robotId")
+
+	// 로봇 찾기
+	var robot *model.Robot
+	for i := range h.cfg.Robots {
+		if h.cfg.Robots[i].ID == robotID {
+			robot = &h.cfg.Robots[i]
+			break
+		}
+	}
+	if robot == nil {
+		return echo.NewHTTPError(404, "robot not found")
+	}
+
+	// WebSocket 업그레이드
+	ws, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
+	if err != nil {
+		return err
+	}
+	defer ws.Close()
+
+	// SSH 클라이언트 설정
+	sshConfig, err := h.buildSSHConfig(robot)
+	if err != nil {
+		ws.WriteJSON(map[string]string{"type": "error", "message": err.Error()})
+		return nil
+	}
+
+	// SSH 연결
+	addr := fmt.Sprintf("%s:%d", robot.Host, robot.Port)
+	conn, err := ssh.Dial("tcp", addr, sshConfig)
+	if err != nil {
+		ws.WriteJSON(map[string]string{"type": "error", "message": "SSH connection failed: " + err.Error()})
+		return nil
+	}
+	defer conn.Close()
+
+	// SSH 세션 생성
+	session, err := conn.NewSession()
+	if err != nil {
+		ws.WriteJSON(map[string]string{"type": "error", "message": "SSH session failed: " + err.Error()})
+		return nil
+	}
+	defer session.Close()
+
+	// PTY 요청
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          1,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}
+	if err := session.RequestPty("xterm-256color", 24, 80, modes); err != nil {
+		ws.WriteJSON(map[string]string{"type": "error", "message": "PTY request failed: " + err.Error()})
+		return nil
+	}
+
+	// stdin/stdout 파이프
+	sshIn, err := session.StdinPipe()
+	if err != nil {
+		return err
+	}
+	sshOut, err := session.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	// Shell 시작
+	if err := session.Shell(); err != nil {
+		ws.WriteJSON(map[string]string{"type": "error", "message": "Shell start failed: " + err.Error()})
+		return nil
+	}
+
+	ws.WriteJSON(map[string]string{"type": "status", "message": "connected"})
+
+	// SSH stdout → WebSocket (Browser)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := sshOut.Read(buf)
+			if err != nil {
+				return
+			}
+			if err := ws.WriteMessage(websocket.TextMessage, buf[:n]); err != nil {
+				return
+			}
+		}
+	}()
+
+	// WebSocket (Browser) → SSH stdin
+	go func() {
+		for {
+			_, msg, err := ws.ReadMessage()
+			if err != nil {
+				session.Close()
+				return
+			}
+
+			// 리사이즈 메시지 처리
+			var resize resizeMessage
+			if json.Unmarshal(msg, &resize) == nil && resize.Type == "resize" {
+				session.WindowChange(resize.Rows, resize.Cols)
+				continue
+			}
+
+			sshIn.Write(msg)
+		}
+	}()
+
+	// SSH 세션 종료 대기
+	<-done
+	return nil
+}
+
+func (h *TerminalHandler) buildSSHConfig(robot *model.Robot) (*ssh.ClientConfig, error) {
+	config := &ssh.ClientConfig{
+		User:            robot.Username,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // 개발용: 프로덕션에서는 known_hosts 검증 필요
+		Timeout:         10 * time.Second,
+	}
+
+	switch robot.AuthType {
+	case model.AuthPassword:
+		// 환경변수에서 비밀번호 로드: ROBOT_ROBOT_1_PASSWORD 형태
+		envKey := fmt.Sprintf("ROBOT_%s_PASSWORD", robot.ID)
+		password := os.Getenv(envKey)
+		config.Auth = []ssh.AuthMethod{ssh.Password(password)}
+
+	case model.AuthPrivateKey:
+		keyPath := h.cfg.SSH.PrivateKeyPath
+		key, err := os.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read private key: %w", err)
+		}
+		signer, err := ssh.ParsePrivateKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse private key: %w", err)
+		}
+		config.Auth = []ssh.AuthMethod{ssh.PublicKeys(signer)}
+	}
+
+	return config, nil
+}
+```
+
+#### (5) 로봇 목록 API 핸들러 — `backend/internal/handler/robot.go`
+
+```go
+package handler
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"web-ssh-terminal/internal/config"
+	"web-ssh-terminal/internal/model"
+
+	"github.com/labstack/echo/v4"
+)
+
+type RobotHandler struct {
+	cfg *config.Config
+}
+
+func NewRobotHandler(cfg *config.Config) *RobotHandler {
+	return &RobotHandler{cfg: cfg}
+}
+
+// ListRobots — GET /api/robots
+func (h *RobotHandler) ListRobots(c echo.Context) error {
+	robots := make([]model.Robot, len(h.cfg.Robots))
+	copy(robots, h.cfg.Robots)
+
+	for i := range robots {
+		robots[i].IsOnline = checkSSHPort(robots[i].Host, robots[i].Port)
+	}
+
+	return c.JSON(http.StatusOK, robots)
+}
+
+func checkSSHPort(host string, port int) bool {
+	addr := fmt.Sprintf("%s:%d", host, port)
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+```
+
+#### (6) 메인 엔트리포인트 — `backend/main.go`
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"web-ssh-terminal/internal/config"
+	"web-ssh-terminal/internal/handler"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func main() {
+	cfg, err := config.Load("config.yaml")
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	e := echo.New()
+
+	// 미들웨어
+	e.Use(middleware.Logger())
+	e.Use(middleware.Recover())
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"http://localhost:5173"}, // Vite dev server
+	}))
+
+	// 핸들러
+	robotHandler := handler.NewRobotHandler(cfg)
+	terminalHandler := handler.NewTerminalHandler(cfg)
+
+	// API 라우트
+	e.GET("/api/robots", robotHandler.ListRobots)
+	e.GET("/ws/terminal", terminalHandler.HandleTerminal)
+
+	// 프로덕션: React 빌드 결과 정적 파일 서빙
+	e.Static("/", "../frontend/dist")
+
+	addr := fmt.Sprintf(":%d", cfg.Server.Port)
+	log.Printf("Server starting on %s", addr)
+	e.Logger.Fatal(e.Start(addr))
+}
+```
+
+#### (7) xterm.js 터미널 컴포넌트 — `frontend/src/components/Terminal.tsx`
+
+```tsx
+import { useEffect, useRef, useCallback } from 'react';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+
+interface TerminalProps {
+  robotId: string;
+  onDisconnect?: () => void;
+}
+
+export default function Terminal({ robotId, onDisconnect }: TerminalProps) {
+  const terminalRef = useRef<HTMLDivElement>(null);
+
+  const connect = useCallback(() => {
+    if (!terminalRef.current) return;
+
+    const term = new XTerm({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      theme: {
+        background: '#1e1e2e',
+        foreground: '#cdd6f4',
+        cursor: '#f5e0dc',
+      },
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(terminalRef.current);
+    fitAddon.fit();
+
+    term.writeln('Connecting to robot...');
+
+    // Go 백엔드 WebSocket 연결
+    const wsHost = import.meta.env.DEV ? 'localhost:8080' : window.location.host;
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${protocol}//${wsHost}/ws/terminal?robotId=${robotId}`);
+
+    ws.onopen = () => {
+      term.writeln('WebSocket connected. Waiting for SSH...');
+    };
+
+    ws.onmessage = (event) => {
+      const data = event.data;
+      try {
+        const parsed = JSON.parse(data);
+        if (parsed.type === 'status') {
+          term.writeln(`SSH ${parsed.message}\r\n`);
+          return;
+        }
+        if (parsed.type === 'error') {
+          term.writeln(`Error: ${parsed.message}`);
+          return;
+        }
+      } catch {
+        // JSON이 아니면 터미널 출력
+      }
+      term.write(data);
+    };
+
+    ws.onclose = () => {
+      term.writeln('\r\n\r\nConnection closed.');
+      onDisconnect?.();
+    };
+
+    // 키 입력 → WebSocket 전송
+    term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(data);
+      }
+    });
+
+    // 리사이즈 처리
+    const handleResize = () => {
+      fitAddon.fit();
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+      }
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      ws.close();
+      term.dispose();
+    };
+  }, [robotId, onDisconnect]);
+
+  useEffect(() => {
+    const cleanup = connect();
+    return cleanup;
+  }, [connect]);
+
+  return (
+    <div ref={terminalRef} className="w-full h-full min-h-[400px] bg-[#1e1e2e] rounded-lg p-1" />
+  );
+}
+```
+
+#### (8) 로봇 카드 컴포넌트 — `frontend/src/components/RobotCard.tsx`
+
+```tsx
+import { Link } from 'react-router-dom';
+
+interface RobotCardProps {
+  id: string;
+  name: string;
+  host: string;
+  description?: string;
+  isOnline: boolean;
+}
+
+export default function RobotCard({ id, name, host, description, isOnline }: RobotCardProps) {
+  return (
+    <Link to={`/terminal/${id}`}>
+      <div className="border rounded-xl p-6 hover:shadow-lg transition-shadow cursor-pointer bg-white dark:bg-gray-800">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-lg font-semibold">{name}</h3>
+          <span
+            className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium ${
+              isOnline ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+            }`}
+          >
+            <span className={`w-2 h-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
+            {isOnline ? 'Online' : 'Offline'}
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 font-mono">{host}</p>
+        {description && <p className="text-sm text-gray-600 mt-2">{description}</p>}
+      </div>
+    </Link>
+  );
+}
+```
+
+### 6.3 주요 의존성
+
+**Go 백엔드 (`backend/go.mod`)**:
+
+```
+module web-ssh-terminal
+
+go 1.25
+
+require (
+    github.com/gorilla/websocket v1.5.3
+    github.com/labstack/echo/v4 v4.13.3
+    golang.org/x/crypto v0.32.0
+    gopkg.in/yaml.v3 v3.0.1
+)
+```
+
+**React 프론트엔드 (`frontend/package.json`)**:
+
+```json
+{
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0",
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^6.0.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+---
+
+## 7. 보안 고려사항
+
+| 항목 | 대응 방안 |
+|------|----------|
+| SSH 자격 증명 노출 | 환경 변수(.env.local)로 관리, 절대 프론트엔드에 노출하지 않음 |
+| WebSocket 무단 접근 | 프로덕션에서는 JWT/세션 기반 인증 필수 |
+| 중간자 공격 | HTTPS + WSS 사용, SSH host key 검증 |
+| 명령어 제한 | 프로덕션에서는 rbash(restricted bash) 또는 명령 화이트리스트 고려 |
+| 동시 접속 제한 | 로봇당 최대 세션 수 제한 |
+
+> **블로그 주의사항**: 샘플 코드는 학습 목적이므로 인증/보안이 최소화되어 있다. 프로덕션에서는 반드시 적절한 보안 조치를 추가해야 한다.
+
+---
+
+## 8. 블로그 구성안
+
+### 8.1 블로그 포스트 구조
+
+```
+1. 소개
+   - 왜 웹 기반 SSH 터미널이 필요한가?
+   - 완성 화면 미리보기 (스크린샷/GIF)
+
+2. 아키텍처 설계
+   - 전체 데이터 흐름 (Browser ↔ WebSocket ↔ SSH ↔ Robot)
+   - 핵심 기술 스택 소개 (xterm.js, x/crypto/ssh, gorilla/websocket)
+   - 왜 Go 백엔드인가? (단일 바이너리 배포, 고성능 동시성)
+   - 왜 WebSocket인가? (HTTP polling 대비 장점)
+
+3. 프로젝트 셋업
+   - Go 백엔드 프로젝트 구조 (Echo v4)
+   - React 프론트엔드 프로젝트 구조 (Vite + xterm.js)
+   - config.yaml로 로봇 목록 관리
+   - Docker Compose로 테스트용 SSH 서버 구성
+
+4. 핵심 구현 — Go 백엔드
+   4.1 WebSocket + SSH 브릿지 핸들러
+       - x/crypto/ssh로 SSH 연결, PTY 요청, Shell 시작
+       - gorilla/websocket ↔ SSH stdin/stdout 양방향 파이프
+       - 터미널 리사이즈 (WindowChange) 처리
+   4.2 로봇 목록 REST API
+       - TCP dial로 온라인 상태 체크
+       - JSON 응답
+
+5. 핵심 구현 — React 프론트엔드
+   5.1 xterm.js 터미널 컴포넌트
+       - xterm.js 초기화 및 FitAddon 설정
+       - WebSocket 연결 및 입출력 바인딩
+   5.2 로봇 목록 페이지
+       - 로봇 카드 UI + 온라인/오프라인 상태 표시
+       - React Router로 터미널 페이지 전환
+
+6. 실행 및 테스트
+   - Docker Compose로 SSH 서버 실행
+   - Go 백엔드 + React 프론트엔드 동시 실행
+   - 실제 접속 데모
+
+7. 개선 아이디어
+   - 다중 터미널 탭
+   - 세션 녹화/재생
+   - SFTP 파일 관리
+   - 사용자 인증 연동 (JWT)
+
+8. 정리
+   - 핵심 요약
+   - 참고 자료
+```
+
+### 8.2 대안 기술 비교 (블로그에 포함)
+
+| 기술 | 장점 | 단점 | 비고 |
+|------|------|------|------|
+| **xterm.js + Go (직접 구현)** | 커스터마이징 자유도 높음, 단일 바이너리, 고성능 | 직접 구현 필요 | 이 블로그에서 채택 |
+| [Apache Guacamole](https://guacamole.apache.org/) | SSH/VNC/RDP 통합, 완성도 높음 | Java 기반, 무거움, 별도 서버 필요 | 엔터프라이즈 환경에 적합 |
+| [Wetty](https://github.com/butlerx/wetty) | 설치 간단, 즉시 사용 가능 | 커스터마이징 제한적 | 단일 서버 접속에 적합 |
+| [ttyd](https://github.com/tsl0922/ttyd) | C 기반 경량, 빠름 | 웹 UI 커스터마이징 어려움 | CLI 도구 웹 공유에 적합 |
+| [Gotty](https://github.com/yudai/gotty) | Go 기반, 설치 간단 | 유지보수 중단, 읽기 전용 기본 | 데모/모니터링용 |
+
+### 8.3 테스트 환경 구성 가이드 (블로그에 포함)
+
+실제 로봇이 없어도 Docker로 SSH 서버를 띄워서 테스트할 수 있다:
+
+```bash
+# Ubuntu SSH 서버 컨테이너 실행
+docker run -d \
+  --name test-robot-1 \
+  -p 2222:22 \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  -e PASSWORD_ACCESS=true \
+  -e USER_PASSWORD=testpass \
+  -e USER_NAME=ubuntu \
+  lscr.io/linuxserver/openssh-server:latest
+
+# 접속 테스트
+ssh -p 2222 ubuntu@localhost
+```
+
+---
+
+## 9. 작업 항목
+
+> 상세 체크리스트는 `12_ssh_todo.md` 참조
+
+---
+
+## 10. 참고 자료
+
+- [xterm.js 공식 문서](https://xtermjs.org/)
+- [golang.org/x/crypto/ssh](https://pkg.go.dev/golang.org/x/crypto/ssh) — Go SSH 클라이언트
+- [gorilla/websocket](https://github.com/gorilla/websocket) — Go WebSocket 라이브러리
+- [Echo v4 공식 문서](https://echo.labstack.com/) — Go 웹 프레임워크
+- [WebSocket API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
+- [Apache Guacamole](https://guacamole.apache.org/) — 대안 참고
+- [Wetty](https://github.com/butlerx/wetty) — 대안 참고

--- a/docs/done/12_ssh_todo.md
+++ b/docs/done/12_ssh_todo.md
@@ -1,0 +1,87 @@
+# 웹 기반 SSH 로봇 관리 시스템 - TODO
+
+## 1단계: 테스트 환경 구성
+
+- [x] `tutorials-go/web-ssh-terminal/` 디렉토리 생성
+- [x] `docker-compose.yaml` 작성 (SSH 서버 2대: port 2222, 2223)
+- [x] `docker compose up -d`로 SSH 서버 실행
+- [x] SSH 접속 테스트 (웹 터미널을 통해 확인)
+
+## 2단계: Go 백엔드 구현
+
+- [x] `backend/` 디렉토리 생성 + `go mod init web-ssh-terminal`
+- [x] 의존성 설치 (`echo/v4`, `gorilla/websocket`, `x/crypto/ssh`, `yaml.v3`, `godotenv`)
+- [x] `internal/model/robot.go` — Robot 구조체 정의
+- [x] `internal/config/config.go` — YAML 설정 로더
+- [x] `config.yaml` — 테스트용 로봇 목록 (localhost:2222, 2223)
+- [x] `.env` — 테스트 비밀번호 (`ROBOT_ROBOT_1_PASSWORD=testpass`)
+- [x] `internal/handler/robot.go` — `GET /api/robots` (목록 + TCP 상태 체크)
+- [x] `internal/handler/terminal.go` — `GET /ws/terminal` (WebSocket + SSH 브릿지)
+  - [x] gorilla/websocket Upgrader 설정
+  - [x] x/crypto/ssh 연결 (비밀번호 + keyboard-interactive / 공개키 분기)
+  - [x] PTY 요청 + Shell 시작
+  - [x] SSH stdout → WebSocket 전송 (goroutine)
+  - [x] WebSocket → SSH stdin 전송 (goroutine)
+  - [x] 리사이즈 JSON 메시지 → `session.WindowChange()`
+- [x] `main.go` — Echo 서버 셋업 (CORS, 라우트 등록)
+- [x] `go run main.go`로 서버 실행 확인
+- [x] `curl http://localhost:8090/api/robots`로 API 응답 확인
+
+## 3단계: React 프론트엔드 구현
+
+- [x] `frontend/` 디렉토리 생성 (`npm create vite@latest -- --template react-ts`)
+- [x] Tailwind CSS 설치 + 설정
+- [x] `@xterm/xterm`, `@xterm/addon-fit`, `react-router-dom` 설치
+- [x] `vite.config.ts` — Go 백엔드 프록시 설정 (`/api`, `/ws`)
+- [x] `src/api/robots.ts` — `GET /api/robots` 호출 유틸리티
+- [x] `src/components/StatusBadge.tsx` — Online/Offline 뱃지
+- [x] `src/components/RobotCard.tsx` — 로봇 카드 (이름, IP, 상태, Connect)
+- [x] `src/components/RobotList.tsx` — 카드 그리드 레이아웃
+- [x] `src/components/Terminal.tsx` — xterm.js 래퍼
+  - [x] xterm.js 초기화 + FitAddon
+  - [x] WebSocket 연결 + 메시지 바인딩
+  - [x] 키 입력 → WebSocket 전송
+  - [x] 리사이즈 이벤트 → resize JSON 전송
+  - [x] 언마운트 시 cleanup (ws.close, term.dispose)
+- [x] `src/pages/HomePage.tsx` — 로봇 목록 페이지
+- [x] `src/pages/TerminalPage.tsx` — 터미널 페이지 (헤더 바, 상태 바)
+- [x] `src/App.tsx` — React Router 라우팅 (`/`, `/terminal/:robotId`)
+
+## 4단계: 통합 테스트 (MCP chrome-devtools)
+
+- [x] Docker Compose SSH 서버 실행 확인
+- [x] Go 백엔드 + React 프론트엔드 동시 실행
+- [x] MCP chrome-devtools로 UI 테스트:
+  - [x] `/` 페이지 접속 → 로봇 카드 2개 표시 확인
+  - [x] Online 상태 뱃지 표시 확인
+  - [x] 로봇 카드 Connect 클릭 → `/terminal/:robotId` 이동 확인
+  - [x] 터미널 영역에 SSH 프롬프트 표시 확인
+  - [x] 터미널에 `ls -la` 명령어 입력 → 출력 표시 확인
+  - [x] ← Back 클릭 → 로봇 목록 복귀 확인
+  - [ ] Disconnect 클릭 → 연결 종료 확인
+- [ ] 브라우저 리사이즈 시 터미널 자동 조절 확인
+- [ ] 동작 스크린샷 캡처
+
+## 5단계: 블로그 Draft 작성
+
+- [x] `docs/start/go-web-ssh-터미널-로봇-관리/` 디렉토리 생성
+- [x] `index.md` frontmatter 작성 (title, description, date, tags)
+- [x] 섹션 1: 소개 — 왜 웹 기반 SSH 터미널인가?
+- [x] 섹션 2: 아키텍처 — 전체 흐름 다이어그램 (Mermaid)
+- [x] 섹션 3: 프로젝트 셋업 — Go + React 프로젝트 구조
+- [x] 섹션 4: Go 백엔드 — WebSocket+SSH 브릿지 핸들러 코드 설명
+- [x] 섹션 5: React 프론트엔드 — xterm.js 터미널 + 로봇 목록
+- [x] 섹션 6: 실행 및 데모 — Docker Compose + 접속 테스트
+- [x] 섹션 7: 대안 비교 — Guacamole, Wetty, ttyd, Gotty
+- [x] 섹션 8: 개선 아이디어 + 정리
+- [ ] 커버 이미지 준비 (`cover.png`) — 사용자 직접 준비 필요
+
+## 6단계: 검증 및 PR
+
+- [x] `file -I` 로 UTF-8 인코딩 확인 (블로그 글)
+- [ ] Mermaid 다이어그램 렌더링 확인
+- [ ] `go test ./...` — Go 백엔드 테스트 (해당 시)
+- [x] feature 브랜치 생성 (`feat/699-web-ssh-terminal` on tutorials-go)
+- [ ] 커밋 (샘플 코드 + 블로그 글)
+- [ ] `gh pr create` + HEREDOC으로 PR 생성
+- [ ] reviewer 지정 (kenshin579)

--- a/docs/start/go-web-ssh-터미널-로봇-관리/index.md
+++ b/docs/start/go-web-ssh-터미널-로봇-관리/index.md
@@ -1,0 +1,677 @@
+---
+title: "Go + xterm.js로 웹 기반 SSH 터미널 만들기"
+description: "Go 백엔드(Echo + x/crypto/ssh)와 React 프론트엔드(xterm.js)로 브라우저에서 SSH 접속하는 로봇 관리 시스템 구축하기"
+date: 2026-04-11
+update: 2026-04-11
+tags:
+  - Go
+  - SSH
+  - WebSocket
+  - xterm.js
+  - React
+  - Echo
+---
+
+로봇이나 서버를 원격으로 관리할 때 보통 터미널에서 `ssh user@host`로 접속한다. 1~2대면 문제없지만, 여러 대를 관리해야 하는 환경에서는 매번 IP와 인증 정보를 찾아야 하고, 여러 터미널 창을 오가야 하며, 비개발자에게는 접근 장벽이 높다.
+
+이 글에서는 **웹 브라우저에서 로봇 목록을 보고 클릭 한 번으로 SSH 터미널을 열어 명령어를 실행**할 수 있는 시스템을 Go와 React로 구축해 본다.
+
+> 전체 소스 코드는 GitHub에서 확인할 수 있다: [web-ssh-terminal](https://github.com/kenshin579/tutorials-go/tree/master/web-ssh-terminal)
+
+## 1. 아키텍처
+
+### 1.1 전체 데이터 흐름
+
+시스템은 세 개의 계층으로 구성된다.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser (xterm.js)
+    participant S as Go Server (Echo)
+    participant R as Robot (Ubuntu SSH)
+
+    B->>S: WebSocket 연결 (/ws/terminal?robotId=xxx)
+    S->>R: SSH Dial (x/crypto/ssh)
+    R-->>S: SSH Session + Shell
+    S-->>B: WebSocket 연결 확인 (status: connected)
+
+    loop 터미널 입출력
+        B->>S: 키 입력 (WebSocket)
+        S->>R: SSH stdin
+        R-->>S: SSH stdout
+        S-->>B: 터미널 출력 (WebSocket)
+    end
+
+    B->>S: 연결 종료
+    S->>R: SSH 세션 종료
+```
+
+**핵심 아이디어**: Go 서버가 브라우저와 로봇 사이의 **브릿지** 역할을 한다. 브라우저는 WebSocket으로 Go 서버와 통신하고, Go 서버는 SSH로 로봇과 통신한다.
+
+### 1.2 기술 스택
+
+| 계층 | 기술 | 역할 |
+|------|------|------|
+| 프론트엔드 | React 19 + Vite + xterm.js | 터미널 UI 렌더링, WebSocket 통신 |
+| 백엔드 | Go 1.25 + Echo v4 | REST API, WebSocket ↔ SSH 브릿지 |
+| WebSocket | gorilla/websocket | 브라우저 ↔ 서버 실시간 양방향 통신 |
+| SSH | golang.org/x/crypto/ssh | 서버 → 로봇 SSH 연결 |
+
+### 1.3 왜 WebSocket인가?
+
+터미널은 키 하나를 누를 때마다 서버로 전송하고, 서버의 응답을 즉시 화면에 표시해야 한다. HTTP 요청/응답 모델로는 이런 실시간 양방향 스트림을 구현할 수 없다. WebSocket은 한 번 연결하면 양쪽에서 자유롭게 데이터를 주고받을 수 있어 터미널 입출력에 적합하다.
+
+## 2. 프로젝트 구조
+
+```
+web-ssh-terminal/
+├── backend/                        # Go 백엔드
+│   ├── go.mod
+│   ├── main.go                     # Echo 서버 엔트리포인트
+│   ├── config.yaml                 # 로봇 목록 설정
+│   └── internal/
+│       ├── config/config.go        # YAML 설정 로더
+│       ├── handler/
+│       │   ├── robot.go            # GET /api/robots
+│       │   └── terminal.go         # GET /ws/terminal (WebSocket + SSH)
+│       └── model/robot.go          # Robot 구조체
+├── frontend/                       # React 프론트엔드
+│   ├── package.json
+│   ├── vite.config.ts              # 프록시 설정 포함
+│   └── src/
+│       ├── App.tsx                 # React Router
+│       ├── api/robots.ts           # API 유틸리티
+│       ├── components/
+│       │   ├── Terminal.tsx        # xterm.js 래퍼
+│       │   ├── RobotCard.tsx       # 로봇 카드
+│       │   └── ...
+│       └── pages/
+│           ├── HomePage.tsx        # 로봇 목록
+│           └── TerminalPage.tsx    # 터미널 페이지
+└── docker-compose.yaml             # 테스트용 SSH 서버
+```
+
+## 3. Go 백엔드 구현
+
+### 3.1 로봇 모델과 설정
+
+먼저 로봇을 표현하는 구조체를 정의한다.
+
+```go
+// internal/model/robot.go
+package model
+
+type AuthType string
+
+const (
+    AuthPassword   AuthType = "password"
+    AuthPrivateKey AuthType = "privateKey"
+)
+
+type Robot struct {
+    ID          string   `json:"id" yaml:"id"`
+    Name        string   `json:"name" yaml:"name"`
+    Host        string   `json:"host" yaml:"host"`
+    Port        int      `json:"port" yaml:"port"`
+    Username    string   `json:"username" yaml:"username"`
+    AuthType    AuthType `json:"authType" yaml:"authType"`
+    Description string   `json:"description,omitempty" yaml:"description"`
+    IsOnline    bool     `json:"isOnline" yaml:"-"`
+}
+```
+
+로봇 목록은 `config.yaml`에서 관리한다.
+
+```yaml
+# config.yaml
+server:
+  port: 8090
+
+ssh:
+  privateKeyPath: ~/.ssh/id_rsa
+
+robots:
+  - id: robot-1
+    name: Assembly Robot A
+    host: 192.168.1.101
+    port: 22
+    username: ubuntu
+    authType: password
+    description: 조립 라인 1번 로봇
+
+  - id: robot-2
+    name: Inspection Robot B
+    host: 192.168.1.102
+    port: 22
+    username: ubuntu
+    authType: privateKey
+    description: 품질 검사 로봇
+```
+
+설정 로더는 YAML 파일을 읽어 `Config` 구조체로 변환한다.
+
+```go
+// internal/config/config.go
+func Load(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, err
+    }
+
+    var cfg Config
+    if err := yaml.Unmarshal(data, &cfg); err != nil {
+        return nil, err
+    }
+
+    if cfg.Server.Port == 0 {
+        cfg.Server.Port = 8080
+    }
+    return &cfg, nil
+}
+```
+
+### 3.2 로봇 목록 API
+
+로봇 목록을 반환할 때 각 로봇의 SSH 포트에 TCP 연결을 시도하여 **온라인 상태**를 확인한다.
+
+```go
+// internal/handler/robot.go
+
+// ListRobots handles GET /api/robots
+func (h *RobotHandler) ListRobots(c echo.Context) error {
+    robots := make([]model.Robot, len(h.cfg.Robots))
+    copy(robots, h.cfg.Robots)
+
+    for i := range robots {
+        robots[i].IsOnline = checkSSHPort(robots[i].Host, robots[i].Port)
+    }
+
+    return c.JSON(http.StatusOK, robots)
+}
+
+func checkSSHPort(host string, port int) bool {
+    addr := fmt.Sprintf("%s:%d", host, port)
+    conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+    if err != nil {
+        return false
+    }
+    conn.Close()
+    return true
+}
+```
+
+`net.DialTimeout`으로 2초 내에 TCP 연결이 되면 Online, 실패하면 Offline으로 판단한다.
+
+### 3.3 WebSocket + SSH 브릿지 (핵심)
+
+이 핸들러가 시스템의 핵심이다. WebSocket 연결을 받아서 SSH 세션과 양방향으로 파이프하는 역할을 한다.
+
+```go
+// internal/handler/terminal.go
+
+var upgrader = websocket.Upgrader{
+    CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// HandleTerminal handles GET /ws/terminal?robotId=xxx
+func (h *TerminalHandler) HandleTerminal(c echo.Context) error {
+    robotID := c.QueryParam("robotId")
+
+    // 1. 로봇 설정 조회
+    var robot *model.Robot
+    for i := range h.cfg.Robots {
+        if h.cfg.Robots[i].ID == robotID {
+            robot = &h.cfg.Robots[i]
+            break
+        }
+    }
+    if robot == nil {
+        return echo.NewHTTPError(http.StatusNotFound, "robot not found")
+    }
+
+    // 2. HTTP → WebSocket 업그레이드
+    ws, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
+    if err != nil {
+        return err
+    }
+    defer ws.Close()
+
+    // 3. SSH 연결
+    sshConfig, err := h.buildSSHConfig(robot)
+    if err != nil {
+        ws.WriteJSON(map[string]string{"type": "error", "message": err.Error()})
+        return nil
+    }
+
+    addr := fmt.Sprintf("%s:%d", robot.Host, robot.Port)
+    conn, err := ssh.Dial("tcp", addr, sshConfig)
+    if err != nil {
+        ws.WriteJSON(map[string]string{
+            "type": "error",
+            "message": "SSH connection failed: " + err.Error(),
+        })
+        return nil
+    }
+    defer conn.Close()
+
+    // 4. SSH 세션 + PTY + Shell
+    session, err := conn.NewSession()
+    if err != nil {
+        ws.WriteJSON(map[string]string{"type": "error", "message": err.Error()})
+        return nil
+    }
+    defer session.Close()
+
+    modes := ssh.TerminalModes{
+        ssh.ECHO:          1,
+        ssh.TTY_OP_ISPEED: 14400,
+        ssh.TTY_OP_OSPEED: 14400,
+    }
+    if err := session.RequestPty("xterm-256color", 24, 80, modes); err != nil {
+        ws.WriteJSON(map[string]string{"type": "error", "message": err.Error()})
+        return nil
+    }
+
+    sshIn, _ := session.StdinPipe()
+    sshOut, _ := session.StdoutPipe()
+
+    if err := session.Shell(); err != nil {
+        ws.WriteJSON(map[string]string{"type": "error", "message": err.Error()})
+        return nil
+    }
+
+    ws.WriteJSON(map[string]string{"type": "status", "message": "connected"})
+
+    // 5. 양방향 파이프
+    done := make(chan struct{})
+
+    // SSH stdout → WebSocket (Browser)
+    go func() {
+        defer close(done)
+        buf := make([]byte, 4096)
+        for {
+            n, err := sshOut.Read(buf)
+            if err != nil {
+                return
+            }
+            if err := ws.WriteMessage(websocket.TextMessage, buf[:n]); err != nil {
+                return
+            }
+        }
+    }()
+
+    // WebSocket (Browser) → SSH stdin
+    go func() {
+        for {
+            _, msg, err := ws.ReadMessage()
+            if err != nil {
+                session.Close()
+                return
+            }
+
+            // 리사이즈 메시지 처리
+            var resize resizeMessage
+            if json.Unmarshal(msg, &resize) == nil && resize.Type == "resize" {
+                session.WindowChange(resize.Rows, resize.Cols)
+                continue
+            }
+
+            sshIn.Write(msg)
+        }
+    }()
+
+    <-done
+    return nil
+}
+```
+
+처리 흐름을 단계별로 정리하면:
+
+1. **로봇 조회**: `robotId` 쿼리 파라미터로 설정에서 로봇 정보를 찾는다
+2. **WebSocket 업그레이드**: HTTP 연결을 WebSocket으로 업그레이드한다
+3. **SSH 연결**: `ssh.Dial`로 로봇에 SSH 연결을 생성한다
+4. **PTY + Shell**: `RequestPty`로 가상 터미널을 요청하고 `Shell`로 셸을 시작한다
+5. **양방향 파이프**: 2개의 goroutine으로 SSH ↔ WebSocket 데이터를 양방향으로 전달한다
+
+### 3.4 SSH 인증 설정
+
+비밀번호와 공개키, 두 가지 인증 방식을 지원한다. 일부 SSH 서버는 `password` 대신 `keyboard-interactive` 방식을 요구하므로 두 방식을 모두 제공한다.
+
+```go
+func (h *TerminalHandler) buildSSHConfig(robot *model.Robot) (*ssh.ClientConfig, error) {
+    sshCfg := &ssh.ClientConfig{
+        User:            robot.Username,
+        HostKeyCallback: ssh.InsecureIgnoreHostKey(), // 개발용
+        Timeout:         10 * time.Second,
+    }
+
+    switch robot.AuthType {
+    case model.AuthPassword:
+        // 환경변수에서 비밀번호 로드: ROBOT_ROBOT_1_PASSWORD
+        normalizedID := strings.ToUpper(strings.ReplaceAll(robot.ID, "-", "_"))
+        envKey := fmt.Sprintf("ROBOT_%s_PASSWORD", normalizedID)
+        password := os.Getenv(envKey)
+        sshCfg.Auth = []ssh.AuthMethod{
+            ssh.Password(password),
+            ssh.KeyboardInteractive(func(user, instruction string,
+                questions []string, echos []bool) ([]string, error) {
+                answers := make([]string, len(questions))
+                for i := range answers {
+                    answers[i] = password
+                }
+                return answers, nil
+            }),
+        }
+
+    case model.AuthPrivateKey:
+        key, err := os.ReadFile(h.cfg.SSH.PrivateKeyPath)
+        if err != nil {
+            return nil, fmt.Errorf("failed to read private key: %w", err)
+        }
+        signer, err := ssh.ParsePrivateKey(key)
+        if err != nil {
+            return nil, fmt.Errorf("failed to parse private key: %w", err)
+        }
+        sshCfg.Auth = []ssh.AuthMethod{ssh.PublicKeys(signer)}
+    }
+
+    return sshCfg, nil
+}
+```
+
+> **주의**: `ssh.InsecureIgnoreHostKey()`는 개발 편의를 위한 설정이다. 프로덕션에서는 반드시 `known_hosts` 파일을 검증하는 콜백을 사용해야 한다.
+
+### 3.5 서버 엔트리포인트
+
+```go
+// main.go
+func main() {
+    _ = godotenv.Load()
+
+    cfg, err := config.Load("config.yaml")
+    if err != nil {
+        log.Fatalf("Failed to load config: %v", err)
+    }
+
+    e := echo.New()
+
+    e.Use(middleware.Logger())
+    e.Use(middleware.Recover())
+    e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+        AllowOrigins: []string{"http://localhost:5173"},
+    }))
+
+    robotHandler := handler.NewRobotHandler(cfg)
+    terminalHandler := handler.NewTerminalHandler(cfg)
+
+    e.GET("/api/robots", robotHandler.ListRobots)
+    e.GET("/ws/terminal", terminalHandler.HandleTerminal)
+
+    // 프로덕션: React 빌드 정적 파일 서빙
+    e.Static("/", "../frontend/dist")
+
+    addr := fmt.Sprintf(":%d", cfg.Server.Port)
+    e.Logger.Fatal(e.Start(addr))
+}
+```
+
+`godotenv.Load()`로 `.env` 파일에서 SSH 비밀번호를 로드하고, Echo 서버에 REST API와 WebSocket 핸들러를 등록한다.
+
+## 4. React 프론트엔드 구현
+
+### 4.1 xterm.js 터미널 컴포넌트
+
+프론트엔드의 핵심은 xterm.js를 감싼 `Terminal` 컴포넌트다.
+
+```tsx
+// src/components/Terminal.tsx
+import { useEffect, useRef, useCallback } from 'react';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+
+export default function Terminal({ robotId, onDisconnect }: TerminalProps) {
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const connect = useCallback(() => {
+    if (!terminalRef.current) return;
+
+    // 1. xterm.js 초기화
+    const term = new XTerm({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      theme: {
+        background: '#1e1e2e',
+        foreground: '#cdd6f4',
+        cursor: '#f5e0dc',
+      },
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(terminalRef.current);
+    fitAddon.fit();
+
+    // 2. WebSocket 연결 (Vite 프록시 경유)
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(
+      `${protocol}//${window.location.host}/ws/terminal?robotId=${robotId}`
+    );
+
+    // 3. 서버 → 브라우저: 터미널 출력
+    ws.onmessage = (event) => {
+      const data = event.data;
+      try {
+        const parsed = JSON.parse(data);
+        if (parsed.type === 'status' || parsed.type === 'error') {
+          term.writeln(`${parsed.type}: ${parsed.message}`);
+          return;
+        }
+      } catch { /* 일반 터미널 출력 */ }
+      term.write(data);
+    };
+
+    // 4. 브라우저 → 서버: 키 입력
+    term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) ws.send(data);
+    });
+
+    // 5. 리사이즈 처리
+    const handleResize = () => {
+      fitAddon.fit();
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({
+          type: 'resize', cols: term.cols, rows: term.rows
+        }));
+      }
+    };
+    window.addEventListener('resize', handleResize);
+
+    cleanupRef.current = () => {
+      window.removeEventListener('resize', handleResize);
+      ws.close();
+      term.dispose();
+    };
+  }, [robotId, onDisconnect]);
+
+  useEffect(() => {
+    connect();
+    return () => cleanupRef.current?.();
+  }, [connect]);
+
+  return (
+    <div ref={terminalRef}
+      className="w-full h-full min-h-[400px] bg-[#1e1e2e] rounded-lg p-1" />
+  );
+}
+```
+
+**xterm.js 핵심 포인트:**
+- `FitAddon`이 컨테이너 크기에 맞춰 터미널 행/열을 자동 계산한다
+- 브라우저 창 리사이즈 시 `fitAddon.fit()`으로 터미널을 다시 맞추고, resize 메시지를 서버에 보내 SSH PTY 크기도 함께 조정한다
+- `term.onData`로 키 입력을 받아 WebSocket으로 전송한다
+- 언마운트 시 WebSocket과 xterm 인스턴스를 정리한다
+
+### 4.2 로봇 카드 컴포넌트
+
+각 로봇을 카드 형태로 표시하고, 온라인 상태에 따라 Connect 버튼을 활성화/비활성화한다.
+
+```tsx
+// src/components/RobotCard.tsx
+import { Link } from 'react-router-dom';
+import StatusBadge from './StatusBadge';
+
+export default function RobotCard({ id, name, host, port, description, isOnline }) {
+  return (
+    <div className="border rounded-xl p-6 bg-white shadow-sm hover:shadow-md transition-shadow">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold">{name}</h3>
+        <StatusBadge isOnline={isOnline} />
+      </div>
+      <p className="text-sm text-gray-500 font-mono">{host}:{port}</p>
+      {description && <p className="text-sm text-gray-600 mt-2">{description}</p>}
+      <div className="mt-4">
+        {isOnline ? (
+          <Link to={`/terminal/${id}`}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+            Connect
+          </Link>
+        ) : (
+          <span className="px-4 py-2 bg-gray-200 text-gray-400 rounded-lg cursor-not-allowed">
+            Offline
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+### 4.3 Vite 프록시 설정
+
+개발 환경에서 프론트엔드(포트 5173)가 Go 백엔드(포트 8090)에 접근할 수 있도록 Vite 프록시를 설정한다.
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8090',
+      '/ws': {
+        target: 'http://localhost:8090',
+        ws: true,  // WebSocket 프록시 활성화
+      },
+    },
+  },
+});
+```
+
+이렇게 하면 프론트엔드에서 `/api/robots`나 `/ws/terminal`을 호출할 때 자동으로 Go 서버로 프록시된다. 프로덕션에서는 Go 서버가 `frontend/dist/`의 정적 파일을 직접 서빙하므로 프록시가 필요 없다.
+
+## 5. 실행 및 테스트
+
+### 5.1 테스트 환경: Docker Compose
+
+실제 로봇이 없어도 Docker로 SSH 서버를 띄워서 테스트할 수 있다.
+
+```yaml
+# docker-compose.yaml
+services:
+  robot-1:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: test-robot-1
+    ports:
+      - "2222:2222"   # 내부 포트가 2222
+    environment:
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=testpass
+      - USER_NAME=ubuntu
+
+  robot-2:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: test-robot-2
+    ports:
+      - "2223:2222"
+    environment:
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=testpass
+      - USER_NAME=ubuntu
+```
+
+> **주의**: `linuxserver/openssh-server` 이미지는 SSH 기본 포트가 **2222**이다(22가 아님). 포트 매핑 시 `2222:2222`로 설정해야 한다.
+
+### 5.2 실행 순서
+
+```bash
+# 1. 테스트 SSH 서버 실행
+cd web-ssh-terminal
+docker compose up -d
+
+# 2. Go 백엔드 실행
+cd backend
+go run main.go
+# > Server starting on :8090
+
+# 3. React 프론트엔드 실행 (별도 터미널)
+cd frontend
+npm install
+npm run dev
+# > http://localhost:5173
+
+# 4. 브라우저에서 http://localhost:5173 접속
+```
+
+### 5.3 동작 확인
+
+브라우저에서 `http://localhost:5173`에 접속하면 로봇 목록이 표시된다.
+
+**로봇 목록 페이지**: 각 로봇의 이름, IP, 온라인 상태, Connect 버튼이 카드 형태로 표시된다.
+
+**터미널 페이지**: Connect를 클릭하면 SSH 터미널이 열리고, 실제 명령어를 입력하고 결과를 확인할 수 있다.
+
+## 6. 대안 기술 비교
+
+웹 기반 SSH 터미널을 구현하는 방법은 여러 가지가 있다.
+
+| 기술 | 장점 | 단점 |
+|------|------|------|
+| **xterm.js + Go (이 글)** | 커스터마이징 자유도 높음, 단일 바이너리, 고성능 | 직접 구현 필요 |
+| [Apache Guacamole](https://guacamole.apache.org/) | SSH/VNC/RDP 통합, 완성도 높음 | Java 기반, 무거움 |
+| [Wetty](https://github.com/butlerx/wetty) | 설치 간단, 즉시 사용 가능 | 커스터마이징 제한적 |
+| [ttyd](https://github.com/tsl0922/ttyd) | C 기반 경량, 빠름 | 웹 UI 커스터마이징 어려움 |
+
+단일 서버에 빠르게 SSH를 열고 싶다면 Wetty나 ttyd가 적합하다. 하지만 **여러 로봇을 관리하는 대시보드**를 만들려면 직접 구현하는 것이 자유도가 높다.
+
+## 7. 개선 아이디어
+
+이 샘플 코드는 MVP 수준이다. 프로덕션 적용 시 고려할 사항:
+
+- **사용자 인증**: JWT 기반 로그인, WebSocket 연결 시 토큰 검증
+- **다중 터미널 탭**: 여러 로봇에 동시 접속, 탭으로 전환
+- **세션 녹화**: 터미널 입출력을 저장하여 나중에 재생
+- **파일 전송**: SCP/SFTP 기능 추가
+- **SSH Host Key 검증**: `known_hosts` 파일 기반 검증
+- **동시 접속 제한**: 로봇당 최대 세션 수 관리
+- **로봇 CRUD**: 웹 UI에서 로봇 등록/수정/삭제
+
+## 8. 정리
+
+이 글에서는 Go 백엔드와 React 프론트엔드로 웹 기반 SSH 터미널 시스템을 구축해 보았다. 핵심은 **Go 서버가 WebSocket과 SSH 사이의 브릿지** 역할을 하는 것이다.
+
+| 기술 | 용도 |
+|------|------|
+| `golang.org/x/crypto/ssh` | SSH 연결, PTY 요청, Shell 시작 |
+| `gorilla/websocket` | 브라우저 ↔ 서버 실시간 통신 |
+| `xterm.js` | 브라우저에서 터미널 에뮬레이션 |
+| `Echo v4` | REST API + WebSocket 핸들러 |
+
+## 참고 자료
+
+- [전체 소스 코드 - GitHub](https://github.com/kenshin579/tutorials-go/tree/master/web-ssh-terminal)
+- [xterm.js 공식 문서](https://xtermjs.org/)
+- [golang.org/x/crypto/ssh](https://pkg.go.dev/golang.org/x/crypto/ssh)
+- [gorilla/websocket](https://github.com/gorilla/websocket)
+- [Echo v4 공식 문서](https://echo.labstack.com/)


### PR DESCRIPTION
## Summary
- 블로그 초안 작성: Go 백엔드(Echo + x/crypto/ssh) + React 프론트엔드(xterm.js)로 웹 SSH 터미널 구축 가이드
- PRD, 구현 문서, TODO 체크리스트 작성 완료 → docs/done으로 이동
- 관련 샘플 코드: kenshin579/tutorials-go#700

## 블로그 구성
1. 아키텍처 (Mermaid 시퀀스 다이어그램)
2. 프로젝트 구조
3. Go 백엔드 (WebSocket + SSH 브릿지 핵심)
4. React 프론트엔드 (xterm.js 터미널)
5. 실행 및 테스트 (Docker Compose)
6. 대안 비교 (Guacamole, Wetty, ttyd)
7. 개선 아이디어
8. 정리

## Test plan
- [x] UTF-8 인코딩 확인 (`file -I`)
- [x] Mermaid 다이어그램 문법 확인
- [ ] 커버 이미지 추가 (추후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)