### PR TITLE
feat(tags): Tags 페이지를 디자인 스펙에 맞춰 bento 그리드로 재구성

### DIFF
--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { getAllArticles } from '@/lib/articles';
 import { Breadcrumb } from '@/components/breadcrumb';
+import { TagsBentoGrid, type TagEntry } from '@/components/tags-bento-grid';
 
 export const metadata = {
   title: "Tags | Frank's IT Blog",
@@ -13,82 +14,152 @@ const FOCUS_RING =
 export default async function TagsPage() {
   const all = await getAllArticles();
 
-  // Aggregate tag counts (raw, case-sensitive)
-  const counts = new Map<string, number>();
+  // tag별 count + 관련 카테고리 + 최근 사용일 집계
+  type Agg = { count: number; categories: Map<string, number>; lastUsed: string };
+  const agg = new Map<string, Agg>();
+
   for (const a of all) {
     if (!a.tags) continue;
     for (const t of a.tags) {
-      counts.set(t, (counts.get(t) ?? 0) + 1);
+      const existing = agg.get(t) ?? { count: 0, categories: new Map(), lastUsed: '' };
+      existing.count += 1;
+      existing.categories.set(a.category, (existing.categories.get(a.category) ?? 0) + 1);
+      if (a.date > existing.lastUsed) existing.lastUsed = a.date;
+      agg.set(t, existing);
     }
   }
 
-  const entries = Array.from(counts.entries())
-    .map(([tag, count]) => ({ tag, count }))
-    .sort((a, b) => a.tag.localeCompare(b.tag, 'ko'));
+  const entries: TagEntry[] = Array.from(agg.entries()).map(([tag, v]) => ({
+    tag,
+    count: v.count,
+    categories: Array.from(v.categories.entries())
+      .sort((x, y) => y[1] - x[1])
+      .map(([cat]) => cat),
+    lastUsed: v.lastUsed,
+  }));
 
-  const maxCount = entries.reduce((acc, e) => Math.max(acc, e.count), 0);
+  const totalUses = entries.reduce((s, e) => s + e.count, 0);
+  const byCount = [...entries].sort(
+    (a, b) => b.count - a.count || a.tag.localeCompare(b.tag, 'ko'),
+  );
+  const top5 = byCount.slice(0, 5);
+  const heroCloud = byCount.slice(0, 24);
 
   return (
     <main className="min-h-screen bg-bento-bg pb-20">
-      <Breadcrumb
-        items={[
-          { label: 'Home', href: '/' },
-          { label: 'Tags' },
-        ]}
-      />
+      <Breadcrumb items={[{ label: 'Home', href: '/' }, { label: 'Tags' }]} />
 
-      {/* Hero */}
+      {/* Hero — two columns */}
       <section className="mx-auto max-w-canvas px-6 md:px-10">
-        <div className="relative overflow-hidden rounded-card-xl bg-bento-hero-dark p-8 text-white md:p-12">
-          <div
-            aria-hidden="true"
-            className="absolute -right-32 -top-32 h-[420px] w-[420px] rounded-full opacity-55"
-            style={{ background: 'radial-gradient(circle, rgb(var(--bento-accent)) 0%, transparent 70%)' }}
-          />
-          <div className="relative">
-            <p className="text-[12px] uppercase tracking-[0.12em] text-white/70">All tags</p>
-            <div className="my-4 text-[56px] font-bold leading-[0.95] tracking-tightest md:text-[88px]">
-              #{entries.length}
-              <span className="text-white/40"> tags</span>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[2fr_1fr]">
+          {/* Left: dark hero with inline tag cloud */}
+          <div className="relative overflow-hidden rounded-card-xl bg-bento-hero-dark p-8 text-white md:p-12">
+            <div
+              aria-hidden="true"
+              className="absolute -right-32 -top-32 h-[420px] w-[420px] rounded-full opacity-55"
+              style={{
+                background:
+                  'radial-gradient(circle, rgb(var(--bento-accent)) 0%, transparent 70%)',
+              }}
+            />
+            <div className="relative">
+              <p className="text-[12px] uppercase tracking-[0.12em] text-white/70">
+                Index
+              </p>
+              <h1 className="my-4 text-[56px] font-bold leading-[0.95] tracking-tightest md:text-[88px]">
+                Tags.
+              </h1>
+              <p className="max-w-lg text-base leading-relaxed text-white/75 md:text-lg">
+                카테고리를 가로지르는 주제들. 같은 #{top5[0]?.tag ?? 'tag'} 태그라도 여러
+                카테고리에 걸쳐 발견됩니다.
+              </p>
+
+              {heroCloud.length > 0 && (
+                <div className="mt-8 flex flex-wrap gap-x-3 gap-y-2 leading-tight">
+                  {heroCloud.map((e, i) => {
+                    const size =
+                      i < 3
+                        ? 'text-[36px] font-extrabold text-white md:text-[44px]'
+                        : i < 7
+                          ? 'text-[24px] font-bold text-white/85 md:text-[28px]'
+                          : 'text-[16px] font-medium text-white/55 md:text-[18px]';
+                    return (
+                      <Link
+                        key={e.tag}
+                        href={`/tags/${encodeURIComponent(e.tag)}`}
+                        className={[
+                          'no-underline tracking-tight transition hover:text-white',
+                          size,
+                          FOCUS_RING,
+                        ].join(' ')}
+                      >
+                        #{e.tag}
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
             </div>
-            <p className="max-w-lg text-base leading-relaxed text-white/75 md:text-lg">
-              {all.length}편의 글을 가로지르는 주제어. 클릭해서 관련된 모든 글을 모아보세요.
-            </p>
+          </div>
+
+          {/* Right: stats + top 5 */}
+          <div className="flex flex-col gap-4">
+            <div className="rounded-card-xl bg-bento-butter p-7 text-bento-ink">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-bento-ink/60">
+                At a glance
+              </p>
+              <div className="mt-4 grid grid-cols-2 gap-4">
+                <div>
+                  <div className="text-4xl font-extrabold leading-none md:text-[44px]">
+                    {entries.length}
+                  </div>
+                  <div className="mt-1 text-[12px] text-bento-ink/70">전체 태그</div>
+                </div>
+                <div>
+                  <div className="text-4xl font-extrabold leading-none md:text-[44px]">
+                    {totalUses}
+                  </div>
+                  <div className="mt-1 text-[12px] text-bento-ink/70">총 사용 횟수</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex-1 rounded-card-xl bg-bento-card p-6 text-bento-ink">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-bento-ink/60">
+                Top 5 — Most written
+              </p>
+              <ol className="mt-4 space-y-2.5">
+                {top5.map((e, i) => (
+                  <li key={e.tag}>
+                    <Link
+                      href={`/tags/${encodeURIComponent(e.tag)}`}
+                      className={[
+                        'flex items-center justify-between gap-3 rounded-card-sm px-2 py-1.5 no-underline transition hover:bg-bento-ink/5',
+                        FOCUS_RING,
+                      ].join(' ')}
+                    >
+                      <span className="flex items-center gap-3">
+                        <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-bento-ink text-[10px] font-bold text-white">
+                          {i + 1}
+                        </span>
+                        <span className="text-[14px] font-medium text-bento-ink">
+                          #{e.tag}
+                        </span>
+                      </span>
+                      <span className="font-mono text-[11px] text-bento-dim">
+                        {e.count}편
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ol>
+            </div>
           </div>
         </div>
       </section>
 
-      {/* Tag cloud (chips, 3-tier sizes) */}
-      {entries.length > 0 && (
-        <section className="mx-auto mt-8 max-w-canvas px-6 md:px-10">
-          <div className="flex flex-wrap gap-2 rounded-card-xl bg-bento-card p-6 md:p-8">
-            {entries.map((e) => {
-              const weight = maxCount > 0 ? e.count / maxCount : 0;
-              const sizeClass =
-                weight > 0.66
-                  ? 'text-2xl font-semibold'
-                  : weight > 0.33
-                    ? 'text-lg font-medium'
-                    : 'text-sm';
-              return (
-                <Link
-                  key={e.tag}
-                  href={`/tags/${encodeURIComponent(e.tag)}`}
-                  className={[
-                    'inline-flex items-baseline gap-1.5 rounded-full bg-bento-ink/[0.05] px-4 py-2 text-bento-ink no-underline transition hover:bg-bento-ink/10 dark:bg-white/10 dark:hover:bg-white/15',
-                    sizeClass,
-                    FOCUS_RING,
-                  ].join(' ')}
-                >
-                  <span className="text-bento-accent">#</span>
-                  <span>{e.tag}</span>
-                  <span className="font-mono text-[11px] font-normal text-bento-dim">{e.count}</span>
-                </Link>
-              );
-            })}
-          </div>
-        </section>
-      )}
+      {/* Bento grid (sortable) */}
+      {entries.length > 0 && <TagsBentoGrid entries={entries} />}
     </main>
   );
 }

--- a/components/tags-bento-grid.tsx
+++ b/components/tags-bento-grid.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+
+export interface TagEntry {
+  tag: string;
+  count: number;
+  categories: string[];
+  lastUsed: string;
+}
+
+type SortMode = 'count' | 'alpha' | 'recent';
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
+
+// rank별 컬러 (sage → butter → rose → lavender → cream 순환)
+const COLOR_CYCLE = [
+  'bg-bento-sage',
+  'bg-bento-butter',
+  'bg-bento-rose',
+  'bg-bento-lavender',
+  'bg-bento-cream',
+] as const;
+
+function colorFor(rank: number): string {
+  return COLOR_CYCLE[rank % COLOR_CYCLE.length];
+}
+
+// rank별 크기 tier
+// 0-1: 2-col span large card
+// 2-4: 1-col medium card
+// 5-10: 1-col compact card
+// 11+: 1/2-col compact pill-ish card (small grid)
+function tierFor(rank: number): 'xl' | 'lg' | 'md' | 'sm' {
+  if (rank < 2) return 'xl';
+  if (rank < 5) return 'lg';
+  if (rank < 11) return 'md';
+  return 'sm';
+}
+
+export function TagsBentoGrid({ entries }: { entries: TagEntry[] }) {
+  const [sortMode, setSortMode] = useState<SortMode>('count');
+
+  const sorted = useMemo(() => {
+    const list = [...entries];
+    if (sortMode === 'count') {
+      list.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag, 'ko'));
+    } else if (sortMode === 'alpha') {
+      list.sort((a, b) => a.tag.localeCompare(b.tag, 'ko'));
+    } else {
+      list.sort((a, b) => b.lastUsed.localeCompare(a.lastUsed) || b.count - a.count);
+    }
+    return list;
+  }, [entries, sortMode]);
+
+  // Split for layout: count-sort일 때만 bento tier가 의미 있음
+  const useBento = sortMode === 'count';
+
+  return (
+    <section className="mx-auto mt-12 max-w-canvas px-6 md:px-10">
+      {/* Header row */}
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <p className="text-[15px] text-bento-ink">
+          <span className="font-semibold">{entries.length}</span>
+          <span className="text-bento-dim"> 개의 태그</span>
+        </p>
+        <div className="flex gap-1 rounded-full bg-bento-ink/[0.06] p-1 dark:bg-white/10">
+          <SortTab active={sortMode === 'count'} onClick={() => setSortMode('count')}>
+            By count
+          </SortTab>
+          <SortTab active={sortMode === 'alpha'} onClick={() => setSortMode('alpha')}>
+            A → Z
+          </SortTab>
+          <SortTab active={sortMode === 'recent'} onClick={() => setSortMode('recent')}>
+            Recently used
+          </SortTab>
+        </div>
+      </div>
+
+      {useBento ? <BentoLayout sorted={sorted} /> : <FlatLayout sorted={sorted} />}
+    </section>
+  );
+}
+
+function BentoLayout({ sorted }: { sorted: TagEntry[] }) {
+  const xl = sorted.slice(0, 2);
+  const lg = sorted.slice(2, 5);
+  const md = sorted.slice(5, 11);
+  const sm = sorted.slice(11);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* XL: 2-col span large cards */}
+      {xl.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {xl.map((e, i) => (
+            <TagCard key={e.tag} entry={e} rank={i} tier="xl" />
+          ))}
+        </div>
+      )}
+      {/* LG: 3-col medium cards */}
+      {lg.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {lg.map((e, i) => (
+            <TagCard key={e.tag} entry={e} rank={i + 2} tier="lg" />
+          ))}
+        </div>
+      )}
+      {/* MD: 3-col compact cards */}
+      {md.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {md.map((e, i) => (
+            <TagCard key={e.tag} entry={e} rank={i + 5} tier="md" />
+          ))}
+        </div>
+      )}
+      {/* SM: 6-col compact cards */}
+      {sm.length > 0 && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
+          {sm.map((e, i) => (
+            <TagCard key={e.tag} entry={e} rank={i + 11} tier="sm" />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FlatLayout({ sorted }: { sorted: TagEntry[] }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+      {sorted.map((e, i) => (
+        <TagCard key={e.tag} entry={e} rank={i} tier="sm" />
+      ))}
+    </div>
+  );
+}
+
+function TagCard({
+  entry,
+  rank,
+  tier,
+}: {
+  entry: TagEntry;
+  rank: number;
+  tier: 'xl' | 'lg' | 'md' | 'sm';
+}) {
+  const color = colorFor(rank);
+
+  const sizeStyles = {
+    xl: {
+      minH: 'min-h-[176px]',
+      pad: 'p-7',
+      title: 'text-3xl font-bold',
+      countBadge: 'h-7 min-w-[2rem] rounded-full bg-bento-ink px-2.5 text-white',
+      countText: 'text-[13px] font-semibold',
+    },
+    lg: {
+      minH: 'min-h-[152px]',
+      pad: 'p-6',
+      title: 'text-2xl font-bold',
+      countBadge: 'h-6 min-w-[1.75rem] rounded-full bg-bento-ink/10 px-2 text-bento-ink',
+      countText: 'text-[12px] font-semibold',
+    },
+    md: {
+      minH: 'min-h-[88px]',
+      pad: 'p-4',
+      title: 'text-lg font-bold',
+      countBadge: 'h-5 min-w-[1.5rem] rounded-full bg-bento-ink/10 px-1.5 text-bento-ink',
+      countText: 'text-[11px] font-semibold',
+    },
+    sm: {
+      minH: 'min-h-[64px]',
+      pad: 'p-3.5',
+      title: 'text-sm font-semibold',
+      countBadge: 'h-5 min-w-[1.5rem] rounded-full bg-bento-ink/10 px-1.5 text-bento-ink',
+      countText: 'text-[10px] font-semibold',
+    },
+  }[tier];
+
+  return (
+    <Link
+      href={`/tags/${encodeURIComponent(entry.tag)}`}
+      className={[
+        'group flex flex-col justify-between rounded-card no-underline transition hover:-translate-y-0.5 hover:shadow-md',
+        color,
+        sizeStyles.minH,
+        sizeStyles.pad,
+        FOCUS_RING,
+      ].join(' ')}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className={['truncate text-bento-ink', sizeStyles.title].join(' ')}>
+          #{entry.tag}
+        </span>
+        <span
+          className={[
+            'inline-flex shrink-0 items-center justify-center font-mono',
+            sizeStyles.countBadge,
+            sizeStyles.countText,
+          ].join(' ')}
+        >
+          {entry.count}
+        </span>
+      </div>
+      {(tier === 'xl' || tier === 'lg') && entry.categories.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {entry.categories.slice(0, 3).map((cat) => (
+            <span
+              key={cat}
+              className="inline-flex items-center rounded-full bg-bento-ink/[0.08] px-3 py-1 text-[11px] font-medium text-bento-ink"
+            >
+              {cat}
+            </span>
+          ))}
+        </div>
+      )}
+    </Link>
+  );
+}
+
+function SortTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'rounded-full px-3.5 py-1.5 text-[12px] font-medium transition',
+        active
+          ? 'bg-bento-ink text-white dark:bg-white dark:text-bento-bg'
+          : 'text-bento-ink hover:bg-bento-ink/5 dark:text-white',
+        FOCUS_RING,
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

기존 Tags 페이지를 디자인 시안에 맞춰 전면 재구성. 단일 pill 리스트에서 정보 밀도 높은 hero + bento 그리드 레이아웃으로 변경.

### 변경 내용

#### 1. Hero 2-column 레이아웃
- **왼쪽 (dark 카드)**: \`INDEX\` 라벨 + \`Tags.\` 대형 타이틀 + 설명 + 상위 24개 태그 인라인 cloud
  - rank 0~2: 36~44px extrabold
  - rank 3~6: 24~28px bold
  - rank 7+: 16~18px medium (옅은 색상)
- **오른쪽 (butter + white 카드)**:
  - \`AT A GLANCE\`: 전체 태그 수 / 총 사용 횟수
  - \`TOP 5 — MOST WRITTEN\`: 1~5 랭크된 상위 태그 리스트

#### 2. Sort tabs (client component)
- \`By count\` (기본) / \`A → Z\` / \`Recently used\` — pill toggle UI
- count 정렬일 때만 bento 4-tier 카드 사용, 나머지는 flat 6-col grid

#### 3. Bento grid (count 정렬 시)
| rank | tier | layout | 카테고리 chip |
|---|---|---|---|
| 0~1 | XL | 2-col span (큰 카드) | ✓ |
| 2~4 | LG | 3-col | ✓ |
| 5~10 | MD | 3-col compact | ✗ |
| 11+ | SM | 6-col mini | ✗ |

- 카드 색상: \`sage → butter → rose → lavender → cream\` 순환 (bento 디자인 토큰 활용)
- 각 카드: 태그명 + 글 수 badge + 카테고리 chip (XL/LG 한정)
- hover 시 살짝 들림 + 그림자 (\`-translate-y-0.5\`, \`shadow-md\`)

### 데이터 집계 변경
태그별로 다음 메타데이터 집계:
- \`count\`: 해당 태그가 달린 글 수
- \`categories\`: 해당 태그가 등장한 카테고리 (등장 빈도 순)
- \`lastUsed\`: 가장 최근에 달린 글의 날짜 (Recently used 정렬용)

### 검증 (chrome-devtools)
- Hero 영역 + 우측 stats/Top 5 카드 정상 렌더링
- Bento grid에서 #java (34편), #자바 (33편)이 XL 카드로 표시되고 그 아래 LG/MD/SM 단계적으로 배치
- A → Z 탭 클릭 시 모든 태그가 flat 6-col grid에 알파벳 순으로 표시
- 5개 bento 색상이 순환 적용되어 시각적 다양성 확보

## Test plan
- [ ] \`/tags\` 페이지 hero 영역(좌: dark cloud / 우: stats + Top 5)이 디자인과 일치하는지 확인
- [ ] By count 정렬에서 상위 2개가 XL 카드(카테고리 chip 포함)로 표시되는지 확인
- [ ] A → Z 정렬 시 flat grid로 전환되고 정렬 순서가 한글 기준 정확한지 확인
- [ ] Recently used 정렬 시 최근 작성된 글의 태그가 상위에 오는지 확인
- [ ] 모바일/태블릿 반응형에서 grid가 단일 column으로 적절히 줄어드는지 확인
- [ ] 다크 모드에서 bento 카드 색상과 텍스트 대비가 충분한지 확인
- [ ] 각 카드 클릭 시 \`/tags/{tag}\` 페이지로 정상 이동하는지 확인

## Notes
- 현재 데이터에 #java/#자바, #go/#고랭 같은 동의어가 분리 저장되어 있어 877개 태그로 표시됨 (디자인 시안의 39개는 mock 데이터). 태그 정규화는 별도 작업으로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)