### PR TITLE
docs: uber/fx 글 제목 변경

### DIFF
--- a/contents/go/go-fx-의존성-주입/index.md
+++ b/contents/go/go-fx-의존성-주입/index.md
@@ -1,5 +1,5 @@
 ---
-title: "uber/fx로 의존성 주입 구현하기"
+title: "uber/fx로 시작하는 Go 의존성 주입"
 description: "uber/fx를 사용하여 Go 애플리케이션의 의존성을 자동으로 연결하고 수명주기를 관리하는 방법을 다룬다. fx.Module, fx.Decorate, fx.Annotate 등 고급 패턴과 테스트 전략까지 실전 예제로 설명한다."
 date: 2026-05-24
 update: 2026-05-24


### PR DESCRIPTION
## Summary
- uber/fx 글의 제목을 "uber/fx로 의존성 주입 구현하기" → "uber/fx로 시작하는 Go 의존성 주입"으로 변경
- 검색 키워드(Go, 의존성 주입)를 제목 앞쪽에 배치하고 입문~실전 흐름을 강조
- frontmatter의 `title`만 수정, slug(디렉토리명)은 유지

## Test plan
- [ ] 로컬에서 글 목록/상세에 변경된 제목이 정상 노출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)