### PR TITLE
[#460] chore: 시리즈 글 제목 편 번호 포맷 통일 ((N) → N편)

### DIFF
--- a/contents/database/mqtt-v5-완벽-가이드-1-입문과-기본-아키텍처/index.md
+++ b/contents/database/mqtt-v5-완벽-가이드-1-입문과-기본-아키텍처/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MQTT v5 완벽 가이드 (1): 개념과 아키텍처 이해하기"
+title: "MQTT v5 완벽 가이드 1편: 개념과 아키텍처 이해하기"
 description: "MQTT v5의 기본 개념, Broker 중심 아키텍처, HTTP와의 차이점을 알아봅니다. MQTT를 처음 접하는 개발자를 위한 입문 가이드이다."
 date: 2026-02-04
 update: 2026-02-04
@@ -255,7 +255,7 @@ Broker는 "똑똑한 우체국"과 같다:
 - v5에서는 Reason Code, User Properties 등이 추가되어 디버깅과 확장성이 크게 개선되었다
 - Client, Broker, Topic이 핵심 구성 요소이며, 모든 메시지는 Broker를 통해 라우팅된다
 
-> **다음 편 안내**: MQTT v5 완벽 가이드 (2)에서는 Topic 설계와 메시지 모델을 다룬다.
+> **다음 편 안내**: MQTT v5 완벽 가이드 2편에서는 Topic 설계와 메시지 모델을 다룬다.
 
 # 4. 참고
 

--- a/contents/database/mqtt-v5-완벽-가이드-2-topic-설계와-메시지-모델/index.md
+++ b/contents/database/mqtt-v5-완벽-가이드-2-topic-설계와-메시지-모델/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MQTT v5 완벽 가이드 (2): Topic 설계와 메시지 모델"
+title: "MQTT v5 완벽 가이드 2편: Topic 설계와 메시지 모델"
 description: "MQTT Topic 설계 Best Practice와 Wildcard 사용법, v5의 User Properties, Message Expiry 등 메시지 모델을 상세히 알아본다."
 date: 2026-02-11
 update: 2026-02-11
@@ -356,7 +356,7 @@ v5에서는 User Properties로 메타데이터를 전달하고, Message Expiry�
 
 Topic 설계는 운영 후 변경이 어렵기 때문에 초기 단계에서 충분히 검토하길 바란다.
 
-> **다음 편 안내**: [MQTT v5 완벽 가이드 (3): QoS, Session, 재연결 전략](/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략)에서는 `QoS` 동작 원리, 세션 관리, 그리고 실무에서 가장 중요한 재연결 전략을 다룬다.
+> **다음 편 안내**: [MQTT v5 완벽 가이드 3편: QoS, Session, 재연결 전략](/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략)에서는 `QoS` 동작 원리, 세션 관리, 그리고 실무에서 가장 중요한 재연결 전략을 다룬다.
 
 
 # 5. 참고

--- a/contents/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략/index.md
+++ b/contents/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MQTT v5 완벽 가이드 (3): QoS, Session, 재연결 전략"
+title: "MQTT v5 완벽 가이드 3편: QoS, Session, 재연결 전략"
 description: "MQTT의 핵심인 QoS 동작 원리, Session 관리, 그리고 실무에서 가장 중요한 재연결 전략을 상세히 다룬다."
 date: 2026-02-14
 update: 2026-02-14
@@ -709,7 +709,7 @@ for _, msg := range messages {
 
 ---
 
-> **다음 편 안내**: [MQTT v5 완벽 가이드 (4): 고급 기능과 보안](/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안)에서는 Shared Subscription, Request/Response 패턴, Reason Code, 그리고 TLS 보안 설정을 다룬다.
+> **다음 편 안내**: [MQTT v5 완벽 가이드 4편: 고급 기능과 보안](/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안)에서는 Shared Subscription, Request/Response 패턴, Reason Code, 그리고 TLS 보안 설정을 다룬다.
 
 ---
 

--- a/contents/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안/index.md
+++ b/contents/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MQTT v5 완벽 가이드 (4): 고급 기능과 보안"
+title: "MQTT v5 완벽 가이드 4편: 고급 기능과 보안"
 description: "MQTT v5의 Shared Subscription, Request/Response 패턴, Reason Code 활용법과 TLS, ACL 등 보안 설정을 다룬다."
 date: 2026-02-17
 update: 2026-02-17
@@ -780,7 +780,7 @@ function Dashboard() {
 다음 편에서는 `Go` 언어로 이 기능들을 실제로 구현하는 방법을 살펴본다.
 
 
-> **다음 편 안내**: [MQTT v5 완벽 가이드 (5): Go + Paho 실전 구현과 운영](/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영)에서는 Go 언어로 `MQTT` v5 클라이언트를 구현하는 방법과 프로덕션 운영 전략을 다룬다.
+> **다음 편 안내**: [MQTT v5 완벽 가이드 5편: Go + Paho 실전 구현과 운영](/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영)에서는 Go 언어로 `MQTT` v5 클라이언트를 구현하는 방법과 프로덕션 운영 전략을 다룬다.
 
 # 4. 참고
 

--- a/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index.md
+++ b/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MQTT v5 완벽 가이드 (5): Go + Paho 실전 구현과 운영"
+title: "MQTT v5 완벽 가이드 5편: Go + Paho 실전 구현과 운영"
 description: "Go 언어로 MQTT v5 클라이언트를 구현하는 방법과 운영 모니터링, MQTT 사용 판단 기준을 다룬다."
 date: 2026-02-20
 update: 2026-02-20

--- a/contents/go/golang-concurrency-1-goroutine-기초/index.md
+++ b/contents/go/golang-concurrency-1-goroutine-기초/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Golang Concurrency (1) - 개요와 Goroutine 기초"
+title: "Golang Concurrency 1편 - 개요와 Goroutine 기초"
 description: "Go 동시성의 기본 개념 Concurrency vs Parallelism, CSP 모델, GMP 스케줄러와 Goroutine 기초를 다룹니다"
 date: 2026-03-07
 update: 2026-03-07

--- a/contents/go/golang-concurrency-2-channel-완전-정복/index.md
+++ b/contents/go/golang-concurrency-2-channel-완전-정복/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Golang Concurrency (2) - Channel 완전 정복"
+title: "Golang Concurrency 2편 - Channel 완전 정복"
 description: "Go Channel의 기본 동작부터 buffered/unbuffered 차이, 방향 제한, close 규칙, producer-consumer 패턴까지 다룹니다"
 date: 2026-03-19
 update: 2026-03-19

--- a/contents/go/golang-concurrency-3-select와-channel-심화/index.md
+++ b/contents/go/golang-concurrency-3-select와-channel-심화/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Golang Concurrency (3) - Select와 Channel 심화 패턴"
+title: "Golang Concurrency 3편 - Select와 Channel 심화 패턴"
 description: "Go select문을 활용한 timeout, fan-in/fan-out, nil channel 동적 비활성화 등 Channel 심화 패턴을 다룹니다"
 date: 2026-04-08
 update: 2026-04-08

--- a/contents/go/golang-concurrency-4-sync-패키지/index.md
+++ b/contents/go/golang-concurrency-4-sync-패키지/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Golang Concurrency (4) - sync 패키지 완벽 가이드"
+title: "Golang Concurrency 4편 - sync 패키지 완벽 가이드"
 description: "Go sync 패키지의 WaitGroup, Mutex, RWMutex, Once, sync.Map 사용법과 Race Condition 해결법을 다룹니다"
 date: 2026-04-15
 update: 2026-04-15

--- a/contents/go/golang-generics-1-개요와-기본-문법/index.md
+++ b/contents/go/golang-generics-1-개요와-기본-문법/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Golang Generics (1) - 개요와 기본 문법"
-description: "Golang Generics (1) - 개요와 기본 문법"
+title: "Golang Generics 1편 - 개요와 기본 문법"
+description: "Golang Generics 1편 - 개요와 기본 문법"
 date: 2026-03-01
 update: 2026-03-01
 tags:

--- a/contents/go/golang-generics-2-type-constraint-완벽-이해/index.md
+++ b/contents/go/golang-generics-2-type-constraint-완벽-이해/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Golang Generics (2) - Type Constraint 완벽 이해"
-description: "Golang Generics (2) - Type Constraint 완벽 이해"
+title: "Golang Generics 2편 - Type Constraint 완벽 이해"
+description: "Golang Generics 2편 - Type Constraint 완벽 이해"
 date: 2026-03-02
 update: 2026-03-02
 tags:

--- a/contents/go/golang-generics-3-실전-예제-모음/index.md
+++ b/contents/go/golang-generics-3-실전-예제-모음/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Golang Generics (3) - 실전 예제 모음"
-description: "Golang Generics (3) - 실전 예제 모음"
+title: "Golang Generics 3편 - 실전 예제 모음"
+description: "Golang Generics 3편 - 실전 예제 모음"
 date: 2026-03-03
 update: 2026-03-03
 tags:

--- a/docs/start/2_title_prd.md
+++ b/docs/start/2_title_prd.md
@@ -1,0 +1,106 @@
+## 시리즈 글 제목 포맷 통일 - PRD
+
+### 1. 배경 및 목적
+
+`contents/` 디렉토리의 시리즈 글(`series:` 메타데이터가 있는 글) 제목에서 편 번호 표기 방식이 혼재되어 있다. 동일한 시리즈 내에서도 `(1)`, `(5)`, `5편` 등 서로 다른 포맷이 섞여 있어 일관성이 떨어지고 시리즈 소속 글이라는 인식을 저해한다.
+
+- 기존 포맷 예시: `Golang Concurrency (1) - ...`, `MQTT v5 완벽 가이드 (3): ...`, `Golang Concurrency 5편 - ...`
+- **목표 포맷**: `N편` (예: `1편`, `2편`, `3편`)
+- **기준 사례**: `Golang Concurrency 5편 - Context 완벽 가이드` (이미 목표 포맷 준수)
+
+### 2. 변환 규칙
+
+**Title 변환 규칙:**
+
+| 기존 포맷 | 변환 후 |
+|---|---|
+| `... (1): 본문` | `... 1편: 본문` |
+| `... (2) - 본문` | `... 2편 - 본문` |
+
+원칙:
+- 괄호 `(N)` → `N편`으로 치환
+- 뒤따르는 구분자(`:`, `-`)와 띄어쓰기는 그대로 유지
+- 숫자 외 다른 텍스트는 변경하지 않음
+
+### 3. 수정 대상
+
+#### 3.1 Title 필드 (총 12개 파일)
+
+**MQTT v5 완벽 가이드 시리즈 (5개) — `database/`**
+
+| 파일 | 변경 전 | 변경 후 |
+|---|---|---|
+| `contents/database/mqtt-v5-완벽-가이드-1-입문과-기본-아키텍처/index.md` | `"MQTT v5 완벽 가이드 (1): 개념과 아키텍처 이해하기"` | `"MQTT v5 완벽 가이드 1편: 개념과 아키텍처 이해하기"` |
+| `contents/database/mqtt-v5-완벽-가이드-2-topic-설계와-메시지-모델/index.md` | `"MQTT v5 완벽 가이드 (2): Topic 설계와 메시지 모델"` | `"MQTT v5 완벽 가이드 2편: Topic 설계와 메시지 모델"` |
+| `contents/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략/index.md` | `"MQTT v5 완벽 가이드 (3): QoS, Session, 재연결 전략"` | `"MQTT v5 완벽 가이드 3편: QoS, Session, 재연결 전략"` |
+| `contents/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안/index.md` | `"MQTT v5 완벽 가이드 (4): 고급 기능과 보안"` | `"MQTT v5 완벽 가이드 4편: 고급 기능과 보안"` |
+| `contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index.md` | `"MQTT v5 완벽 가이드 (5): Go + Paho 실전 구현과 운영"` | `"MQTT v5 완벽 가이드 5편: Go + Paho 실전 구현과 운영"` |
+
+**Golang Generics 시리즈 (3개) — `go/`**
+
+| 파일 | 변경 전 | 변경 후 |
+|---|---|---|
+| `contents/go/golang-generics-1-개요와-기본-문법/index.md` | `"Golang Generics (1) - 개요와 기본 문법"` | `"Golang Generics 1편 - 개요와 기본 문법"` |
+| `contents/go/golang-generics-2-type-constraint-완벽-이해/index.md` | `"Golang Generics (2) - Type Constraint 완벽 이해"` | `"Golang Generics 2편 - Type Constraint 완벽 이해"` |
+| `contents/go/golang-generics-3-실전-예제-모음/index.md` | `"Golang Generics (3) - 실전 예제 모음"` | `"Golang Generics 3편 - 실전 예제 모음"` |
+
+**Golang Concurrency 시리즈 (4개) — `go/`**
+
+| 파일 | 변경 전 | 변경 후 |
+|---|---|---|
+| `contents/go/golang-concurrency-1-goroutine-기초/index.md` | `"Golang Concurrency (1) - 개요와 Goroutine 기초"` | `"Golang Concurrency 1편 - 개요와 Goroutine 기초"` |
+| `contents/go/golang-concurrency-2-channel-완전-정복/index.md` | `"Golang Concurrency (2) - Channel 완전 정복"` | `"Golang Concurrency 2편 - Channel 완전 정복"` |
+| `contents/go/golang-concurrency-3-select와-channel-심화/index.md` | `"Golang Concurrency (3) - Select와 Channel 심화 패턴"` | `"Golang Concurrency 3편 - Select와 Channel 심화 패턴"` |
+| `contents/go/golang-concurrency-4-sync-패키지/index.md` | `"Golang Concurrency (4) - sync 패키지 완벽 가이드"` | `"Golang Concurrency 4편 - sync 패키지 완벽 가이드"` |
+
+> 주의: `contents/go/golang-concurrency-5-context-완벽-가이드/index.md`의 title `"Golang Concurrency 5편 - Context 완벽 가이드"`는 이미 목표 포맷과 일치하므로 **변경하지 않는다**.
+
+#### 3.2 Description 필드 (3개 파일)
+
+Golang Generics 시리즈의 `description:` 필드에도 `(N)` 표기가 들어 있어 함께 수정한다.
+
+| 파일 | 변경 전 | 변경 후 |
+|---|---|---|
+| `contents/go/golang-generics-1-개요와-기본-문법/index.md` (line 3) | `"Golang Generics (1) - 개요와 기본 문법"` | `"Golang Generics 1편 - 개요와 기본 문법"` |
+| `contents/go/golang-generics-2-type-constraint-완벽-이해/index.md` (line 3) | `"Golang Generics (2) - Type Constraint 완벽 이해"` | `"Golang Generics 2편 - Type Constraint 완벽 이해"` |
+| `contents/go/golang-generics-3-실전-예제-모음/index.md` (line 3) | `"Golang Generics (3) - 실전 예제 모음"` | `"Golang Generics 3편 - 실전 예제 모음"` |
+
+> MQTT v5, Golang Concurrency 시리즈의 description은 `(N)` 표기가 없어 수정 불필요.
+
+#### 3.3 본문 내 상호 참조 링크 (4개 파일, MQTT v5)
+
+본문 하단 "다음 편 안내" 영역에서 시리즈 다음 편 제목을 참조하는 문구도 title과 일치시켜야 한다.
+
+| 파일 | 위치 | 변경 전 | 변경 후 |
+|---|---|---|---|
+| `contents/database/mqtt-v5-완벽-가이드-1-입문과-기본-아키텍처/index.md` | line 258 | `MQTT v5 완벽 가이드 (2)` | `MQTT v5 완벽 가이드 2편` |
+| `contents/database/mqtt-v5-완벽-가이드-2-topic-설계와-메시지-모델/index.md` | line 359 | `[MQTT v5 완벽 가이드 (3): QoS, Session, 재연결 전략]` | `[MQTT v5 완벽 가이드 3편: QoS, Session, 재연결 전략]` |
+| `contents/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략/index.md` | line 712 | `[MQTT v5 완벽 가이드 (4): 고급 기능과 보안]` | `[MQTT v5 완벽 가이드 4편: 고급 기능과 보안]` |
+| `contents/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안/index.md` | line 783 | `[MQTT v5 완벽 가이드 (5): Go + Paho 실전 구현과 운영]` | `[MQTT v5 완벽 가이드 5편: Go + Paho 실전 구현과 운영]` |
+
+> 마크다운 링크의 URL(괄호 안의 경로)은 슬러그 기반이므로 **변경 없음**. 링크 텍스트만 수정한다.
+> Golang Concurrency/Generics 본문에는 다음 편을 "다음 편에서는 ..." 형태로 서술할 뿐, 편 번호를 직접 표기한 링크가 없어 수정 불필요.
+
+### 4. 영향도 분석
+
+- **URL/슬러그**: 디렉토리명과 `manifest.json`(구 구조) 등 경로는 변경하지 않으므로 영구 링크, SEO, 외부 공유 링크에 영향 없음.
+- **series 메타데이터**: `series:` 값은 모두 편 번호가 없는 순수 시리즈명(`"MQTT v5 완벽 가이드"`, `"Golang Generics"`, `"Golang Concurrency"`)이므로 변경 불필요.
+- **검색 인덱스(MiniSearch)**: title/description이 검색 대상이지만 클라이언트 사이드에서 로드 시 매번 재인덱싱되므로 별도 조치 불필요.
+- **파일 개수 총계**: title 12건 + description 3건 + 본문 링크 4건 = **총 19곳 수정**
+
+### 5. 수정 체크리스트
+
+- [ ] MQTT v5 완벽 가이드 title 5건 수정
+- [ ] Golang Generics title 3건 수정
+- [ ] Golang Generics description 3건 수정
+- [ ] Golang Concurrency title 4건 수정 (5편 제외)
+- [ ] MQTT v5 본문 "다음 편 안내" 링크 4건 수정
+- [ ] 수정 후 `grep -rE "\([0-9]+\)" contents/` 로 잔존 `(N)` 포맷 최종 확인
+- [ ] UTF-8 인코딩 확인 (`file -I`)
+- [ ] 로컬 dev 서버(`npm run dev`)로 시리즈 목록·본문 렌더링 확인
+
+### 6. 작업 방식 제안
+
+- 브랜치: `chore/unify-series-title-format` (이슈 번호가 있다면 `chore/#번호-unify-series-title-format`)
+- 커밋 단위: 시리즈별(MQTT v5 / Golang Generics / Golang Concurrency) 3개 커밋 또는 전체 1개 커밋
+- PR 생성 시 `gh pr create` + HEREDOC 사용, 리뷰어 `kenshin579` 지정


### PR DESCRIPTION
## Summary

- 시리즈 글 title에서 혼재하던 편 번호 포맷 `(N)`을 기준 포맷 `N편`으로 통일
- 대상: MQTT v5 완벽 가이드(5편), Golang Generics(3편), Golang Concurrency(1~4편)
- Golang Concurrency 5편은 이미 목표 포맷이라 변경 제외

## 변경 상세 (총 19곳)

| 영역 | 건수 | 대상 |
|---|---|---|
| title 필드 | 12건 | MQTT v5 (5), Golang Generics (3), Golang Concurrency (4) |
| description 필드 | 3건 | Golang Generics |
| 본문 "다음 편 안내" 링크 | 4건 | MQTT v5 |

## 변경 제외

- 디렉토리명 / 슬러그 / URL → 영구 링크 보존
- `series:` 메타데이터 값 (편 번호 없음)
- Golang Concurrency 5편 title (이미 통일 포맷)

## 관련 문서

- PRD: `docs/start/2_title_prd.md`
- Issue: #460

## Test plan

- [ ] 잔존 `(N)` 포맷 없음 확인 (grep)
- [ ] UTF-8 인코딩 유지 확인 (file -I)
- [ ] 로컬 dev 서버로 시리즈 목록 및 본문 렌더링 확인
- [ ] MQTT v5 본문 "다음 편" 링크 경로 정상 동작 확인