### PR TITLE
fix(footer): SNS URL 수정 (Instagram, LinkedIn)

### DIFF
--- a/config/social.ts
+++ b/config/social.ts
@@ -8,12 +8,12 @@ export const socialLinks = [
   },
   {
     name: 'Instagram',
-    url: 'https://instagram.com/advenoh',
+    url: 'https://www.instagram.com/frank.photosnap/',
     icon: Instagram
   },
   {
     name: 'LinkedIn',
-    url: 'https://linkedin.com/in/advenoh',
+    url: 'https://www.linkedin.com/in/frank-oh-abb80b10/',
     icon: Linkedin
   },
 ];

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -20,7 +20,7 @@ export const socialLinks: SocialLink[] = [
   },
   {
     name: 'Instagram',
-    url: 'https://www.instagram.com/frank.photosnap',
+    url: 'https://www.instagram.com/frank.photosnap/',
     icon: 'Instagram',
     ariaLabel: 'Instagram 프로필 방문'
   },


### PR DESCRIPTION
## Summary
Footer에 노출되던 Instagram / LinkedIn URL이 잘못된 핸들 (`advenoh`)로 설정되어 있어 정상 프로필로 수정.

| SNS | Before | After |
|---|---|---|
| Instagram | `https://instagram.com/advenoh` | `https://www.instagram.com/frank.photosnap/` |
| LinkedIn | `https://linkedin.com/in/advenoh` | `https://www.linkedin.com/in/frank-oh-abb80b10/` |

## 변경 파일
- `config/social.ts` — `SiteFooter`가 import (footer SNS 아이콘)
- `lib/site-config.ts` — `SocialLinks`가 import (Instagram trailing `/` 정합성)

## 검증
- `npm run build` 통과 (1097 pages)
- 빌드 산출물 `out/index.html`에서 새 URL만 노출 확인
  - `https://www.instagram.com/frank.photosnap/` ✓
  - `https://www.linkedin.com/in/frank-oh-abb80b10/` ✓

## Test plan
- [ ] 홈 footer에서 Instagram / LinkedIn 아이콘 클릭 → 정상 프로필 페이지로 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)