### PR TITLE
fix(home): Latest 5개 확장 + Series 카드 다크모드 numbering 보정

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,7 +85,7 @@ export default async function HomePage() {
   const featured = articles[0];
   const latest = articles.slice(1, 5);
   const recent = articles.slice(5, 9);
-  const wideLatest = articles.slice(9, 13);
+  const wideLatest = articles.slice(9, 14);
 
   const featuredSeriesArticle = articles.find((a) => a.series);
   let spotlightEpisodes: Array<{ num: number; title: string; slug: string }> = [];

--- a/components/home/series-spotlight-card.tsx
+++ b/components/home/series-spotlight-card.tsx
@@ -31,8 +31,8 @@ export function SeriesSpotlightCard({ seriesName, seriesHref, episodes }: Props)
                 className={[
                   'flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-bold',
                   active
-                    ? 'bg-bento-ink text-white'
-                    : 'bg-bento-ink/10 text-bento-ink/40',
+                    ? 'bg-bento-ink text-white dark:text-bento-bg'
+                    : 'bg-bento-ink/10 text-bento-ink/40 dark:bg-bento-ink/20 dark:text-bento-ink/60',
                 ].join(' ')}
               >
                 {ep.num}


### PR DESCRIPTION
## Summary
홈 페이지 두 가지 후속 수정:

1. **WideLatestList ("이번 달 글" 섹션)**: 표시 개수 4개 → 5개로 확장
   - `articles.slice(9, 13)` → `articles.slice(9, 14)`

2. **SeriesSpotlightCard 번호 badge 다크 모드 가시성 보정**
   - 다크 모드에서 `bento-ink` 토큰이 light로 flip → 활성 badge가 흰 글씨/흰 배경 = 안 보임
   - 비활성 badge도 `bento-ink/10`, `/40`이 너무 흐림
   - 수정: 활성은 `dark:text-bento-bg` (어두운 글씨), 비활성은 opacity 상향 (`dark:bg-bento-ink/20 dark:text-bento-ink/60`)

## 변경 파일
- `app/page.tsx` (1줄)
- `components/home/series-spotlight-card.tsx` (2줄)

## 검증
- `npm run build` 통과 (1097 pages)
- 렌더된 HTML로 직접 확인
  - WideLatestList `<li>` 5개 ✓
  - 활성 badge: `bg-bento-ink text-white dark:text-bento-bg` ✓
  - 비활성 badge: `bg-bento-ink/10 text-bento-ink/40 dark:bg-bento-ink/20 dark:text-bento-ink/60` ✓

## Test plan
- [ ] 홈 페이지 "이번 달 글" 섹션 5개 표시 확인
- [ ] 다크 모드 토글 → Series 스포트라이트 카드의 번호(1, 2, 3...) 가시성 확인
- [ ] 라이트 모드는 기존과 동일하게 보이는지 확인 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)