### PR TITLE
fix(article): 본문 헤딩 두께 강화 및 Pretendard 로딩 버그 수정

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -543,8 +543,8 @@ pre[class*="language-"] {
 
 .prose-bento h1 {
   font-size: 2.25rem;
-  font-weight: 700;
-  letter-spacing: -0.025em;
+  font-weight: 900;
+  letter-spacing: -0.035em;
   margin-top: 2rem;
   margin-bottom: 1rem;
   scroll-margin-top: 5rem;
@@ -552,8 +552,8 @@ pre[class*="language-"] {
 
 .prose-bento h2 {
   font-size: 1.875rem;
-  font-weight: 700;
-  letter-spacing: -0.025em;
+  font-weight: 900;
+  letter-spacing: -0.035em;
   margin-top: 2.5rem;
   margin-bottom: 0.75rem;
   scroll-margin-top: 5rem;
@@ -561,8 +561,8 @@ pre[class*="language-"] {
 
 .prose-bento h3 {
   font-size: 1.5rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-weight: 800;
+  letter-spacing: -0.03em;
   margin-top: 2rem;
   margin-bottom: 0.5rem;
   scroll-margin-top: 5rem;
@@ -570,7 +570,8 @@ pre[class*="language-"] {
 
 .prose-bento h4 {
   font-size: 1.25rem;
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
   scroll-margin-top: 5rem;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko" suppressHydrationWarning>
+    <html lang="ko" suppressHydrationWarning className={`${pretendard.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}>
       {/* JSON-LD WebSite Schema */}
       <Script
         id="website-schema"
@@ -105,7 +105,7 @@ export default function RootLayout({
         }}
       />
 
-      <body className={`${pretendard.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}>
+      <body>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"


### PR DESCRIPTION
## Summary

### 1. 본문 헤딩 두께 강화 (`app/globals.css`)
디자인 스펙 대비 헤딩이 가볍게 느껴지는 문제를 수정:
- `h1`, `h2`: `font-weight` 700 → **900** (Pretendard Black)
- `h3`: `font-weight` 700 → **800** (ExtraBold)
- `h4`: `font-weight` 600 → **700** (Bold)
- `letter-spacing`도 디자인에 맞춰 더 타이트하게 조정

### 2. Pretendard 폰트 로딩 버그 수정 (`app/layout.tsx`)
실제 페이지가 Pretendard가 아닌 시스템 fallback(`Apple SD Gothic Neo`)으로 렌더링되던 버그:

- **원인**: `app/globals.css`의 `:root`에서 `--font-sans: var(--font-pretendard), ...`로 정의했는데, `--font-pretendard`는 Next.js localFont가 생성한 module class를 통해 `<body>`에만 설정됨
- `:root` 스코프에서 `var(--font-pretendard)`가 resolve되지 않아 전체 `--font-sans` 선언이 invalid 처리됨
- 결과적으로 본문/헤딩 모두 시스템 fallback으로 렌더링되어, 헤딩 weight를 올려도 시각적 차이가 거의 없었음
- **수정**: localFont variable className을 `<body>` → `<html>`로 이동하여 `:root` 스코프에서 변수가 resolve되도록 함

### 검증 결과 (chrome-devtools)
- `--font-sans` 정상 resolve: `"pretendard","pretendard Fallback",Inter,system-ui,...`
- `document.fonts` Pretendard status: `loaded`
- 헤딩 computed style: `font-family: pretendard`, `font-weight: 900`

## Test plan
- [ ] `npm run build && npm start`로 production 빌드 검증
- [ ] 아티클 페이지에서 h1/h2/h3 두께가 디자인 시안과 일치하는지 확인
- [ ] DevTools에서 computed `font-family`가 Pretendard로 표시되는지 확인
- [ ] 다크 모드에서도 동일하게 적용되는지 확인
- [ ] 본문 텍스트도 Pretendard로 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)