### PR TITLE
feat: 메인 페이지 명언 카드를 inspire-me QOTD로 교체

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,8 @@ import { CategoriesCard } from '@/components/home/categories-card';
 import { RecentCard } from '@/components/home/recent-card';
 import { StatsCard } from '@/components/home/stats-card';
 import { ActivityHeatmap } from '@/components/home/activity-heatmap';
-import { QuoteCard } from '@/components/home/quote-card';
+import { QuoteSection } from '@/components/home/quote-section';
+import type { QuoteViewData } from '@/hooks/use-quote-of-the-day';
 import { WideLatestList } from '@/components/home/wide-latest-list';
 
 export const metadata = {
@@ -18,6 +19,11 @@ export const metadata = {
 };
 
 const RECENT_TONES = ['sage', 'butter', 'rose', 'cream'] as const;
+
+const QOTD_FALLBACK: QuoteViewData = {
+  content: '잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물.',
+  attribution: '— writing principle',
+};
 
 const HEATMAP_WEEKS = 16;
 
@@ -189,10 +195,7 @@ export default async function HomePage() {
           />
         )}
 
-        <QuoteCard
-          content="잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물."
-          attribution="— writing principle"
-        />
+        <QuoteSection fallback={QOTD_FALLBACK} />
       </section>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -190,11 +190,7 @@ export default async function HomePage() {
         )}
 
         <QuoteCard
-          lines={[
-            '잘 정리된 노트는',
-            '미래의 나에게 보내는',
-            '가장 좋은 선물.',
-          ]}
+          content="잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물."
           attribution="— writing principle"
         />
       </section>

--- a/components/home/quote-card.tsx
+++ b/components/home/quote-card.tsx
@@ -1,26 +1,45 @@
 type Props = {
-  lines: string[];
+  content: string;
   attribution: string;
+  /** 있으면 카드 전체가 새 탭 링크로 동작. 없으면 일반 카드. */
+  href?: string;
 };
 
