### PR TITLE
feat(article): 시리즈 네비게이션을 본문 위로 이동

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -138,6 +138,15 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         tags={manifestArticle?.tags}
       />
 
+      {/* Series nav (only when series article) — 본문 위에 배치하여 시리즈 맥락을 먼저 보여줌 */}
+      {manifestArticle?.series && seriesEpisodes.length > 1 && (
+        <SeriesNavigation
+          seriesName={manifestArticle.series}
+          articles={seriesEpisodes}
+          currentSlug={manifestArticle.slug}
+        />
+      )}
+
       {/* Body + sticky TOC (desktop) / collapsible TOC (mobile) */}
       <section className="mx-auto mt-12 max-w-canvas px-6 md:px-10">
         {toc.length > 0 && (
@@ -161,15 +170,6 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
           )}
         </div>
       </section>
-
-      {/* Series nav (only when series article) */}
-      {manifestArticle?.series && seriesEpisodes.length > 1 && (
-        <SeriesNavigation
-          seriesName={manifestArticle.series}
-          articles={seriesEpisodes}
-          currentSlug={manifestArticle.slug}
-        />
-      )}
 
       {/* Prev/Next (only when series article and has prev or next) */}
       {(prev || next) && (


### PR DESCRIPTION
## Summary

### 변경 내용
시리즈 글의 `SeriesNavigation` 컴포넌트 위치를 본문 아래에서 **본문 위(HeroCard 직후)** 로 이동.

### 이유
- 기존: 본문을 다 읽은 후에야 시리즈 전체 episode 목록과 현재 위치를 확인할 수 있어 글 진입 시점에 컨텍스트 파악이 어려움
- 변경 후: HeroCard 바로 다음에 시리즈 네비게이션이 나와서 독자가 글의 위치(예: 시리즈 3편 중 1번째)와 다른 episode를 먼저 확인한 뒤 본문을 읽을 수 있음

### 페이지 구조 변화
| 위치 | 기존 | 변경 후 |
|---|---|---|
| 1 | HeroCard | HeroCard |
| 2 | 본문 + TOC | **SeriesNavigation** ← 이동 |
| 3 | SeriesNavigation | 본문 + TOC |
| 4 | PrevNext | PrevNext |
| 5 | RelatedCards | RelatedCards |

`PrevNext`와 `RelatedCards`는 본문 아래에 그대로 유지 (글을 다 읽은 후 다음 글로 넘어가는 흐름은 자연스러우므로).

### 검증 (chrome-devtools)
- `seriesNavY: 561` (HeroCard 아래, 본문 위)
- `articleY: 826`
- 시각적으로도 HeroCard 직후 SeriesNavigation 카드 정상 표시 확인

## Test plan
- [ ] 시리즈 글에서 HeroCard 바로 아래에 SeriesNavigation이 표시되는지 확인
- [ ] 비-시리즈 글에서는 SeriesNavigation이 표시되지 않는지 확인 (조건부 렌더링 유지)
- [ ] 본문 하단에 PrevNext, RelatedCards가 정상 표시되는지 확인
- [ ] 모바일/태블릿 반응형에서도 정상 표시되는지 확인
- [ ] 시리즈 내 현재 글이 ★ 마커로 강조되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)