### PR TITLE
[chore] README 자동 생성 PR auto-merge 활성화

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -43,6 +43,7 @@ jobs:
           git add README.md
           git commit -am "update README file"
     - name: Create Pull Request
+      id: create-pr
       uses: peter-evans/create-pull-request@v7
       with:
         commit-message: Update README file
@@ -55,3 +56,9 @@ jobs:
           automated pr
         assignees: kenshin579
         reviewers: kenshin579
+
+    - name: Enable auto-merge
+      if: steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"


### PR DESCRIPTION
## Summary
- `generate-readme.yml`에 auto-merge 스텝 추가 — conflict 없으면 자동 머지
- `peter-evans/create-pull-request` 출력의 `pull-request-number`를 받아 `gh pr merge --auto --squash` 실행
- `pull-request-operation` 체크로 실제 PR이 생성/업데이트된 경우에만 머지 시도 (변경 없을 때 스킵)

## Notes
- 동작 전제: 리포 **Settings → General → Pull Requests → "Allow auto-merge"** 가 활성화되어 있어야 함
- 기존 `auto-merge-pr.yml` (매일 오전 7시 일괄 머지)과 별개로, README PR은 즉시 머지 가능 상태가 되면 바로 처리됨

## Test plan
- [ ] merge 후 README 관련 변경이 발생하는 push 트리거 시 PR이 자동 생성되고 머지되는지 확인
- [ ] 변경사항 없는 경우 auto-merge 스텝이 스킵되는지 확인