### PR TITLE
fix(header): Cmd+K(Ctrl+K) 검색 단축키 동작 추가

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Search, Rss, Menu, Sun, Moon } from 'lucide-react';
@@ -36,6 +36,17 @@ export function SiteHeader() {
   const pathname = usePathname();
 
   const toggleTheme = () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setSearchOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary

### 증상
헤더 검색 버튼에 `⌘K` 키 안내 배지는 표시되지만, 실제로 Cmd+K를 눌러도 검색 dialog가 열리지 않는 문제.

### 원인
- `SiteHeader`에 `⌘K` kbd 표시만 있고 글로벌 keydown 리스너가 없음
- `CommandK` 컴포넌트의 keydown 리스너는 `open === true`일 때만 동작 (dialog 내부의 Escape/Arrow/Enter용)
- 어디에도 `(Meta|Ctrl)+K`로 `setSearchOpen(true)`를 호출하는 코드가 없었음

### 수정
`SiteHeader`에 `useEffect`로 글로벌 keydown 리스너 추가:
- Meta+K 또는 Ctrl+K 입력 시 `setSearchOpen` 토글 (열기/닫기 모두 가능)
- `e.preventDefault()`로 브라우저 기본 동작 차단 (Chrome 주소창 포커스 등)
- unmount 시 리스너 해제

### 검증 (chrome-devtools)
- production 빌드 후 `Meta+K` → dialog 열림 (`dialogOpen: true`)
- 다시 `Meta+K` → 닫힘 (`dialogStillOpen: false`)
- 한 번 더 `Meta+K` → 다시 열림 (스크린샷 확인)

## Test plan
- [ ] macOS에서 Cmd+K로 검색 dialog가 열리는지 확인
- [ ] Windows/Linux에서 Ctrl+K로 검색 dialog가 열리는지 확인
- [ ] 검색 dialog가 열린 상태에서 Cmd+K로 다시 닫히는지 확인
- [ ] 검색 input에 포커스가 있을 때 Cmd+K가 정상 작동하는지 확인
- [ ] Escape로 닫고 다시 Cmd+K로 열기 반복 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)