### PR TITLE
fix(article): mermaid 다이어그램 렌더링 안 되는 문제 수정

### DIFF
--- a/components/article/mermaid-renderer.tsx
+++ b/components/article/mermaid-renderer.tsx
@@ -13,9 +13,9 @@ export function MermaidRenderer({ html }: MermaidRendererProps) {
   const { resolvedTheme } = useTheme();
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    const container = containerRef.current;
+    if (!container) return;
 
-    // Mermaid 초기화
     mermaid.initialize({
       startOnLoad: false,
       theme: resolvedTheme === 'dark' ? 'dark' : 'default',
@@ -23,33 +23,53 @@ export function MermaidRenderer({ html }: MermaidRendererProps) {
       fontFamily: 'inherit',
     });
 
-    // language-mermaid 코드 블록 찾기
-    const codeBlocks = containerRef.current.querySelectorAll(
-      'code.language-mermaid'
-    );
+    // mermaid 코드를 먼저 수집한다.
+    const sources = Array.from(
+      container.querySelectorAll<HTMLElement>('code.language-mermaid')
+    )
+      .map((code) => code.textContent || '')
+      .filter((code) => code.trim());
 
-    codeBlocks.forEach(async (codeBlock, index) => {
-      const pre = codeBlock.parentElement;
-      if (!pre || pre.tagName !== 'PRE') return;
+    if (sources.length === 0) return;
 
-      const code = codeBlock.textContent || '';
-      if (!code.trim()) return;
+    let cancelled = false;
 
-      try {
-        const id = `mermaid-diagram-${index}-${Date.now()}`;
-        const { svg } = await mermaid.render(id, code);
+    (async () => {
+      // 모든 mermaid 렌더링을 병렬로 실행한 뒤 SVG 결과만 모은다.
+      const results = await Promise.all(
+        sources.map(async (code, index) => {
+          try {
+            const id = `mermaid-diagram-${index}-${Date.now()}`;
+            const { svg } = await mermaid.render(id, code);
+            return svg;
+          } catch (error) {
+            console.error('Mermaid 렌더링 실패:', error);
+            return null;
+          }
+        })
+      );
+      if (cancelled) return;
 
-        // pre 요소를 mermaid 다이어그램으로 교체
+      // await가 끝난 뒤 React가 dangerouslySetInnerHTML을 재적용했을 수 있으므로
+      // pre 요소를 다시 조회하여 동기적으로 교체한다.
+      const pres = container.querySelectorAll<HTMLElement>('pre.language-mermaid');
+      results.forEach((svg, index) => {
+        const pre = pres[index];
+        if (!pre || !document.contains(pre)) return;
+        if (!svg) {
+          pre.classList.add('mermaid-error');
+          return;
+        }
         const wrapper = document.createElement('div');
         wrapper.className = 'mermaid-diagram';
         wrapper.innerHTML = svg;
         pre.replaceWith(wrapper);
-      } catch (error) {
-        console.error('Mermaid 렌더링 실패:', error);
-        // 에러 시 원본 코드 블록 유지하고 에러 표시
-        pre.classList.add('mermaid-error');
-      }
-    });
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [html, resolvedTheme]);
 
   return (


### PR DESCRIPTION
## Summary

### 증상
아티클 본문의 mermaid 다이어그램이 SVG로 변환되지 않고 코드 블록 그대로 표시되는 문제.

### 원인 (디버그 로그로 확정)
`MermaidRenderer`의 useEffect 안에서 `await mermaid.render()`를 호출하는 동안 microtask가 양보됨. 이때 React가 hydration 중에 `dangerouslySetInnerHTML`을 재적용하면서 useEffect 시작 시점에 잡아둔 원본 `<pre>` 노드들이 **detach** 됨. await 이후 `pre.replaceWith()`가 분리된 노드에 호출되어 silent no-op이 됨.

디버그 로그 결과:
- await 전: `pre attached: true`
- await 후: `pre still attached: false`
- replaceWith 직후: `wrapper in doc: false`

### 수정
1. mermaid 코드 소스를 먼저 sync로 수집
2. `Promise.all`로 SVG 렌더링만 병렬 실행
3. **모든 await 완료 후** container에서 `<pre>`를 다시 query하여 단일 sync 루프에서 한 번에 replace (await 사이에 DOM mutation 없음)
4. unmount/re-render 대비 `cancelled` cleanup flag 추가

### 검증 (chrome-devtools)
- production 빌드 후 직접 페이지 확인
- `codeBlocks: 0, diagrams: 3` — 3개 mermaid 다이어그램 모두 정상 SVG로 렌더링됨
- 시각적으로도 flowchart 정상 표시 확인

## Test plan
- [ ] `npm run build && npm start`로 production 빌드 검증
- [ ] mermaid 다이어그램이 포함된 아티클(예: claude-code-superpowers-완벽-가이드)에서 모든 다이어그램이 SVG로 렌더링되는지 확인
- [ ] 다크 모드에서도 정상 렌더링 확인
- [ ] 페이지 내 mermaid 코드 블록이 여러 개인 경우에도 모두 렌더링되는지 확인
- [ ] 잘못된 mermaid 문법인 경우 `.mermaid-error` 클래스가 부여되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)