### PR TITLE
fix(article): language 지정 없는 코드 블록 가독성 문제 수정

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -453,20 +453,20 @@ pre[class*="language-"] {
   text-decoration: underline;
 }
 
-/* 인라인 코드 스타일 (backtick으로 감싼 텍스트) */
-.prose code:not([class*="language-"]) {
+/* 인라인 코드 스타일 (backtick으로 감싼 텍스트, pre 바깥만) */
+.prose :not(pre) > code:not([class*="language-"]) {
   @apply font-mono text-sm px-1.5 py-0.5 rounded;
   background-color: hsl(var(--muted));
   color: hsl(var(--foreground));
 }
 
 /* Tailwind Typography가 추가하는 backtick 문자 제거 */
-.prose code:not([class*="language-"])::before,
-.prose code:not([class*="language-"])::after {
+.prose :not(pre) > code:not([class*="language-"])::before,
+.prose :not(pre) > code:not([class*="language-"])::after {
   content: none;
 }
 
-/* 코드 블록 안의 인라인 코드는 별도 배경 없음 */
+/* 코드 블록 안의 코드는 배경/패딩 제거 (pre 스타일 상속) */
 .prose pre code {
   @apply p-0 bg-transparent;
 }
@@ -631,8 +631,8 @@ pre[class*="language-"] {
   font-style: italic;
 }
 
-/* Inline code (not language-*) */
-.prose-bento code:not([class*="language-"]) {
+/* Inline code (pre 바깥의 인라인 code만) */
+.prose-bento :not(pre) > code:not([class*="language-"]) {
   font-family: var(--font-mono);
   font-size: 0.875em;
   padding: 0.125em 0.375em;
@@ -641,12 +641,12 @@ pre[class*="language-"] {
   color: rgb(var(--bento-ink));
 }
 
-.dark .prose-bento code:not([class*="language-"]) {
+.dark .prose-bento :not(pre) > code:not([class*="language-"]) {
   background: rgb(255 255 255 / 0.1);
 }
 
-.prose-bento code:not([class*="language-"])::before,
-.prose-bento code:not([class*="language-"])::after {
+.prose-bento :not(pre) > code:not([class*="language-"])::before,
+.prose-bento :not(pre) > code:not([class*="language-"])::after {
   content: none;
 }
 
@@ -706,7 +706,7 @@ pre[class*="language-"] {
 /* Article 코드블록 — 다크 카드 + 언어 라벨                     */
 /* ========================================================== */
 
-.prose-bento pre[class*="language-"] {
+.prose-bento pre {
   position: relative;
   margin: 1.5rem 0;
   padding: 2rem 1.25rem 1.25rem;
@@ -719,7 +719,7 @@ pre[class*="language-"] {
   line-height: 1.65;
 }
 
-.prose-bento pre[class*="language-"] code {
+.prose-bento pre code {
   font-family: inherit;
   font-size: inherit;
   background: transparent;
@@ -728,7 +728,7 @@ pre[class*="language-"] {
 }
 
 /* 언어 라벨 (top-right) */
-.prose-bento pre[class*="language-"]::before {
+.prose-bento pre::before {
   position: absolute;
   top: 0.5rem;
   right: 0.875rem;
@@ -737,7 +737,7 @@ pre[class*="language-"] {
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: #7A7770;
-  content: 'code';
+  content: 'text';
 }
 
 .prose-bento pre.language-go::before        { content: 'go'; }


### PR DESCRIPTION
## Summary

### 증상
디렉토리 트리처럼 language 지정 없는 plain code block이 다크 배경에 다크 글자로 렌더링되어 거의 보이지 않던 문제.

(예: claude-code-superpowers 가이드의 4.3 디렉토리 구조 섹션)

### 원인
1. **인라인 code 규칙의 specificity가 더 높았음**
   - `.prose code:not([class*="language-"])` specificity = (0,2,1)
   - `.prose pre code` specificity = (0,1,2)
   - 결과적으로 pre 안의 code에도 인라인 스타일(다크 글자 + 옅은 배경)이 우선 적용
2. **다크 카드 스타일이 language 지정된 pre에만 적용됨**
   - `.prose-bento pre[class*="language-"]` 셀렉터가 language 클래스 조건 필요
   - language 없는 pre는 다크 카드 스타일도 못 받고, 안의 code는 다크 글자로 렌더링 → 가독성 망가짐

### 수정
- `.prose-bento pre[class*="language-"]` → `.prose-bento pre`로 셀렉터 확장
  - language 없는 plain pre도 다크 카드 스타일 적용
  - default 라벨은 `text` 표시
- `.prose code:not([class*="language-"])` 와 `.prose-bento code:not([class*="language-"])` 규칙에 `:not(pre) >` 추가
  - 인라인 code 스타일이 pre 안 code에 침범하지 못하도록 스코프 제한

### 검증 (chrome-devtools)
4.3 디렉토리 구조 섹션의 plain code block에서:
- `preBg: rgb(15, 15, 15)` ✓ 다크 카드
- `codeColor: rgb(232, 230, 225)` ✓ 밝은 글자
- `codeBg: rgba(0, 0, 0, 0)` ✓ 투명 (다크 카드 배경 그대로 보임)
- `::before content: "text"` ✓ language 라벨

## Test plan
- [ ] 4.3 디렉토리 구조 등 plain code block이 다크 카드에 밝은 글자로 보이는지 확인
- [ ] language 지정된 code block(go, bash, json 등)이 기존과 동일하게 보이는지 확인 (라벨 포함)
- [ ] 본문 인라인 code (`` ` ``로 감싼 텍스트)가 기존 스타일대로 옅은 배경에 다크 글자로 보이는지 확인
- [ ] 다크 모드에서도 인라인 code 배경이 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)