-export function QuoteCard({ lines, attribution }: Props) {
-  return (
-    <div className="col-span-12 flex min-h-[260px] flex-col justify-between rounded-card-xl bg-bento-hero-dark p-7 text-white md:col-span-4 md:min-h-[260px] md:p-8">
+const BASE_CLASSES =
+  'col-span-12 flex min-h-[260px] flex-col justify-between rounded-card-xl bg-bento-hero-dark p-7 text-white md:col-span-4 md:min-h-[260px] md:p-8';
+
+const LINK_CLASSES =
+  'transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bento-accent';
+
+export function QuoteCard({ content, attribution, href }: Props) {
+  const body = (
+    <>
       <div
         aria-hidden="true"
         className="text-6xl font-bold leading-none text-bento-accent"
         style={{ lineHeight: 0.7 }}
       >
-        "
+        &ldquo;
       </div>
-      <blockquote className="my-3 font-serif text-lg font-medium leading-tight tracking-tighter md:text-xl">
-        {lines.map((line, i) => (
-          <span key={i} className="block">
-            {line}
-          </span>
-        ))}
+      <blockquote className="my-3 font-serif text-lg font-medium leading-tight tracking-tighter md:text-xl [text-wrap:balance]">
+        {content}
       </blockquote>
       <cite className="text-xs not-italic text-white/60">{attribution}</cite>
-    </div>
+    </>
   );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${BASE_CLASSES} ${LINK_CLASSES}`}
+      >
+        {body}
+      </a>
+    );
+  }
+
+  return <div className={BASE_CLASSES}>{body}</div>;
 }

--- a/components/home/quote-card.tsx
+++ b/components/home/quote-card.tsx
@@ -9,7 +9,7 @@ const BASE_CLASSES =
   'col-span-12 flex min-h-[260px] flex-col justify-between rounded-card-xl bg-bento-hero-dark p-7 text-white md:col-span-4 md:min-h-[260px] md:p-8';
 
 const LINK_CLASSES =
-  'transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bento-accent';
+  'cursor-pointer transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bento-accent';
 
 export function QuoteCard({ content, attribution, href }: Props) {
   const body = (

--- a/components/home/quote-section.tsx
+++ b/components/home/quote-section.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { QuoteCard } from '@/components/home/quote-card';
+import {
+  useQuoteOfTheDay,
+  type QuoteViewData,
+} from '@/hooks/use-quote-of-the-day';
+
+type Props = {
+  /** 빌드 시 정적 HTML에 박히는 명언. fetch 실패/지연 시에도 이 값이 표시된다. */
+  fallback: QuoteViewData;
+};
+
+export function QuoteSection({ fallback }: Props) {
+  const data = useQuoteOfTheDay(fallback);
+  return (
+    <QuoteCard
+      content={data.content}
+      attribution={data.attribution}
+      href={data.href}
+    />
+  );
+}

--- a/docs/superpowers/plans/2026-05-16-qotd-on-homepage.md
+++ b/docs/superpowers/plans/2026-05-16-qotd-on-homepage.md
@@ -1,0 +1,539 @@
+# 메인 페이지 명언 카드를 inspire-me QOTD로 교체 - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** blog-v2 메인 페이지의 하드코딩된 명언 카드를 inspire-me(`https://inspire-me.advenoh.pe.kr`)의 widget API에서 받아오는 오늘의 명언으로 교체하고, 카드 클릭 시 새 탭으로 inspire-me 상세 페이지(`/quotes/{id}`)를 연다.
+
+**Architecture:** 정적 export 사이트이므로 빌드 HTML에 fallback 명언을 박아두고, 브라우저 로드 후 클라이언트 컴포넌트가 widget API(`/api/widget/quote-of-the-day?language=ko`, 인증/CORS 제약 없음)를 호출해 데이터를 교체. 실패 시 fallback 유지 + 링크 비활성. 표시 컴포넌트 `QuoteCard`는 순수 함수 컴포넌트로 유지하고, 데이터 페칭은 훅 `useQuoteOfTheDay`와 클라이언트 컴포넌트 `QuoteSection`이 담당한다.
+
+**Tech Stack:** Next.js 16 App Router (`output: 'export'`), React 19, TypeScript, Tailwind CSS. 기존 프로젝트에 단위 테스트 인프라가 없으므로 본 plan은 **`npm run check` (tsc) + `npm run build` + 수동 브라우저 검증**으로 각 단계의 정상 동작을 확인한다. 테스트 인프라(Vitest + @testing-library 등) 도입은 본 plan 범위를 넘으며, 필요 시 후속 plan으로 진행한다.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-qotd-on-homepage-design.md`
+
+**Branch:** `feature/qotd-on-homepage` (이미 생성됨, 스펙 커밋 `e9b8354`)
+
+---
+
+## File Map
+
+| 파일 | 동작 | 책임 |
+|---|---|---|
+| `lib/inspireme.ts` | **신규** | API base URL 상수, widget 응답 타입, `quoteDetailUrl()`, `fetchQuoteOfTheDay()` |
+| `components/home/quote-card.tsx` | **수정** | props를 `{ lines: string[] }` → `{ content, attribution, href? }`로 변경. `href` 있으면 `<a target="_blank" rel="noopener noreferrer">`로 카드 전체 wrap |
+| `hooks/use-quote-of-the-day.ts` | **신규** | `useEffect` + `fetch`로 widget API 호출, fallback 초기값 → 성공 시 교체, 실패 시 유지 |
+| `components/home/quote-section.tsx` | **신규** | `'use client'` 경계. 훅 호출 + 결과를 `QuoteCard`에 전달 |
+| `app/page.tsx` | **수정** | `<QuoteCard ... />` 직접 호출을 `<QuoteSection fallback={QOTD_FALLBACK} />`로 교체. import 정리 |
+
+---
+
+## Task 1: API 클라이언트 모듈 (`lib/inspireme.ts`) 신규 작성
+
+**Files:**
+- Create: `lib/inspireme.ts`
+
+목적: inspire-me widget API의 base URL, 응답 타입, fetch 함수를 한 모듈에 모은다. 다른 곳에서 도메인 문자열을 직접 쓰지 않도록 단일 출처로 만든다.
+
+- [ ] **Step 1.1: `lib/inspireme.ts` 생성**
+
+```ts
+// lib/inspireme.ts
+
+/**
+ * inspire-me 외부 서비스의 공개 widget API 호출 헬퍼.
+ * widget API는 인증 키가 필요 없고 모든 origin을 허용한다.
+ */
+
+export const INSPIRE_ME_BASE_URL = 'https://inspire-me.advenoh.pe.kr';
+
+/**
+ * widget API의 quote 응답 형태.
+ * (backend/pkg/widget/handler.go:281-298의 widgetQuoteResponse 기준,
+ *  본 클라이언트에서 사용하는 필드만 정의)
+ */
+export type InspireMeWidgetQuote = {
+  id: string;
+  content: string;
+  author: string;
+  language: string;
+  topics?: string[];
+  tags?: string[];
+};
+
+type WidgetEnvelope<T> = { data: T };
+
+export function quoteDetailUrl(id: string): string {
+  return `${INSPIRE_ME_BASE_URL}/quotes/${id}`;
+}
+
+export async function fetchQuoteOfTheDay(
+  language: string = 'ko',
+): Promise<InspireMeWidgetQuote | null> {
+  const url = `${INSPIRE_ME_BASE_URL}/api/widget/quote-of-the-day?language=${encodeURIComponent(language)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`QOTD widget API returned ${res.status}`);
+  }
+  const json = (await res.json()) as WidgetEnvelope<InspireMeWidgetQuote>;
+  return json?.data ?? null;
+}
+```
+
+- [ ] **Step 1.2: 타입 체크 통과 확인**
+
+Run: `npm run check`
+Expected: 에러 없이 종료 (exit 0). 신규 파일이라 기존 코드에 영향 없음.
+
+- [ ] **Step 1.3: 커밋**
+
+```bash
+git add lib/inspireme.ts
+git commit -m "$(cat <<'EOF'
+[feature/qotd-on-homepage] inspire-me widget API 클라이언트 모듈 추가
+
+* base URL 상수, 응답 타입, quoteDetailUrl(), fetchQuoteOfTheDay() 정의
+* widget API는 인증 키 불필요, CORS는 모든 origin 허용
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `QuoteCard` 컴포넌트 props 리팩터
+
+**Files:**
+- Modify: `components/home/quote-card.tsx`
+- Modify: `app/page.tsx:192-199`
+
+목적: `QuoteCard`의 props를 `{ lines: string[] }` → `{ content: string; attribution: string; href?: string }`로 변경. `href` 있으면 카드 전체가 새 탭 링크가 되고, 없으면 일반 `<div>`로 렌더. **이 task만으로 빌드가 깨지지 않도록** 호출자(`app/page.tsx`)도 새 props로 즉시 교체한다. fallback 명언은 그대로 유지(data fetch는 Task 3-5에서 추가).
+
+- [ ] **Step 2.1: `components/home/quote-card.tsx` 전체 재작성**
+
+```tsx
+// components/home/quote-card.tsx
+
+type Props = {
+  content: string;
+  attribution: string;
+  /** 있으면 카드 전체가 새 탭 링크로 동작. 없으면 일반 카드. */
+  href?: string;
+};
+
+const BASE_CLASSES =
+  'col-span-12 flex min-h-[260px] flex-col justify-between rounded-card-xl bg-bento-hero-dark p-7 text-white md:col-span-4 md:min-h-[260px] md:p-8';
+
+const LINK_CLASSES =
+  'transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bento-accent';
+
+export function QuoteCard({ content, attribution, href }: Props) {
+  const body = (
+    <>
+      <div
+        aria-hidden="true"
+        className="text-6xl font-bold leading-none text-bento-accent"
+        style={{ lineHeight: 0.7 }}
+      >
+        &ldquo;
+      </div>
+      <blockquote className="my-3 font-serif text-lg font-medium leading-tight tracking-tighter md:text-xl [text-wrap:balance]">
+        {content}
+      </blockquote>
+      <cite className="text-xs not-italic text-white/60">{attribution}</cite>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${BASE_CLASSES} ${LINK_CLASSES}`}
+      >
+        {body}
+      </a>
+    );
+  }
+
+  return <div className={BASE_CLASSES}>{body}</div>;
+}
+```
+
+설명:
+- `lines.map` 제거하고 `content`를 단일 문자열로 표시. `[text-wrap:balance]`로 자동 줄 균형.
+- `href`가 truthy면 `<a target="_blank" rel="noopener noreferrer">`로 래핑하고 hover/focus 시각 피드백 추가.
+- `&ldquo;`(왼쪽 큰따옴표)를 명시적으로 사용(린트 경고 회피).
+
+- [ ] **Step 2.2: `app/page.tsx`의 `QuoteCard` 호출부 변경**
+
+기존(라인 192-199):
+```tsx
+        <QuoteCard
+          lines={[
+            '잘 정리된 노트는',
+            '미래의 나에게 보내는',
+            '가장 좋은 선물.',
+          ]}
+          attribution="— writing principle"
+        />
+```
+
+다음으로 교체:
+```tsx
+        <QuoteCard
+          content="잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물."
+          attribution="— writing principle"
+        />
+```
+
+(Task 5에서 다시 `<QuoteSection />`으로 교체하지만, 이 task만으로 빌드를 깨지 않게 임시로 새 props 형태로 호출.)
+
+- [ ] **Step 2.3: 타입 체크 통과 확인**
+
+Run: `npm run check`
+Expected: 에러 없이 종료.
+
+- [ ] **Step 2.4: 수동 확인 (개발 서버)**
+
+Run: `npm run dev`
+브라우저에서 `http://localhost:3000` 열고 메인 페이지의 명언 카드가 기존과 시각적으로 동등한지 확인:
+- 본문 "잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물." 가 한 단락으로 보이고 자동 줄 균형이 적용됨.
+- 큰따옴표 아이콘 + attribution이 기존 위치에 표시됨.
+- 커서 hover 시 클릭 가능 표시가 없는지(href 미전달이므로 일반 `<div>`).
+
+확인 후 dev 서버 종료(Ctrl+C).
+
+- [ ] **Step 2.5: 커밋**
+
+```bash
+git add components/home/quote-card.tsx app/page.tsx
+git commit -m "$(cat <<'EOF'
+[feature/qotd-on-homepage] QuoteCard props를 단일 content + 선택적 href로 리팩터
+
+* lines: string[] → content: string + attribution + href? 로 변경
+* href 있으면 카드 전체가 새 탭 링크(target=_blank, rel=noopener noreferrer)
+* CSS text-wrap:balance로 자동 줄 균형, href 시 hover/focus 시각 피드백 추가
+* page.tsx 호출부를 새 props로 즉시 갱신해 빌드 정상 유지
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `useQuoteOfTheDay` 훅 신규 작성
+
+**Files:**
+- Create: `hooks/use-quote-of-the-day.ts`
+
+목적: fallback 데이터를 초기값으로 받고, 마운트 후 widget API를 호출해 성공 시 상태를 교체하는 훅. 실패 시 fallback 유지(상태 변경 없음). 응답에 `id`가 빠지면 `href`만 `undefined`로 두고 본문은 갱신(부분 graceful degrade).
+
+- [ ] **Step 3.1: `hooks/use-quote-of-the-day.ts` 생성**
+
+```ts
+// hooks/use-quote-of-the-day.ts
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  fetchQuoteOfTheDay,
+  quoteDetailUrl,
+} from '@/lib/inspireme';
+
+export type QuoteViewData = {
+  content: string;
+  attribution: string;
+  /** inspire-me 상세 페이지 절대 URL. fallback 상태일 땐 undefined. */
+  href?: string;
+};
+
+/**
+ * inspire-me의 오늘의 명언을 클라이언트에서 받아온다.
+ * - 초기값은 호출자가 주입하는 fallback (정적 HTML에 박혀 있는 명언).
+ * - 마운트 후 fetch 성공하면 새 데이터로 교체한다.
+ * - 실패하면 fallback을 그대로 유지하고 콘솔에 warn만 남긴다.
+ *   (명언은 데코레이션 요소라 사용자에게 에러를 노출하지 않는다.)
+ */
+export function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData {
+  const [data, setData] = useState<QuoteViewData>(fallback);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchQuoteOfTheDay('ko')
+      .then((q) => {
+        if (cancelled || !q) return;
+        const author = (q.author ?? '').trim();
+        const id = (q.id ?? '').trim();
+        setData({
+          content: q.content,
+          attribution: author ? `— ${author}` : fallback.attribution,
+          href: id ? quoteDetailUrl(id) : undefined,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        // 명언은 비핵심 데코레이션. 실패는 조용히 처리.
+        console.warn('[useQuoteOfTheDay] failed to fetch QOTD:', err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // fallback.attribution은 author가 비어 있을 때 대체값으로 쓰이므로 의존성에 포함.
+  }, [fallback.attribution]);
+
+  return data;
+}
+```
+
+설명:
+- `'use client'` 명시(클라이언트에서만 동작).
+- `cancelled` 플래그로 unmount 후 setState 방지.
+- `author`/`id`가 공백/없음일 때를 모두 falsy로 통합 처리.
+- 성공 시에만 setState (실패 시 초기 fallback이 그대로 유지됨).
+
+- [ ] **Step 3.2: 타입 체크 통과 확인**
+
+Run: `npm run check`
+Expected: 에러 없이 종료. (이 훅은 아직 사용처가 없지만 export만 있으면 TS는 통과.)
+
+- [ ] **Step 3.3: 커밋**
+
+```bash
+git add hooks/use-quote-of-the-day.ts
+git commit -m "$(cat <<'EOF'
+[feature/qotd-on-homepage] useQuoteOfTheDay 훅 추가
+
+* fallback을 초기 상태로 받아 마운트 후 widget API fetch
+* 성공: content/attribution/href로 상태 교체 (id 없으면 href만 undefined)
+* 실패: fallback 유지 + console.warn (사용자에게 에러 노출 안 함)
+* unmount 시 setState 방지(cancelled 플래그)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `QuoteSection` 클라이언트 컴포넌트 신규 작성
+
+**Files:**
+- Create: `components/home/quote-section.tsx`
+
+목적: server 컴포넌트인 `app/page.tsx`와 클라이언트 훅 사이의 경계. 훅을 호출하고 결과를 `QuoteCard`에 그대로 넘긴다. 책임이 매우 작아 한 파일로 분리한다(`QuoteCard`는 순수 표시 유지).
+
+- [ ] **Step 4.1: `components/home/quote-section.tsx` 생성**
+
+```tsx
+// components/home/quote-section.tsx
+'use client';
+
+import { QuoteCard } from '@/components/home/quote-card';
+import {
+  useQuoteOfTheDay,
+  type QuoteViewData,
+} from '@/hooks/use-quote-of-the-day';
+
+type Props = {
+  /** 빌드 시 정적 HTML에 박히는 명언. fetch 실패/지연 시에도 이 값이 표시된다. */
+  fallback: QuoteViewData;
+};
+
+export function QuoteSection({ fallback }: Props) {
+  const data = useQuoteOfTheDay(fallback);
+  return (
+    <QuoteCard
+      content={data.content}
+      attribution={data.attribution}
+      href={data.href}
+    />
+  );
+}
+```
+
+- [ ] **Step 4.2: 타입 체크 통과 확인**
+
+Run: `npm run check`
+Expected: 에러 없이 종료.
+
+- [ ] **Step 4.3: 커밋**
+
+```bash
+git add components/home/quote-section.tsx
+git commit -m "$(cat <<'EOF'
+[feature/qotd-on-homepage] QuoteSection 클라이언트 컴포넌트 추가
+
+* 'use client' 경계: server page에서 받은 fallback을 훅에 전달, 결과를 QuoteCard로 렌더
+* QuoteCard는 순수 표시 컴포넌트로 유지(데이터 페칭과 분리)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `app/page.tsx`에서 `QuoteCard` 직접 호출을 `QuoteSection`으로 교체
+
+**Files:**
+- Modify: `app/page.tsx` (import 라인 12 부근, 사용처 라인 192 부근)
+
+목적: 메인 페이지가 더 이상 `QuoteCard`를 직접 사용하지 않고, fallback 명언을 `QuoteSection`에 props로 전달하도록 변경. 이 task가 완료되면 페이지는 정적 HTML에서는 fallback 명언을, 브라우저 로드 후엔 inspire-me의 그날의 명언을 표시한다.
+
+- [ ] **Step 5.1: `app/page.tsx` import 라인 교체**
+
+기존(라인 12):
+```tsx
+import { QuoteCard } from '@/components/home/quote-card';
+```
+
+다음으로 교체:
+```tsx
+import { QuoteSection } from '@/components/home/quote-section';
+```
+
+- [ ] **Step 5.2: `app/page.tsx`에 fallback 상수 추가**
+
+기존(라인 20 근처, 다른 const 옆):
+```tsx
+const RECENT_TONES = ['sage', 'butter', 'rose', 'cream'] as const;
+```
+
+바로 아래(또는 가까운 위치)에 추가(파일 상단의 다른 import 옆에 `QuoteViewData` 타입도 함께 import):
+
+```tsx
+// 다른 import 옆 (예: QuoteSection import 바로 아래)
+import type { QuoteViewData } from '@/hooks/use-quote-of-the-day';
+```
+
+```tsx
+// const RECENT_TONES 아래
+const QOTD_FALLBACK: QuoteViewData = {
+  content: '잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물.',
+  attribution: '— writing principle',
+};
+```
+
+설명: `as const` 대신 명시적 타입 어노테이션을 써서 `QuoteSection`의 `fallback` props 타입과 의도된 일치를 명확히 한다.
+
+- [ ] **Step 5.3: `app/page.tsx`의 `<QuoteCard ... />` 호출을 `<QuoteSection fallback={...} />`로 교체**
+
+기존(Task 2 이후 상태, 라인 192-195 근처):
+```tsx
+        <QuoteCard
+          content="잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물."
+          attribution="— writing principle"
+        />
+```
+
+다음으로 교체:
+```tsx
+        <QuoteSection fallback={QOTD_FALLBACK} />
+```
+
+- [ ] **Step 5.4: 타입 체크 통과 확인**
+
+Run: `npm run check`
+Expected: 에러 없이 종료. (`QuoteCard` import가 사라졌으니 미사용 import 경고도 없음.)
+
+- [ ] **Step 5.5: 정적 export 빌드 통과 확인**
+
+Run: `npm run build`
+Expected: 빌드 성공. `out/` 디렉토리가 생성되고 메인 페이지(`out/index.html`)에 fallback 명언 텍스트("잘 정리된 노트는 미래의 나에게 보내는 가장 좋은 선물.")가 포함되어 있어야 함.
+
+확인:
+```bash
+grep -c "잘 정리된 노트는" out/index.html
+# Expected: 1 이상 (정적 HTML에 fallback 명언이 박혀 있음)
+```
+
+- [ ] **Step 5.6: 커밋**
+
+```bash
+git add app/page.tsx
+git commit -m "$(cat <<'EOF'
+[feature/qotd-on-homepage] 메인 페이지에서 QuoteSection으로 inspire-me QOTD 연동
+
+* QuoteCard 직접 호출을 <QuoteSection fallback={QOTD_FALLBACK} />로 교체
+* 정적 HTML에 fallback 명언이 박힘 → 브라우저에서 widget API로 교체
+* QuoteCard import 제거
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: 통합 수동 검증
+
+**Files:** 없음(검증 전용 task)
+
+목적: 사용자 시나리오 3개(정상 / offline / 새 탭)가 모두 의도대로 동작하는지 브라우저에서 확인.
+
+- [ ] **Step 6.1: 개발 서버 기동**
+
+Run: `npm run dev`
+브라우저에서 `http://localhost:3000` 열기.
+
+- [ ] **Step 6.2: 정상 시나리오 확인**
+
+- [ ] 초기 페인트에 fallback 명언("잘 정리된 노트는 …")이 **즉시** 보임(스켈레톤/공백 없음).
+- [ ] 1-2초 안에 명언이 inspire-me의 오늘의 명언으로 교체됨(텍스트가 다르면 정상).
+- [ ] 교체된 카드에 hover 시 시각 피드백(`opacity-90`)이 나타남.
+- [ ] DevTools Network 탭에서 `GET https://inspire-me.advenoh.pe.kr/api/widget/quote-of-the-day?language=ko` 요청이 200으로 응답함.
+- [ ] DevTools Console에 에러/경고 없음.
+
+- [ ] **Step 6.3: 새 탭 이동 확인**
+
+- [ ] 교체된 명언 카드 클릭 → **새 탭**으로 `https://inspire-me.advenoh.pe.kr/quotes/{id}` 형식의 URL이 열림.
+- [ ] 원래 blog-v2 탭은 그대로 유지됨.
+- [ ] 모바일 viewport(DevTools 디바이스 모드)에서도 카드 전체가 탭 가능한 영역인지 확인.
+
+- [ ] **Step 6.4: 오프라인 fallback 시나리오 확인**
+
+- [ ] DevTools Network 탭에서 throttling을 **Offline**으로 설정.
+- [ ] 페이지 새로고침(Cmd+R).
+- [ ] fallback 명언("잘 정리된 노트는 …")이 그대로 표시됨.
+- [ ] 카드에 hover해도 클릭 가능 표시 없음(`<a>`가 아닌 `<div>`로 렌더됨).
+- [ ] 카드를 클릭해도 아무 일도 일어나지 않음.
+- [ ] Console에 `[useQuoteOfTheDay] failed to fetch QOTD: ...` warning이 한 번 찍힘(에러 아님).
+
+- [ ] **Step 6.5: throttling 해제 및 dev 서버 종료**
+
+DevTools Network throttling을 No throttling으로 복원, 터미널에서 dev 서버 Ctrl+C로 종료.
+
+- [ ] **Step 6.6: 정적 export 산출물 sanity 체크**
+
+Run: `npm run build && npx serve@latest out -l 3001`
+별도 터미널에서 `curl -s http://localhost:3001/ | grep -c "잘 정리된 노트는"` 실행 → 1 이상이면 정적 HTML에 fallback이 박혀 있음. Ctrl+C로 serve 종료.
+
+- [ ] **Step 6.7: 검증 완료 커밋 (선택, no-op 변경이 있을 때만)**
+
+검증 중 코드 변경이 없었다면 추가 커밋 불필요. 만약 빌드 산출물 외 변경이 발생했다면 별도 task로 빼서 해결한다(이 plan은 종료).
+
+---
+
+## Out of Scope (의도적으로 본 plan에서 제외한 항목)
+
+- **단위 테스트 추가**: blog-v2에 테스트 인프라(Vitest/Jest/@testing-library)가 없음. 인프라 도입은 별도 plan으로 처리.
+- **blog-v2 CLAUDE.md 갱신**: 현재 파일이 outdated(React 18 + Express로 적혀 있으나 실제는 Next.js 16 App Router 정적 export). 본 작업과 무관하므로 별도 PR로 처리 권장.
+- **다국어/언어 토글**: 스펙 §3 비목표.
+- **캐싱(localStorage/SWR/TanStack Query)**: 스펙 §3 비목표. 페이지당 1회 호출이라 캐싱 가치가 낮음.
+- **로딩 스켈레톤**: fallback이 즉시 렌더되므로 스켈레톤이 보일 시점이 없음.
+- **재시도/backoff**: 명언은 비핵심 데코레이션. 한 번 실패하면 fallback으로 충분.
+
+---
+
+## Done Criteria
+
+- [ ] 모든 Task의 모든 Step 체크박스 완료.
+- [ ] `npm run check`, `npm run build` 모두 통과.
+- [ ] 정상/오프라인/새 탭 시나리오 모두 수동 확인 완료.
+- [ ] `feature/qotd-on-homepage` 브랜치에 의도된 커밋만 존재(빌드 산출물 같은 의도치 않은 변경 없음).
+- [ ] 사용자가 PR 생성을 요청하면 `gh pr create` + HEREDOC으로 PR 작성.

--- a/docs/superpowers/specs/2026-05-16-qotd-on-homepage-design.md
+++ b/docs/superpowers/specs/2026-05-16-qotd-on-homepage-design.md
@@ -1,0 +1,178 @@
+---
+date: 2026-05-16
+status: draft
+project: blog-v2.advenoh.pe.kr
+related:
+  - inspireme.advenoh.pe.kr (외부 API 제공)
+---
+
+# 메인 페이지 명언 카드를 inspire-me QOTD로 교체
+
+## 1. 배경 (Context)
+
+blog-v2 메인 페이지의 `QuoteCard`는 현재 `app/page.tsx:192-199`에 텍스트가 하드코딩되어 있다. 별도의 명언 서비스인 inspire-me(`https://inspire-me.advenoh.pe.kr/`)에 "오늘의 명언(Quote of the Day, QOTD)" 기능이 이미 구현되어 있으므로, 이를 연동해 매일 자동으로 갱신되는 명언이 표시되도록 한다. 동시에 카드를 클릭하면 inspire-me의 해당 명언 상세 페이지로 이동하게 만들어, 두 사이트 간 트래픽이 자연스럽게 연결되도록 한다.
+
+## 2. 목표 (Goals)
+
+- 메인 페이지 명언 카드가 매일 inspire-me의 그날의 명언을 표시한다.
+- 명언 카드 전체가 클릭 가능하며, inspire-me의 해당 명언 상세 페이지(`/quotes/{id}`)를 새 탭으로 연다.
+- API 호출 실패/지연 시에도 메인 페이지 레이아웃이 깨지지 않고, 사용자가 정적 fallback 명언을 즉시 본다.
+- 외부 API 의존성을 최소 비용으로 추가한다(인증 키, 도메인 화이트리스트, 추가 의존성 없음).
+
+## 3. 비목표 (Non-goals)
+
+- 다국어 명언 표시(영어/한국어 토글). 현재 blog-v2에 언어 토글 UI가 없어 `language=ko` 고정.
+- 명언 캐싱(localStorage, SWR/TanStack Query 등). 페이지당 1회 호출이라 캐싱 가치가 낮음.
+- 로딩 스켈레톤. fallback이 즉시 표시되므로 불필요.
+- API 실패 시 재시도 로직. 명언은 페이지의 데코레이션이며 핵심 콘텐츠가 아님.
+- 명언 카테고리/태그/배경 이미지 등 추가 메타 표시.
+
+## 4. 아키텍처
+
+### 4.1 데이터 플로
+
+```
+[빌드 타임]
+  app/page.tsx (server) → <QuoteSection fallback={{content, attribution}} />
+       → QuoteSection이 'use client' 경계이지만 fallback은 server에서 props로 전달
+       → 정적 HTML에 fallback 명언이 포함된 채 배포됨
+
+[브라우저 런타임]
+  1. HTML 도착 → fallback 명언 즉시 표시 (깜빡임 없음, SEO 친화적)
+  2. JS 하이드레이션 → QuoteSection 내부 useQuoteOfTheDay(fallback)의
+       useEffect에서 widget API fetch
+       GET https://inspire-me.advenoh.pe.kr/api/widget/quote-of-the-day?language=ko
+  3a. 성공 → content/attribution/href 교체, 카드 전체가 새 탭 링크가 됨
+       href = https://inspire-me.advenoh.pe.kr/quotes/{id}
+  3b. 실패 → fallback 유지, href 없음 → 클릭 비활성
+```
+
+### 4.2 외부 API 선택 근거
+
+inspire-me 백엔드는 동일 QOTD 데이터에 대해 세 가지 엔드포인트를 제공한다:
+
+| 엔드포인트 | 인증 | CORS | 적합도 |
+|---|---|---|---|
+| `/api/quote-of-the-day` | Internal Token | 제한적 | ❌ 내부용 |
+| `/api/v1/quote-of-the-day` | API Key 필수 (Bearer) | `localhost:3000`, `inspireme.advenoh.pe.kr`만 | ⚠️ 키 발급/보관 부담 |
+| `/api/widget/quote-of-the-day` | 없음 | `*` (모든 origin) | ✅ 임베드용으로 설계됨 |
+
+본 작업에서는 **widget API**를 채택한다. 이유:
+- 인증 키 없음 → 정적 사이트에서도 별도 비밀 관리 불필요.
+- CORS가 모든 origin 허용 → blog-v2 도메인 추가 등의 백엔드 변경 불필요.
+- IP당 분당 60회 rate limit → 일반 블로그 트래픽에 충분.
+- 명시적으로 외부 임베드용으로 설계된 엔드포인트.
+
+### 4.3 컴포넌트 단위 분리
+
+| 단위 | 책임 | 의존 |
+|---|---|---|
+| `QuoteCard` | 명언 카드의 순수 표시. `href` 유무에 따라 `<a>` 또는 `<div>`로 렌더. | 없음 |
+| `useQuoteOfTheDay` | inspire-me widget API 호출과 fallback 상태 관리. | `lib/inspireme` |
+| `QuoteSection` | `'use client'` 경계. 훅을 호출하고 결과를 `QuoteCard`에 전달. | `QuoteCard`, `useQuoteOfTheDay` |
+| `lib/inspireme` | API base URL 상수, 응답 타입, URL 빌더(`quoteDetailUrl(id)`). | 없음 |
+| `app/page.tsx` | server 컴포넌트 유지. fallback 명언을 `QuoteSection`에 props로 전달. | `QuoteSection` |
+
+각 단위는 단독으로 이해/테스트 가능하며, 표시 컴포넌트(`QuoteCard`)는 데이터 페칭에 의존하지 않는다.
+
+## 5. 컴포넌트 API
+
+### 5.1 `QuoteCard` props (변경)
+
+```ts
+type Props = {
+  content: string;       // 명언 본문 (한 문장)
+  attribution: string;   // 예: "— 소크라테스", "— writing principle"
+  href?: string;         // 있으면 카드 전체가 새 탭 링크, 없으면 일반 카드
+};
+```
+
+- 기존 `lines: string[]`는 제거. 단일 문자열을 받고 CSS(`text-balance`, `max-w-*`)로 시각적 줄바꿈을 처리한다.
+- `href`가 있으면 `<a href target="_blank" rel="noopener noreferrer">`로 카드 전체를 감싸고 hover 상태를 추가한다.
+- `href`가 없으면 `<div>`로 감싸며, hover 효과/커서 변경 없음(= fallback 시 클릭 불가가 시각적으로 명확).
+
+### 5.2 `useQuoteOfTheDay` 반환값
+
+```ts
+type QuoteViewData = {
+  content: string;
+  attribution: string;
+  href?: string;
+};
+
+function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData;
+```
+
+- 초기 반환값 = `fallback`. fetch 성공 시 새로운 `QuoteViewData`로 교체된다.
+- 실패/이상 응답 시 `fallback` 유지(상태 변경 없음). 구체적 에러/로딩 플래그는 노출하지 않는다(소비자가 분기할 일이 없음).
+- 컴포넌트 unmount 시 응답이 늦게 도착해도 setState하지 않도록 cancelled 플래그를 사용한다.
+
+### 5.3 inspire-me 응답 매핑
+
+widget API 응답 (`backend/pkg/widget/handler.go:281-298`의 `widgetQuoteResponse` 기준):
+
+```json
+{
+  "data": {
+    "id": "q-abc123",
+    "content": "오늘도 좋은 하루 되세요",
+    "author": "소크라테스",
+    "language": "ko",
+    ...
+  }
+}
+```
+
+매핑 규칙:
+- `content`: `data.content` 그대로.
+- `attribution`: `data.author`가 있으면 `— ${data.author}`, 없거나 빈 문자열이면 fallback의 attribution을 유지.
+- `href`: `data.id`가 있으면 `https://inspire-me.advenoh.pe.kr/quotes/${data.id}`, 없으면 `undefined`.
+
+## 6. 에러/예외 처리
+
+| 상황 | 동작 |
+|---|---|
+| HTTP 200 + 정상 JSON | 데이터 교체, href 활성 |
+| 4xx/5xx 응답 | fallback 유지, 콘솔에 warning |
+| 네트워크 실패(offline 등) | fallback 유지, 콘솔에 warning |
+| JSON 파싱 실패 | fallback 유지, 콘솔에 warning |
+| 응답에 `id` 없음 | content/attribution은 갱신, `href`만 undefined로 둠(부분 graceful degrade) |
+| Rate limit(429) | fallback 유지(다른 실패와 동일 처리) |
+| 컴포넌트 unmount 후 응답 도착 | setState 호출하지 않음(cancelled 플래그) |
+
+핵심 원칙: 명언 카드는 데코레이션이므로 어떤 실패에도 메인 페이지 렌더를 방해하지 않는다.
+
+## 7. 테스트 전략
+
+### 7.1 단위 테스트 (blog-v2 기존 테스트 환경에 따라 Vitest/Jest 중 선택)
+
+- `QuoteCard`
+  - `href` 있을 때 `<a>` 렌더 및 `href`, `target="_blank"`, `rel="noopener noreferrer"` 속성 검증.
+  - `href` 없을 때 `<div>` 렌더 검증, 링크/포커스 가능 요소 없음 확인.
+  - `content`, `attribution` 텍스트 노출 확인.
+- `useQuoteOfTheDay`
+  - `fetch` mock으로 정상 응답 → fallback이 새 데이터로 교체되는지 확인.
+  - 404/500 응답 → fallback 유지 확인.
+  - 네트워크 실패(`fetch` reject) → fallback 유지 확인.
+  - 응답에 `id` 없음 → `content/attribution`은 갱신, `href`만 `undefined` 확인.
+  - unmount 후 응답 도착해도 setState 미호출 확인(act warning 없음).
+
+### 7.2 수동 확인 (`npm run dev`)
+
+- 메인 페이지 접속 → 초기 페인트에 fallback 명언 즉시 보임 → 잠시 후 inspire-me 명언으로 교체됨.
+- 교체된 카드 클릭 → inspire-me의 해당 명언 상세 페이지가 **새 탭**으로 열림.
+- devtools network를 offline으로 → 새로고침 → fallback 그대로 보이며 클릭해도 반응 없음.
+- 모바일 viewport에서 카드 전체가 탭 가능한지 확인.
+
+## 8. YAGNI 체크 (의도적 제외 항목)
+
+- **localStorage/SWR 캐싱**: 페이지당 1회 호출이므로 캐싱 효용 < 복잡도.
+- **다국어 토글**: blog-v2에 토글 UI 자체가 없음. `language=ko` 고정.
+- **로딩 스켈레톤**: fallback이 즉시 렌더되므로 스켈레톤이 보일 시점이 없음.
+- **재시도(retry/backoff)**: 명언은 비핵심 데코레이션. 한 번 실패하면 fallback으로 충분.
+- **카테고리/태그/배경 이미지**: 현재 카드 디자인 범위 밖. 추후 별도 작업.
+
+## 9. 미해결/추후 결정 사항
+
+- blog-v2 테스트 환경(Vitest/Jest 여부, 셋업 상태)은 구현 시점에 확인. 만약 컴포넌트 테스트 인프라가 없으면 추가 도입 여부를 별도 논의(기본 가정은 기존 패턴 따름).
+- inspire-me API base URL은 모든 환경(dev/prod)에서 production URL(`https://inspire-me.advenoh.pe.kr`)을 사용. 향후 staging이 필요해지면 환경 변수로 분리한다.

--- a/hooks/use-quote-of-the-day.ts
+++ b/hooks/use-quote-of-the-day.ts
@@ -32,10 +32,11 @@ export function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData {
         if (cancelled || !q) return;
         // 방어적 처리: 응답은 검증 없이 캐스팅된 JSON이라 타입상 string이어도
         // 런타임에 null/undefined가 올 수 있다고 가정한다.
+        const content = (q.content ?? '').trim();
         const author = (q.author ?? '').trim();
         const id = (q.id ?? '').trim();
         setData({
-          content: q.content,
+          content: content || fallback.content,
           attribution: author ? `— ${author}` : fallback.attribution,
           href: id ? quoteDetailUrl(id) : undefined,
         });

--- a/hooks/use-quote-of-the-day.ts
+++ b/hooks/use-quote-of-the-day.ts
@@ -30,6 +30,8 @@ export function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData {
     fetchQuoteOfTheDay('ko')
       .then((q) => {
         if (cancelled || !q) return;
+        // 방어적 처리: 응답은 검증 없이 캐스팅된 JSON이라 타입상 string이어도
+        // 런타임에 null/undefined가 올 수 있다고 가정한다.
         const author = (q.author ?? '').trim();
         const id = (q.id ?? '').trim();
         setData({
@@ -47,7 +49,9 @@ export function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData {
     return () => {
       cancelled = true;
     };
-    // fallback.attribution은 author가 비어 있을 때 대체값으로 쓰이므로 의존성에 포함.
+    // fallback.attribution만 의존성에 포함. effect 내부에서 fallback.attribution만 참조하기 때문이다.
+    // fallback.content는 useState 초기값으로만 쓰이고 effect 본문에서 참조되지 않으므로 의도적으로 제외.
+    // (fallback 객체 전체를 dep에 넣으면 호출자가 fallback을 메모이즈하지 않을 경우 무한 재호출 위험.)
   }, [fallback.attribution]);
 
   return data;

--- a/hooks/use-quote-of-the-day.ts
+++ b/hooks/use-quote-of-the-day.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  fetchQuoteOfTheDay,
+  quoteDetailUrl,
+} from '@/lib/inspireme';
+
+export type QuoteViewData = {
+  content: string;
+  attribution: string;
+  /** inspire-me 상세 페이지 절대 URL. fallback 상태일 땐 undefined. */
+  href?: string;
+};
+
+/**
+ * inspire-me의 오늘의 명언을 클라이언트에서 받아온다.
+ * - 초기값은 호출자가 주입하는 fallback (정적 HTML에 박혀 있는 명언).
+ * - 마운트 후 fetch 성공하면 새 데이터로 교체한다.
+ * - 실패하면 fallback을 그대로 유지하고 콘솔에 warn만 남긴다.
+ *   (명언은 데코레이션 요소라 사용자에게 에러를 노출하지 않는다.)
+ */
+export function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData {
+  const [data, setData] = useState<QuoteViewData>(fallback);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchQuoteOfTheDay('ko')
+      .then((q) => {
+        if (cancelled || !q) return;
+        const author = (q.author ?? '').trim();
+        const id = (q.id ?? '').trim();
+        setData({
+          content: q.content,
+          attribution: author ? `— ${author}` : fallback.attribution,
+          href: id ? quoteDetailUrl(id) : undefined,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        // 명언은 비핵심 데코레이션. 실패는 조용히 처리.
+        console.warn('[useQuoteOfTheDay] failed to fetch QOTD:', err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // fallback.attribution은 author가 비어 있을 때 대체값으로 쓰이므로 의존성에 포함.
+  }, [fallback.attribution]);
+
+  return data;
+}

--- a/lib/inspireme.ts
+++ b/lib/inspireme.ts
@@ -9,12 +9,15 @@ export const INSPIRE_ME_BASE_URL = 'https://inspire-me.advenoh.pe.kr';
  * widget API의 quote 응답 형태.
  * (backend/pkg/widget/handler.go:281-298의 widgetQuoteResponse 기준,
  *  본 클라이언트에서 사용하는 필드만 정의)
+ *
+ * 응답은 런타임 검증 없이 캐스팅되므로, 백엔드 변경/오작동에 대비해
+ * 모든 필드를 optional로 정의한다. 소비자는 각 필드의 부재를 안전하게 처리해야 한다.
  */
 export type InspireMeWidgetQuote = {
-  id: string;
-  content: string;
-  author: string;
-  language: string;
+  id?: string;
+  content?: string;
+  author?: string;
+  language?: string;
   topics?: string[];
   tags?: string[];
 };

--- a/lib/inspireme.ts
+++ b/lib/inspireme.ts
@@ -1,0 +1,38 @@
+/**
+ * inspire-me 외부 서비스의 공개 widget API 호출 헬퍼.
+ * widget API는 인증 키가 필요 없고 모든 origin을 허용한다.
+ */
+
+export const INSPIRE_ME_BASE_URL = 'https://inspire-me.advenoh.pe.kr';
+
+/**
+ * widget API의 quote 응답 형태.
+ * (backend/pkg/widget/handler.go:281-298의 widgetQuoteResponse 기준,
+ *  본 클라이언트에서 사용하는 필드만 정의)
+ */
+export type InspireMeWidgetQuote = {
+  id: string;
+  content: string;
+  author: string;
+  language: string;
+  topics?: string[];
+  tags?: string[];
+};
+
+type WidgetEnvelope<T> = { data: T };
+
+export function quoteDetailUrl(id: string): string {
+  return `${INSPIRE_ME_BASE_URL}/quotes/${id}`;
+}
+
+export async function fetchQuoteOfTheDay(
+  language: string = 'ko',
+): Promise<InspireMeWidgetQuote | null> {
+  const url = `${INSPIRE_ME_BASE_URL}/api/widget/quote-of-the-day?language=${encodeURIComponent(language)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`QOTD widget API returned ${res.status}`);
+  }
+  const json = (await res.json()) as WidgetEnvelope<InspireMeWidgetQuote>;
+  return json?.data ?? null;
+}


### PR DESCRIPTION
## Summary

- blog-v2 메인 페이지의 하드코딩된 명언 카드를 inspire-me의 widget API(`/api/widget/quote-of-the-day?language=ko`)에서 받아오는 **오늘의 명언**으로 교체
- 카드 클릭 시 `https://inspire-me.advenoh.pe.kr/quotes/{id}` 상세 페이지를 **새 탭**으로 오픈 (`target=_blank`, `rel=noopener noreferrer`)
- **정적 export(`output: 'export'`) 호환 유지**: 빌드 시 fallback 명언이 정적 HTML에 박혀, JS 로드 전에도 즉시 표시. API 실패/오프라인 시에도 깨끗하게 fallback 유지 + 링크 비활성

## Architecture

| 파일 | 변경 | 책임 |
|---|---|---|
| `lib/inspireme.ts` | **신규** | widget API 클라이언트 (인증 키 불필요, CORS `*`) |
| `hooks/use-quote-of-the-day.ts` | **신규** | `'use client'` 데이터 페칭 훅. fallback 초기값 → 성공 시 교체, 실패 시 유지 |
| `components/home/quote-section.tsx` | **신규** | server/client 경계. 훅 결과를 QuoteCard에 전달 |
| `components/home/quote-card.tsx` | **변경** | props를 `lines: string[]` → `content + attribution + href?` 로 리팩터. `href` 있으면 카드 전체가 새 탭 링크 |
| `app/page.tsx` | **변경** | `<QuoteCard ... />` 직접 호출을 `<QuoteSection fallback={QOTD_FALLBACK} />` 로 교체 |

## 외부 API 선택 근거

inspire-me 백엔드에는 동일 QOTD 데이터를 제공하는 3개 엔드포인트가 있는데, 그중 **widget API**를 채택:

| 엔드포인트 | 인증 | CORS | 비고 |
|---|---|---|---|
| `/api/quote-of-the-day` | Internal Token | 제한적 | ❌ 내부용 |
| `/api/v1/quote-of-the-day` | API Key 필수 | localhost+inspire-me만 | ⚠️ 키 발급/보관 부담 |
| `/api/widget/quote-of-the-day` | **없음** | `*` | ✅ 임베드용으로 설계됨 |

## 에러/실패 처리

| 상황 | 동작 |
|---|---|
| HTTP 200 + 정상 JSON | 데이터 교체, href 활성 |
| 4xx / 5xx / 네트워크 실패 / JSON 파싱 실패 | fallback 유지, 콘솔에 warn (사용자에게 에러 노출 없음) |
| 응답에 `id` 없음 | content/attribution 갱신, `href`만 undefined |
| 응답에 `content` 없음 | fallback.content 유지(빈 카드 방지) |
| 컴포넌트 unmount 후 응답 도착 | setState 호출 안 함 (cancelled 플래그) |

## 의도적 제외 항목 (YAGNI)

- 다국어/언어 토글 — blog-v2에 토글 UI 자체가 없어 `language=ko` 고정
- localStorage / SWR / TanStack Query 캐싱 — 페이지당 1회 호출이라 가치 < 복잡도
- 로딩 스켈레톤 — fallback이 즉시 렌더되므로 스켈레톤이 보일 시점 없음
- 재시도/backoff — 명언은 비핵심 데코레이션
- 단위 테스트 — 프로젝트에 테스트 인프라(Vitest/Jest 등)가 없음. 인프라 도입은 별도 PR로 권장

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-16-qotd-on-homepage-design.md`
- Plan: `docs/superpowers/plans/2026-05-16-qotd-on-homepage.md`

## Test plan

- [x] `npm run check` 통과 (tsc)
- [x] `npm run build` 통과 (정적 export `out/` 생성)
- [x] `out/index.html` 에 fallback 명언 "잘 정리된 노트는 …" 포함 확인
- [ ] 브라우저 정상 시나리오: 초기 페인트에 fallback 즉시 표시 → 1-2초 안에 inspire-me QOTD로 교체 → hover 시 커서 포인터 + opacity 변화
- [ ] 브라우저 새 탭 이동: 교체된 카드 클릭 시 `https://inspire-me.advenoh.pe.kr/quotes/{id}` 가 새 탭으로 열림, 원래 탭 유지
- [ ] 브라우저 오프라인 fallback: DevTools Offline 모드 → 새로고침 → fallback 그대로 표시, 카드 클릭 비반응, 콘솔에 `[useQuoteOfTheDay] failed to fetch QOTD` warning 1회만
- [ ] 모바일 viewport에서 카드 전체가 탭 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)