### PR TITLE
fix: biweekly 뉴스 YAML 날짜 불일치 수정

### DIFF
--- a/contents/biweekly/news-2026-03-15/index.md
+++ b/contents/biweekly/news-2026-03-15/index.md
@@ -1,8 +1,8 @@
 ---
 title: "Frank's IT Biweekly News (2026-03-01 ~ 2026-03-15)"
 description: "Frank's IT Biweekly News (2026-03-01 ~ 2026-03-15)"
-date: 2026-04-09
-update: 2026-04-09
+date: 2026-03-15
+update: 2026-03-15
 tags:
   - news
   - biweekly

--- a/contents/biweekly/news-2026-04-01/index.md
+++ b/contents/biweekly/news-2026-04-01/index.md
@@ -1,8 +1,8 @@
 ---
 title: "Frank's IT Biweekly News (2026-03-18 ~ 2026-04-01)"
 description: "Frank's IT Biweekly News (2026-03-18 ~ 2026-04-01)"
-date: 2026-04-09
-update: 2026-04-09
+date: 2026-04-01
+update: 2026-04-01
 tags:
   - news
   - biweekly


### PR DESCRIPTION
## Summary
- biweekly 뉴스 2개 파일의 YAML `date`/`update` 값이 폴더명 및 title 날짜와 불일치하는 문제 수정
  - `news-2026-03-15`: `2026-04-09` → `2026-03-15`
  - `news-2026-04-01`: `2026-04-09` → `2026-04-01`

## Test plan
- [x] 수정 후 YAML date/update가 폴더명 날짜와 일치하는지 확인
- [ ] 블로그에서 해당 글의 날짜가 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)