### PR TITLE
fix(article): TOC 좌측 세로선과 텍스트 간 여백 추가

### DIFF
--- a/components/article/table-of-contents.tsx
+++ b/components/article/table-of-contents.tsx
@@ -46,14 +46,14 @@ export function TableOfContents({ items, collapsible = false }: TableOfContentsP
   }, [items]);
 
   const list = (
-    <ul className="flex flex-col border-l border-bento-ink/15 dark:border-white/15">
+    <ul className="-ml-2 flex flex-col border-l border-bento-ink/15 dark:border-white/15">
       {items.map((item) => {
         const active = item.id === activeId;
         const isTopLevel = item.level <= 2;
         return (
           <li
             key={item.id}
-            style={{ paddingLeft: `${(item.level - 2) * 0.75 + 0.75}rem` }}
+            style={{ paddingLeft: `${(item.level - 2) * 0.75 + 1.25}rem` }}
             className={
               active
                 ? '-ml-px border-l-2 border-bento-accent'


### PR DESCRIPTION
## Summary
Article 페이지 TOC에서 좌측 세로 border-l이 텍스트에 너무 가까이 붙어 있던 이슈 수정.

## 변경
`components/article/table-of-contents.tsx` (1 파일, 2 줄)

```tsx
// Before
<ul className="flex flex-col border-l border-bento-ink/15 dark:border-white/15">
  ...
  paddingLeft: `${(item.level - 2) * 0.75 + 0.75}rem`

// After
<ul className="-ml-2 flex flex-col border-l border-bento-ink/15 dark:border-white/15">
  ...
  paddingLeft: `${(item.level - 2) * 0.75 + 1.25}rem`
```

- `-ml-2` 추가 → border가 8px 왼쪽으로 이동
- paddingLeft 0.75rem → 1.25rem (top level 기준 +8px)
- 결과: border ↔ text 간 gap **12px → 20px** (text 위치는 거의 그대로 유지)

## 검증
- `npm run build` 통과 (1097 pages)
- 렌더 HTML 검증
  - `<ul class="-ml-2 flex flex-col border-l ..."` ✓
  - `<li ... style="padding-left:1.25rem"` ✓

## Test plan
- [ ] Article 페이지에서 TOC 좌측 세로선이 텍스트와 적당한 여백으로 분리되는지 확인
- [ ] 활성 항목의 녹색 굵은 border-l-2도 정상 위치 (ul border와 align)

🤖 Generated with [Claude Code](https://claude.com/claude-code)