### PR TITLE
fix(article): 본문 헤딩 색상 검정 복구

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -591,6 +591,13 @@ pre[class*="language-"] {
   text-decoration-thickness: 2px;
 }
 
+/* rehypeAutolinkHeadings wraps headings in <a> — keep them black, no underline */
+.prose-bento :is(h1, h2, h3, h4) a,
+.prose-bento :is(h1, h2, h3, h4) a:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
 .prose-bento ul,
 .prose-bento ol {
   margin-bottom: 1.25rem;


### PR DESCRIPTION
## Summary
Article 본문의 H1~H4 헤딩이 green accent로 렌더되던 이슈 수정 (디자인은 검정).

## 원인
`rehypeAutolinkHeadings({ behavior: 'wrap' })`가 모든 헤딩을 `<a>`로 감싸는데, `.prose-bento a { color: var(--bento-accent) }` 규칙이 그 anchor에도 적용 → 헤딩까지 green이 됨.

```html
<h2 id="..."><a href="#...">1. Channel 개념과 생성</a></h2>
```

## 수정 (`app/globals.css`)
헤딩 내부 anchor만 부모 색을 inherit + 밑줄 제거 (단락 내 일반 inline link는 그대로 green 유지):

```css
.prose-bento :is(h1, h2, h3, h4) a,
.prose-bento :is(h1, h2, h3, h4) a:hover {
  color: inherit;
  text-decoration: none;
}
```

## 검증
- `npm run build` 통과 (1097 pages)
- 컴파일된 CSS 번들에서 규칙 출력 확인
- Article HTML에서 H2 구조 확인: `<h2><a>...</a></h2>` → 새 규칙으로 검정 inherit

## Test plan
- [ ] Article 페이지에서 H1~H4 헤딩이 검정으로 표시
- [ ] 단락 내 inline 링크는 green 유지 (회귀 없음)
- [ ] 헤딩 클릭 시 anchor 동작 (#id) 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)