### PR TITLE
fix(article): Hero 카드 디자인 매칭 + description 누락 복구

### DIFF
--- a/components/article/hero-card.tsx
+++ b/components/article/hero-card.tsx
@@ -28,13 +28,18 @@ export function HeroCard({
   return (
     <section className="mx-auto max-w-canvas px-6 pt-2 md:px-10">
       <div className="relative overflow-hidden rounded-card-xl bg-bento-hero-dark p-6 text-white md:p-10">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -right-32 -top-32 h-[480px] w-[480px] rounded-full opacity-50"
+          style={{ background: 'radial-gradient(circle, rgb(var(--bento-accent)) 0%, transparent 70%)' }}
+        />
         <div className="relative">
           <div className="flex flex-wrap items-center gap-2 text-[11px] text-white/70">
             <span className="rounded-full border border-white/20 bg-transparent px-3 py-1 capitalize text-white">
               {category}
             </span>
             {series && (
-              <span className="rounded-full bg-white/15 px-3 py-1 font-semibold uppercase tracking-wider text-white">
+              <span className="rounded-full bg-bento-accent px-3 py-1 font-semibold uppercase tracking-wider text-white">
                 Series · {seriesOrder ?? 1}/{totalEpisodes ?? '?'}
               </span>
             )}
@@ -61,7 +66,7 @@ export function HeroCard({
           )}
 
           <div className="mt-8 flex flex-wrap items-center gap-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-sm font-bold text-white">
+            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-bento-accent text-sm font-bold text-white">
               {author.charAt(0)}
             </span>
             <span className="text-sm font-medium text-white">{author}</span>

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -13,6 +13,7 @@ export interface ArticleFrontmatter {
   title: string;
   date: string;
   excerpt?: string;
+  description?: string;
   tags?: string[];
   series?: string;
   seriesOrder?: number;
@@ -66,9 +67,15 @@ export async function parseMarkdown(markdown: string, slug: string): Promise<Art
 
   const firstImage = extractFirstImage(content);
 
+  const frontmatter = data as ArticleFrontmatter;
+  // Normalize description → excerpt (markdown 파일은 description 키 사용, UI는 excerpt 사용)
+  if (!frontmatter.excerpt && frontmatter.description) {
+    frontmatter.excerpt = frontmatter.description;
+  }
+
   return {
     slug,
-    frontmatter: data as ArticleFrontmatter,
+    frontmatter,
     content,
     html,
     firstImage,


### PR DESCRIPTION
## Summary
Article 페이지 상단 Hero 카드를 prototype 디자인에 다시 정합. 이전에 monochrome으로 변경했던 SERIES badge / avatar / radial glow를 그린 accent로 복원하고, description이 노출되지 않던 버그 수정.

## 변경 내용

### 1. description 누락 복구 (`lib/markdown.ts`)
Markdown frontmatter는 `description:` 키를 사용하지만 `ArticleFrontmatter` 타입은 `excerpt?:` 만 정의 → UI 단에서 항상 undefined 였음.

```ts
// 추가
export interface ArticleFrontmatter {
  ...
  excerpt?: string;
  description?: string;  // ← 신규
}

// parseMarkdown에서 자동 매핑
if (!frontmatter.excerpt && frontmatter.description) {
  frontmatter.excerpt = frontmatter.description;
}
```

### 2. Hero 카드 디자인 매칭 (`components/article/hero-card.tsx`)
| 요소 | Before | After |
|---|---|---|
| SERIES badge | `bg-white/15` (회색) | `bg-bento-accent` (그린) |
| Author avatar | `bg-white/10` (회색) | `bg-bento-accent` (그린) |
| 우측 상단 glow | (없음) | green radial gradient (FeaturedCard와 동일 패턴) |

## 검증
- `npm run build` 통과 (1097 pages)
- 실제 article HTML 렌더 검증
  - `/golang-concurrency-2-channel-완전-정복`
    - SERIES badge: `bg-bento-accent` ✓
    - Avatar: `bg-bento-accent` ✓
    - Radial gradient: `radial-gradient(circle, rgb(var(--bento-accent))...` ✓
    - Excerpt: "Go Channel의 기본 동작부터 buffered/unbuffered 차이..." ✓
  - `/claude-code-superpowers-완벽-가이드`
    - Excerpt: "Claude Code superpowers plugin으로 Todo 웹앱을..." ✓

## Test plan
- [ ] Article 페이지 hero 카드 그린 SERIES pill / avatar / radial glow 확인
- [ ] 모든 article 페이지에 description (excerpt) 표시 확인
- [ ] OpenGraph description 정상 (`generateMetadata`도 frontmatter.excerpt 사용 → 자동 적용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)