### PR TITLE
[#457] RSS 피드에 CORS 헤더 추가

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,8 @@
 [build.environment]
   NODE_VERSION = "22"
   NPM_FLAGS = "--legacy-peer-deps"
+
+[[headers]]
+  for = "/rss.xml"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
## Summary
- `/rss.xml` 응답에 `Access-Control-Allow-Origin: *` 헤더 추가
- v2 포트폴리오(Profile UI v2, kenshin579/v2.advenoh.pe.kr#25) 브라우저 측 RSS fetch 하이브리드 연동을 위한 선결 작업

## 변경 사항
`netlify.toml`에 headers 블록 추가:
```toml
[[headers]]
  for = "/rss.xml"
  [headers.values]
    Access-Control-Allow-Origin = "*"
```

## Test plan
- [ ] PR 머지 후 Netlify 배포 확인
- [ ] 배포 완료 후 헤더 검증:
  ```bash
  curl -sI https://blog.advenoh.pe.kr/rss.xml | grep -i access-control-allow-origin
  # 기대: access-control-allow-origin: *
  ```
- [ ] 브라우저 콘솔에서 cross-origin fetch 테스트:
  ```js
  fetch('https://blog.advenoh.pe.kr/rss.xml').then(r => r.text()).then(console.log)
  ```

Closes #457