### PR TITLE
docs: SNS 로그인 글 JWT vs 세션으로 재구성

### DIFF
--- a/docs/read/go-google-oauth-로그인-구현-가이드/index.md
+++ b/docs/read/go-google-oauth-로그인-구현-가이드/index.md
@@ -1,8 +1,8 @@
 ---
-title: "Go + React로 Google OAuth 2.0 로그인 구현하기"
-description: "Go Echo 백엔드와 React 프론트엔드로 Google OAuth 2.0 소셜 로그인을 구현하는 실전 가이드. Authorization Code Flow, JWT 토큰 관리, Provider 패턴까지 다룹니다."
+title: "Go + React로 Google OAuth 2.0 로그인 구현하기 (JWT vs 세션)"
+description: "Go Echo 백엔드와 React 프론트엔드로 Google OAuth 2.0 소셜 로그인을 구현하는 실전 가이드. OAuth 공통 흐름을 한 번 정리하고, 인증 이후 상태 유지 방식을 JWT(무상태)와 세션(서버 상태) 두 구현으로 나눠 비교합니다."
 date: 2026-03-01
-update: 2026-03-01
+update: 2026-06-03
 tags:
   - oauth2
   - google-login
@@ -10,6 +10,9 @@ tags:
   - golang
   - echo
   - jwt
+  - session
+  - cookie
+  - jwt-vs-session
   - react
   - gorm
   - sqlite
@@ -30,7 +33,9 @@ tags:
 - **UX 개선**: 클릭 한 번으로 로그인 완료
 - **개발 부담 감소**: 비밀번호 관리 로직이 필요 없다
 
-이 글에서는 **Go(Echo) 백엔드 + React 프론트엔드** 조합으로 Google OAuth 2.0 로그인을 처음부터 구현한다. 완성된 프로젝트는 아래와 같은 구조로 동작한다.
+여기서 한 가지 중요한 점을 미리 짚고 가자. **OAuth(신원 위임)와 로그인 이후의 "상태 유지 방식"은 서로 별개의 문제이다.** OAuth는 "이 사용자가 누구인지"를 Google에 위임해 확인하는 과정이고, 그 확인이 끝난 뒤 "이 사용자가 로그인 상태임을 어떻게 계속 기억할 것인가"는 또 다른 설계 결정이다. 상태 유지 방식에는 크게 **JWT(무상태 토큰)** 와 **세션(서버 상태)** 두 가지가 있으며, 둘은 트레이드오프가 다르다.
+
+이 글에서는 **Go(Echo) 백엔드 + React 프론트엔드** 조합으로 Google OAuth 2.0 로그인을 처음부터 구현한다. OAuth 공통 흐름을 한 번 설명한 뒤, 상태 유지 방식을 **① JWT 버전**과 **② 세션 버전** 두 가지로 나눠 각각 구현하고 비교한다.
 
 ```mermaid
 sequenceDiagram
@@ -43,17 +48,20 @@ sequenceDiagram
     FE->>BE: GET /api/auth/google/url
     BE-->>FE: 인증 URL 반환
     FE->>G: 인증 URL로 리다이렉트
-    G-->>FE: Authorization Code 반환
-    FE->>BE: GET /api/auth/google/callback?code=...
+    G-->>U: 로그인 + 동의 화면
+    U->>G: 계정 선택 / 동의
+    G-->>BE: Authorization Code (콜백)
     BE->>G: Code로 Access Token 교환
     G-->>BE: Access Token 반환
     BE->>G: 사용자 정보 조회
     G-->>BE: 이메일, 이름, 프로필 이미지
-    BE-->>FE: JWT 토큰 + 사용자 정보
-    FE->>U: 로그인 완료, 프로필 표시
+    BE-->>FE: 로그인 완료 (토큰 또는 세션 쿠키)
+    FE->>U: 프로필 표시
 ```
 
-> 전체 소스 코드는 [GitHub 저장소](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login)에서 확인할 수 있다.
+> 전체 소스 코드는 두 저장소에서 확인할 수 있다.
+> - JWT(무상태) 버전: [web/sns-login-jwt](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-jwt)
+> - 세션(서버 상태) 버전: [web/sns-login-session](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-session)
 
 # 2. OAuth 2.0 핵심 개념
 
@@ -151,17 +159,27 @@ Google Cloud Console에 등록된 Redirect URI만 허용된다. 공격자가 임
 
 1. **API 및 서비스 > 사용자 인증 정보**에서 **사용자 인증 정보 만들기 > OAuth 클라이언트 ID**를 선택한다
 2. 애플리케이션 유형: **웹 애플리케이션**
-3. 승인된 리다이렉션 URI에 아래 주소를 추가한다:
-   - `http://localhost:8080/api/auth/google/callback`
+3. 승인된 리다이렉션 URI에 **두 개**를 모두 추가한다:
+   - `http://localhost:3000/auth/callback` — **JWT 버전(SPA 토큰 플로우)** 용
+   - `http://localhost:8080/api/auth/google/callback` — **세션 버전(서버 redirect 플로우)** 용
 4. **만들기**를 클릭하면 **Client ID**와 **Client Secret**이 발급된다
 
 <!-- TODO: 스크린샷 삽입 - 클라이언트 ID 생성 -->
 
+> **왜 redirect URI가 두 개인가?** 이 글은 같은 OAuth 클라이언트를 두 구현이 함께 쓴다. Google은 인증이 끝난 뒤 **redirect URI로 Authorization Code를 돌려보내는데, 그 목적지가 두 플로우에서 다르다.**
+>
+> - **JWT 버전(SPA 토큰 플로우)**: Google이 **프론트엔드 라우트**(`http://localhost:3000/auth/callback`)로 redirect한다. 프론트가 URL에서 `code`를 꺼내 백엔드 API로 다시 전달한다.
+> - **세션 버전(서버 redirect 플로우)**: Google이 **백엔드 콜백 엔드포인트**(`http://localhost:8080/api/auth/google/callback`)로 직접 redirect한다. 백엔드가 그 자리에서 쿠키를 설정하고 프론트로 다시 보낸다.
+>
+> 각 버전은 자신에게 맞는 한 개의 URI만 사용하지만, 두 버전을 모두 실습하려면 콘솔에 둘 다 등록해 둬야 한다.
+
 > Client Secret은 절대 클라이언트(브라우저)에 노출하면 안 된다. 반드시 백엔드 환경변수로 관리한다.
 
-# 4. Go Backend 구현
+# 4. 공통 구현 (두 버전 동일)
 
-## 4.1 프로젝트 구조
+JWT 버전과 세션 버전은 **OAuth code 교환과 회원가입까지 완전히 동일**하다. 차이는 "인증이 끝난 뒤 상태를 어떻게 유지하느냐"에만 있다. 이 장에서는 두 버전이 공유하는 부분을 먼저 정리한다.
+
+## 4.1 백엔드 프로젝트 구조
 
 ```
 backend/
@@ -174,15 +192,13 @@ backend/
 ├── handler/
 │   ├── auth_handler.go      # 인증 API 핸들러
 │   └── user_handler.go      # 사용자 API 핸들러
-├── middleware/
-│   └── auth_middleware.go   # JWT 인증 미들웨어
+├── middleware/              # 인증 미들웨어 (버전별로 다름)
 ├── model/
 │   └── user.go              # User 모델 (GORM)
 ├── repository/
 │   └── user_repository.go   # DB 접근 계층
 ├── service/
-│   ├── auth_service.go      # 인증 비즈니스 로직
-│   └── token_service.go     # JWT 토큰 관리
+│   └── auth_service.go      # 인증 비즈니스 로직
 └── data/
     └── app.db               # SQLite 파일 (자동 생성)
 ```
@@ -214,7 +230,7 @@ type UserInfo struct {
 
 ## 4.3 Google OAuth Provider 구현
 
-`golang.org/x/oauth2` 패키지를 사용하여 Google OAuth를 구현한다.
+`golang.org/x/oauth2` 패키지를 사용하여 Google OAuth를 구현한다. 사용자 정보 응답을 읽고 파싱할 때 **에러를 무시하지 않고 모두 처리**하는 것이 중요하다.
 
 ```go
 // provider/google.go
@@ -245,14 +261,22 @@ func (g *GoogleProvider) ExchangeCode(ctx context.Context, code string) (*UserIn
     }
     defer resp.Body.Close()
 
-    // 3. JSON 파싱
+    // 3. 응답 본문 읽기 (에러 처리)
+    body, err := io.ReadAll(resp.Body)
+    if err != nil {
+        return nil, fmt.Errorf("응답 읽기 실패: %w", err)
+    }
+
+    // 4. JSON 파싱 (에러 처리)
     var googleUser struct {
         ID      string `json:"id"`
         Email   string `json:"email"`
         Name    string `json:"name"`
         Picture string `json:"picture"`
     }
-    json.NewDecoder(resp.Body).Decode(&googleUser)
+    if err := json.Unmarshal(body, &googleUser); err != nil {
+        return nil, fmt.Errorf("JSON 파싱 실패: %w", err)
+    }
 
     return &UserInfo{
         Email:      googleUser.Email,
@@ -269,120 +293,45 @@ func (g *GoogleProvider) ExchangeCode(ctx context.Context, code string) (*UserIn
 - `oauth2.Config.Exchange()`: Authorization Code를 Access Token으로 교환한다
 - `config.Client()`: Access Token이 자동으로 포함된 HTTP 클라이언트를 반환한다
 - Google UserInfo API(`/oauth2/v2/userinfo`)에서 이메일, 이름, 프로필 이미지를 가져온다
+- `io.ReadAll`로 본문을 읽고 `json.Unmarshal`로 파싱하되, **두 단계의 에러를 모두 처리**한다. 디코딩 에러를 무시하면 응답이 깨졌을 때 빈 사용자 정보가 그대로 흘러가 버린다
 
-## 4.4 JWT 토큰 관리
+## 4.4 회원가입: findOrCreateUser
 
-사용자 인증 후 **Access Token**(15분)과 **Refresh Token**(7일)을 발급한다.
-
-```go
-// service/token_service.go
-func (s *TokenService) GenerateTokenPair(userID uint) (*TokenPair, error) {
-    accessToken, err := s.generateToken(userID, 15*time.Minute)
-    if err != nil {
-        return nil, err
-    }
-
-    refreshToken, err := s.generateToken(userID, 7*24*time.Hour)
-    if err != nil {
-        return nil, err
-    }
-
-    return &TokenPair{
-        AccessToken:  accessToken,
-        RefreshToken: refreshToken,
-    }, nil
-}
-```
-
-| 토큰 | 만료 시간 | 용도 |
-|------|----------|------|
-| Access Token | 15분 | API 요청 인증 |
-| Refresh Token | 7일 | Access Token 갱신 |
-
-## 4.5 인증 미들웨어
-
-보호된 API에 접근할 때 JWT를 검증하는 Echo 미들웨어이다.
+OAuth로 신원이 확인되면, DB에서 사용자를 조회하고 없으면 **자동으로 회원가입**시킨다. 이미 가입된 사용자라면 재로그인 시 이름/프로필 이미지를 최신 값으로 갱신한다.
 
 ```go
-// middleware/auth_middleware.go
-func JWTAuth(tokenService *service.TokenService) echo.MiddlewareFunc {
-    return func(next echo.HandlerFunc) echo.HandlerFunc {
-        return func(c echo.Context) error {
-            // Authorization: Bearer <token> 헤더 파싱
-            authHeader := c.Request().Header.Get("Authorization")
-            parts := strings.SplitN(authHeader, " ", 2)
-            if len(parts) != 2 || parts[0] != "Bearer" {
-                return echo.NewHTTPError(http.StatusUnauthorized, "잘못된 Authorization 형식")
-            }
-
-            // 토큰 검증
-            claims, err := tokenService.ValidateToken(parts[1])
-            if err != nil {
-                return echo.NewHTTPError(http.StatusUnauthorized, "유효하지 않은 토큰")
-            }
-
-            // Context에 사용자 ID 저장
-            c.Set("user_id", claims.UserID)
-            return next(c)
+// service/auth_service.go
+func (s *AuthService) findOrCreateUser(info *provider.UserInfo) (*model.User, error) {
+    user, err := s.userRepo.FindByProviderID(info.Provider, info.ProviderID)
+    if err == nil {
+        // 재로그인: 프로필 최신화
+        user.Name = info.Name
+        user.AvatarURL = info.AvatarURL
+        if err := s.userRepo.Update(user); err != nil {
+            return nil, err
         }
-    }
-}
-```
-
-## 4.6 API 핸들러 구현
-
-| Method | Path | 설명 | 인증 |
-|--------|------|------|------|
-| GET | `/api/auth/:provider/url` | OAuth 인증 URL 반환 | 불필요 |
-| GET | `/api/auth/:provider/callback` | Authorization Code로 로그인/가입 | 불필요 |
-| POST | `/api/auth/refresh` | Access Token 갱신 | 불필요 |
-| POST | `/api/auth/logout` | 로그아웃 | 불필요 |
-| GET | `/api/user/me` | 현재 사용자 정보 | 필요 |
-
-`auth_handler.go`의 콜백 핸들러는 다음 순서로 동작한다:
-
-1. `state` 파라미터 검증 (CSRF 방지)
-2. Authorization Code로 사용자 정보 교환 (Provider에 위임)
-3. DB에서 사용자 조회 또는 신규 생성
-4. JWT 토큰 쌍 발급 후 응답
-
-```go
-// handler/auth_handler.go - HandleCallback
-func (h *AuthHandler) HandleCallback(c echo.Context) error {
-    providerName := c.Param("provider")
-    code := c.QueryParam("code")
-    state := c.QueryParam("state")
-
-    tokens, user, err := h.authService.HandleCallback(
-        c.Request().Context(), providerName, code, state,
-    )
-    if err != nil {
-        return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+        return user, nil
     }
 
-    return c.JSON(http.StatusOK, map[string]interface{}{
-        "tokens": tokens,
-        "user":   user,
-    })
+    if !errors.Is(err, gorm.ErrRecordNotFound) {
+        return nil, err
+    }
+
+    newUser := &model.User{
+        Email:      info.Email,
+        Name:       info.Name,
+        AvatarURL:  info.AvatarURL,
+        Provider:   info.Provider,
+        ProviderID: info.ProviderID,
+    }
+    if err := s.userRepo.Create(newUser); err != nil {
+        return nil, err
+    }
+    return newUser, nil
 }
 ```
 
-## 4.7 SQLite + GORM 연동
-
-GORM의 `AutoMigrate`를 사용하면 테이블을 자동으로 생성할 수 있다.
-
-```go
-// main.go
-db, err := gorm.Open(sqlite.Open("data/app.db"), &gorm.Config{})
-if err != nil {
-    log.Fatal("DB 연결 실패:", err)
-}
-
-// 테이블 자동 생성
-db.AutoMigrate(&model.User{})
-```
-
-User 모델:
+User 모델(GORM)은 다음과 같다. `provider` + `provider_id` 조합으로 사용자를 식별한다.
 
 ```go
 // model/user.go
@@ -399,17 +348,225 @@ type User struct {
 }
 ```
 
-# 5. React Frontend 연동
+## 4.5 state 저장과 CSRF 검증
 
-## 5.1 인증 서비스 및 API 클라이언트
+`state`는 발급할 때 서버에 저장해 두고, 콜백에서 **그 값이 우리가 발급한 것인지** 확인해야 한다. 이 예제에서는 간단히 `sync.Map`에 저장한다. 인증 URL을 만들 때 `Store`로 넣고, 콜백에서 `LoadAndDelete`로 꺼내면서 동시에 삭제한다(일회성 보장).
 
-Axios 인터셉터를 사용하여 **모든 API 요청에 JWT를 자동으로 첨부**한다. 401 응답 시 Refresh Token으로 갱신을 시도한다.
+```go
+// service/auth_service.go
+type AuthService struct {
+    providers map[string]provider.OAuthProvider
+    userRepo  *repository.UserRepository
+    // ...상태 유지 의존성(버전별로 다름)...
+    states    sync.Map // state 파라미터 저장 (CSRF 방지)
+}
+
+// GetAuthURL은 OAuth 인증 URL과 state를 반환한다
+func (s *AuthService) GetAuthURL(providerName string) (string, error) {
+    p, ok := s.providers[providerName]
+    if !ok {
+        return "", errors.New("지원하지 않는 provider: " + providerName)
+    }
+
+    state := generateState()
+    s.states.Store(state, true) // 발급한 state 저장
+
+    return p.GetAuthURL(state), nil
+}
+
+func generateState() string {
+    b := make([]byte, 16)
+    _, _ = rand.Read(b)
+    return hex.EncodeToString(b)
+}
+```
+
+콜백 처리에서는 `LoadAndDelete`로 state를 검증한다.
+
+```go
+// state 검증 (CSRF 방지) — 콜백 진입 직후
+if _, ok := s.states.LoadAndDelete(state); !ok {
+    return nil, nil, errors.New("유효하지 않은 state")
+}
+```
+
+> `sync.Map` 저장은 단일 인스턴스 데모용이다. 프로덕션에서 서버가 여러 대라면 발급한 state를 Redis 같은 공유 저장소나 서명된 쿠키에 보관해야 한다.
+
+여기까지가 두 버전의 공통부다. 이제 "인증 이후 상태 유지"가 갈라진다.
+
+# 5. 상태 유지 방식 ① — JWT (무상태)
+
+JWT 버전은 로그인에 성공하면 **서명된 토큰(access/refresh)을 클라이언트에 발급**한다. 서버는 별도의 세션 상태를 저장하지 않고, 요청마다 토큰 서명만 검증한다(무상태).
+
+> 전체 코드: [web/sns-login-jwt](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-jwt)
+
+## 5.1 SPA 토큰 플로우
+
+JWT 버전은 **프론트엔드가 콜백을 받는 SPA 토큰 플로우**를 쓴다. Google이 프론트 라우트(`/auth/callback`)로 redirect하고, 프론트가 URL의 `code`를 백엔드 API로 전달해 토큰을 받는다.
+
+```mermaid
+sequenceDiagram
+    participant U as 사용자
+    participant FE as React Frontend
+    participant BE as Go Backend
+    participant G as Google
+
+    U->>FE: Google로 로그인 클릭
+    FE->>BE: GET /api/auth/google/url
+    BE-->>FE: 인증 URL (redirect_uri = 프론트)
+    FE->>G: 인증 URL로 이동
+    G-->>FE: /auth/callback?code&state 로 redirect
+    FE->>BE: GET /api/auth/google/callback?code&state
+    BE->>G: code 교환 → 사용자 정보
+    BE-->>FE: access/refresh 토큰 + 사용자 JSON
+    FE->>FE: localStorage에 토큰 저장
+    FE->>BE: 이후 Authorization Bearer 로 API 호출
+```
+
+따라서 이 버전은 `redirect_uri`가 **프론트엔드** 주소다.
+
+```go
+// config/config.go
+GoogleRedirectURL: getEnv("GOOGLE_REDIRECT_URL", "http://localhost:3000/auth/callback"),
+JWTSecret:         getEnv("JWT_SECRET", "dev-only-change-me"),
+```
+
+> `JWT_SECRET` 기본값 `dev-only-change-me`는 로컬 개발 전용이다. 프로덕션에서는 반드시 충분히 긴 랜덤 값으로 교체한다.
+
+## 5.2 토큰 타입 구분 (access vs refresh)
+
+**Access Token**(15분)과 **Refresh Token**(7일)을 발급하되, 각 토큰에 `token_type` 클레임을 넣어 **용도를 구분**한다. 이렇게 하면 refresh 토큰으로 보호 API를 호출하는 것을 미들웨어에서 차단할 수 있다.
+
+```go
+// service/token_service.go
+const (
+    TokenTypeAccess  = "access"
+    TokenTypeRefresh = "refresh"
+)
+
+type Claims struct {
+    UserID    uint   `json:"user_id"`
+    TokenType string `json:"token_type"`
+    jwt.RegisteredClaims
+}
+
+func (s *TokenService) GenerateTokenPair(userID uint) (*TokenPair, error) {
+    accessToken, err := s.generateToken(userID, TokenTypeAccess, s.accessExpiry)
+    if err != nil {
+        return nil, err
+    }
+    refreshToken, err := s.generateToken(userID, TokenTypeRefresh, s.refreshExpiry)
+    if err != nil {
+        return nil, err
+    }
+    return &TokenPair{AccessToken: accessToken, RefreshToken: refreshToken}, nil
+}
+```
+
+| 토큰 | 만료 시간 | `token_type` | 용도 |
+|------|----------|--------------|------|
+| Access Token | 15분 | `access` | 보호 API 요청 인증 |
+| Refresh Token | 7일 | `refresh` | Access Token 갱신 전용 |
+
+## 5.3 인증 미들웨어 — access 토큰만 허용
+
+보호 API에 접근할 때 JWT를 검증하는 Echo 미들웨어이다. 토큰 서명을 검증한 뒤 **`token_type`이 `access`인지 추가로 확인**해서, 수명이 긴 refresh 토큰으로 API를 호출하는 것을 막는다.
+
+```go
+// middleware/auth_middleware.go
+func JWTAuth(tokenService *service.TokenService) echo.MiddlewareFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            authHeader := c.Request().Header.Get("Authorization")
+            if authHeader == "" {
+                return echo.NewHTTPError(http.StatusUnauthorized, "Authorization 헤더가 필요합니다")
+            }
+
+            // "Bearer <token>" 형식 파싱
+            parts := strings.SplitN(authHeader, " ", 2)
+            if len(parts) != 2 || parts[0] != "Bearer" {
+                return echo.NewHTTPError(http.StatusUnauthorized, "잘못된 Authorization 형식")
+            }
+
+            claims, err := tokenService.ValidateToken(parts[1])
+            if err != nil {
+                return echo.NewHTTPError(http.StatusUnauthorized, "유효하지 않은 토큰")
+            }
+
+            // access 토큰만 보호 API 접근 허용 (refresh 토큰 차단)
+            if claims.TokenType != service.TokenTypeAccess {
+                return echo.NewHTTPError(http.StatusUnauthorized, "access 토큰이 필요합니다")
+            }
+
+            c.Set("user_id", claims.UserID)
+            return next(c)
+        }
+    }
+}
+```
+
+대칭적으로, 토큰 갱신 엔드포인트(`POST /api/auth/refresh`)는 **반드시 refresh 토큰**이어야 한다. access 토큰으로 갱신을 시도하면 거부한다.
+
+```go
+// service/auth_service.go
+func (s *AuthService) RefreshToken(refreshToken string) (*TokenPair, error) {
+    claims, err := s.tokenService.ValidateToken(refreshToken)
+    if err != nil {
+        return nil, errors.New("유효하지 않은 refresh token")
+    }
+
+    if claims.TokenType != TokenTypeRefresh {
+        return nil, errors.New("refresh token이 아닙니다")
+    }
+
+    return s.tokenService.GenerateTokenPair(claims.UserID)
+}
+```
+
+## 5.4 콜백 핸들러
+
+콜백 핸들러는 `code` 누락을 먼저 검증하고, code를 토큰으로 교환해 JSON으로 응답한다.
+
+```go
+// handler/auth_handler.go
+func (h *AuthHandler) HandleCallback(c echo.Context) error {
+    providerName := c.Param("provider")
+    code := c.QueryParam("code")
+    state := c.QueryParam("state")
+
+    if code == "" {
+        return echo.NewHTTPError(http.StatusBadRequest, "code 파라미터가 필요합니다")
+    }
+
+    tokens, user, err := h.authService.HandleCallback(c.Request().Context(), providerName, code, state)
+    if err != nil {
+        return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+    }
+
+    return c.JSON(http.StatusOK, map[string]interface{}{
+        "tokens": tokens,
+        "user":   user,
+    })
+}
+```
+
+| Method | Path | 설명 | 인증 |
+|--------|------|------|------|
+| GET | `/api/auth/:provider/url` | OAuth 인증 URL 반환 | 불필요 |
+| GET | `/api/auth/:provider/callback` | Authorization Code로 로그인/가입 | 불필요 |
+| POST | `/api/auth/refresh` | Access Token 갱신 (refresh 토큰 필요) | 불필요 |
+| POST | `/api/auth/logout` | 로그아웃 (클라이언트가 토큰 삭제) | 불필요 |
+| GET | `/api/user/me` | 현재 사용자 정보 | 필요 (access 토큰) |
+
+## 5.5 프론트엔드 연동
+
+Axios 인터셉터로 **모든 요청에 access 토큰을 자동 첨부**하고, 401 응답 시 refresh 토큰으로 갱신을 시도한다.
 
 ```typescript
 // services/authService.ts
 const api = axios.create({ baseURL: API_URL });
 
-// 요청 인터셉터: JWT 자동 첨부
+// 요청 인터셉터: JWT 토큰 자동 첨부
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('access_token');
   if (token) {
@@ -422,43 +579,27 @@ api.interceptors.request.use((config) => {
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
-    if (error.response?.status === 401 && !error.config._retry) {
-      error.config._retry = true;
-      const tokens = await refreshToken();
-      localStorage.setItem('access_token', tokens.access_token);
-      return api(error.config); // 원래 요청 재시도
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const tokens = await refreshToken();
+        localStorage.setItem('access_token', tokens.access_token);
+        localStorage.setItem('refresh_token', tokens.refresh_token);
+        originalRequest.headers.Authorization = `Bearer ${tokens.access_token}`;
+        return api(originalRequest);
+      } catch {
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('refresh_token');
+        window.location.href = '/login';
+      }
     }
     return Promise.reject(error);
   }
 );
 ```
 
-## 5.2 로그인 UI 구현
-
-### LoginButton
-
-Google 로그인 버튼을 클릭하면 백엔드에서 인증 URL을 받아 리다이렉트한다.
-
-```tsx
-// components/LoginButton.tsx
-export function LoginButton() {
-  const handleGoogleLogin = async () => {
-    const url = await getGoogleAuthURL();
-    window.location.href = url; // Google 인증 페이지로 이동
-  };
-
-  return (
-    <button onClick={handleGoogleLogin}>
-      <img src="google-icon.svg" alt="Google" />
-      Google로 로그인
-    </button>
-  );
-}
-```
-
-### OAuth 콜백 페이지
-
-Google 인증 완료 후 돌아오면 URL의 `code`와 `state`를 백엔드로 전달한다.
+Google이 프론트 라우트로 돌려주면, 콜백 컴포넌트가 URL에서 `code`/`state`를 꺼내 백엔드로 전달하고 받은 토큰을 저장한다.
 
 ```tsx
 // components/OAuthCallback.tsx
@@ -470,10 +611,18 @@ export function OAuthCallback({ onLogin }: Props) {
     const code = searchParams.get('code');
     const state = searchParams.get('state');
 
-    handleCallback(code!, state!)
+    if (!code || !state) {
+      setError('인증 정보가 없습니다');
+      return;
+    }
+
+    handleCallback(code, state)
       .then((res) => {
         onLogin(res.user, res.tokens.access_token, res.tokens.refresh_token);
         navigate('/');
+      })
+      .catch(() => {
+        setError('로그인에 실패했습니다');
       });
   }, [searchParams, onLogin, navigate]);
 
@@ -481,27 +630,243 @@ export function OAuthCallback({ onLogin }: Props) {
 }
 ```
 
-### UserProfile
+# 6. 상태 유지 방식 ② — 세션 (서버 상태 + SQLite)
 
-로그인 후 사용자 정보를 표시하고 로그아웃 기능을 제공한다.
+세션 버전은 로그인에 성공하면 서버가 **`sessions` 테이블에 세션 행(row)을 만들고**, 그 세션 ID를 **HttpOnly 쿠키**로 내려준다. 이후 요청마다 쿠키의 세션 ID로 DB를 조회해 유효성을 확인한다(서버 상태).
 
-```tsx
-// components/UserProfile.tsx
-export function UserProfile({ user, onLogout }: Props) {
-  return (
-    <div>
-      <img src={user.avatar_url} alt="프로필" />
-      <h2>{user.name}</h2>
-      <p>{user.email}</p>
-      <button onClick={onLogout}>로그아웃</button>
-    </div>
-  );
+> 전체 코드: [web/sns-login-session](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-session)
+
+## 6.1 서버 redirect 플로우
+
+세션 버전은 **백엔드가 콜백을 직접 받는** 클래식 서버 세션 플로우다. Google이 백엔드 콜백으로 redirect하면, 백엔드가 그 자리에서 쿠키를 설정하고 프론트로 302 redirect한다. 프론트는 토큰을 직접 다루지 않는다.
+
+```mermaid
+sequenceDiagram
+    participant U as 사용자
+    participant FE as React Frontend
+    participant BE as Go Backend
+    participant G as Google
+
+    U->>FE: Google로 로그인 클릭
+    FE->>BE: GET /api/auth/google/url
+    BE-->>FE: 인증 URL (redirect_uri = 백엔드)
+    FE->>G: 인증 URL로 이동
+    G-->>BE: /api/auth/google/callback?code&state 로 redirect
+    BE->>G: code 교환 → 사용자 정보
+    BE->>BE: sessions row 생성
+    BE-->>FE: Set-Cookie(HttpOnly) + 302 redirect (프론트로)
+    FE->>BE: GET /api/user/me (쿠키 자동 전송)
+    BE-->>FE: 사용자 정보
+```
+
+따라서 이 버전은 `redirect_uri`가 **백엔드** 주소다. JWT 시크릿은 필요 없으므로 config에도 없다.
+
+```go
+// config/config.go
+GoogleRedirectURL: getEnv("GOOGLE_REDIRECT_URL", "http://localhost:8080/api/auth/google/callback"),
+```
+
+## 6.2 Session 모델과 저장소
+
+세션은 SQLite의 `sessions` 테이블에 저장한다. ID는 랜덤 토큰을 PK로 쓰고, 만료 시각을 함께 보관한다.
+
+```go
+// model/session.go
+type Session struct {
+    ID        string    `gorm:"primarykey" json:"id"` // 랜덤 세션 토큰
+    UserID    uint      `gorm:"index;not null" json:"user_id"`
+    ExpiresAt time.Time `gorm:"not null" json:"expires_at"`
+    CreatedAt time.Time `json:"created_at"`
 }
 ```
 
-## 5.3 인증 상태 관리
+저장소는 생성/조회/삭제만 가진 단순한 CRUD다.
 
-`useAuth` 훅으로 인증 상태를 중앙에서 관리한다. 앱이 로드될 때 저장된 토큰으로 사용자 정보를 자동 복원한다.
+```go
+// repository/session_repository.go
+func (r *SessionRepository) Create(s *model.Session) error {
+    return r.db.Create(s).Error
+}
+
+func (r *SessionRepository) FindByID(id string) (*model.Session, error) {
+    var s model.Session
+    if err := r.db.First(&s, "id = ?", id).Error; err != nil {
+        return nil, err
+    }
+    return &s, nil
+}
+
+func (r *SessionRepository) Delete(id string) error {
+    return r.db.Delete(&model.Session{}, "id = ?", id).Error
+}
+```
+
+## 6.3 Session 서비스 — 생성/검증/삭제
+
+서비스는 랜덤 세션 ID를 만들어 저장하고, 검증 시 **만료를 확인**한다. 만료된 세션은 조회 시점에 정리한다.
+
+```go
+// service/session_service.go
+func (s *SessionService) Create(userID uint) (*model.Session, error) {
+    sess := &model.Session{
+        ID:        generateSessionID(),
+        UserID:    userID,
+        ExpiresAt: time.Now().Add(s.expiry),
+    }
+    if err := s.repo.Create(sess); err != nil {
+        return nil, err
+    }
+    return sess, nil
+}
+
+// Validate는 세션 ID로 사용자 ID를 반환한다. 만료/없음이면 에러.
+func (s *SessionService) Validate(id string) (uint, error) {
+    sess, err := s.repo.FindByID(id)
+    if err != nil {
+        return 0, err
+    }
+    if time.Now().After(sess.ExpiresAt) {
+        _ = s.repo.Delete(id) // 만료 세션 정리
+        return 0, errors.New("만료된 세션")
+    }
+    return sess.UserID, nil
+}
+
+func (s *SessionService) Delete(id string) error {
+    return s.repo.Delete(id)
+}
+
+func generateSessionID() string {
+    b := make([]byte, 32)
+    _, _ = rand.Read(b)
+    return hex.EncodeToString(b)
+}
+```
+
+## 6.4 세션 미들웨어 — 쿠키 검증
+
+보호 API에서는 Authorization 헤더 대신 **쿠키의 세션 ID**를 읽어 `Validate`로 검증한다.
+
+```go
+// middleware/session_middleware.go
+const SessionCookieName = "session_id"
+
+// SessionAuth는 세션 쿠키를 검증하는 미들웨어
+func SessionAuth(sessionService *service.SessionService) echo.MiddlewareFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            cookie, err := c.Cookie(SessionCookieName)
+            if err != nil {
+                return echo.NewHTTPError(http.StatusUnauthorized, "세션 쿠키가 필요합니다")
+            }
+            userID, err := sessionService.Validate(cookie.Value)
+            if err != nil {
+                return echo.NewHTTPError(http.StatusUnauthorized, "유효하지 않은 세션")
+            }
+            c.Set("user_id", userID)
+            return next(c)
+        }
+    }
+}
+```
+
+## 6.5 콜백에서 쿠키 설정 + redirect
+
+콜백 핸들러는 세션을 만든 뒤 **HttpOnly 세션 쿠키**를 설정하고 프론트로 302 redirect한다.
+
+```go
+// handler/auth_handler.go
+func (h *AuthHandler) HandleCallback(c echo.Context) error {
+    providerName := c.Param("provider")
+    code := c.QueryParam("code")
+    state := c.QueryParam("state")
+    if code == "" {
+        return echo.NewHTTPError(http.StatusBadRequest, "code 파라미터가 필요합니다")
+    }
+
+    sess, _, err := h.authService.HandleCallback(c.Request().Context(), providerName, code, state)
+    if err != nil {
+        return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+    }
+
+    // HttpOnly 세션 쿠키 설정 후 프론트로 redirect
+    c.SetCookie(&http.Cookie{
+        Name:     customMiddleware.SessionCookieName,
+        Value:    sess.ID,
+        Path:     "/",
+        Expires:  sess.ExpiresAt,
+        HttpOnly: true,
+        SameSite: http.SameSiteLaxMode,
+        // 개발(동일 사이트, localhost)에서는 Lax로 충분.
+        // 프로덕션에서 프론트/백엔드가 다른 사이트면 SameSite=None + Secure 필요 (HTTPS).
+        // Secure: true,
+    })
+    return c.Redirect(http.StatusFound, h.frontendURL)
+}
+```
+
+> **SameSite 주의**: 개발 환경처럼 프론트/백엔드가 같은 사이트(localhost)면 `SameSite=Lax`로 충분하다. 하지만 프로덕션에서 프론트와 백엔드가 **다른 사이트(cross-site)** 라면, 브라우저가 redirect 후 쿠키를 보내도록 `SameSite=None` + `Secure`(HTTPS 필수) 조합을 써야 한다.
+
+## 6.6 로그아웃 = 세션 삭제 (서버측 무효화)
+
+세션 방식의 **가장 큰 차별점**이다. 로그아웃은 단순히 클라이언트 쿠키만 지우는 게 아니라, **서버의 세션 행 자체를 삭제**한다. 행이 사라지면 그 세션 ID는 즉시 무효가 되어, 설령 쿠키가 어딘가에 남아 있어도 더 이상 통하지 않는다(서버측 즉시 무효화). 삭제에 실패하면 500을 반환해 무효화가 누락되지 않도록 한다.
+
+```go
+// handler/auth_handler.go
+func (h *AuthHandler) Logout(c echo.Context) error {
+    if cookie, err := c.Cookie(customMiddleware.SessionCookieName); err == nil {
+        if err := h.authService.Logout(cookie.Value); err != nil {
+            c.Logger().Error(err)
+            return echo.NewHTTPError(http.StatusInternalServerError, "로그아웃 처리 실패")
+        }
+    }
+    c.SetCookie(&http.Cookie{
+        Name:     customMiddleware.SessionCookieName,
+        Value:    "",
+        Path:     "/",
+        Expires:  time.Unix(0, 0),
+        MaxAge:   -1,
+        HttpOnly: true,
+        SameSite: http.SameSiteLaxMode,
+    })
+    return c.JSON(http.StatusOK, map[string]string{"message": "로그아웃 성공"})
+}
+```
+
+`AuthService.Logout`은 세션 서비스에 삭제를 위임할 뿐이다.
+
+```go
+// service/auth_service.go
+func (s *AuthService) Logout(sessionID string) error {
+    return s.sessionService.Delete(sessionID)
+}
+```
+
+## 6.7 프론트엔드 연동 (토큰 보관 없음)
+
+프론트는 토큰을 다루지 않는다. axios에 `withCredentials: true`만 주면 쿠키가 자동으로 오간다. 로그인 상태 확인은 `/api/user/me` 호출로 대신한다.
+
+```typescript
+// services/authService.ts
+// withCredentials: 쿠키를 교차 출처 요청에 포함
+const api = axios.create({ baseURL: API_URL, withCredentials: true });
+
+export async function getGoogleAuthURL(): Promise<string> {
+  const { data } = await api.get<{ url: string }>('/api/auth/google/url');
+  return data.url;
+}
+
+export async function getMe(): Promise<User> {
+  const { data } = await api.get<User>('/api/user/me');
+  return data;
+}
+
+export async function logout(): Promise<void> {
+  await api.post('/api/auth/logout');
+}
+```
+
+`useAuth` 훅은 앱 로드 시 `getMe`를 호출해 쿠키 기반으로 사용자 정보를 복원한다. 별도의 콜백 페이지가 필요 없다(Google → 백엔드 → 프론트 `/`로 자연스럽게 돌아온다).
 
 ```typescript
 // hooks/useAuth.ts
@@ -509,124 +874,57 @@ export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const token = localStorage.getItem('access_token');
-    if (token) {
-      getMe()
-        .then(setUser)
-        .catch(() => {
-          localStorage.removeItem('access_token');
-          localStorage.removeItem('refresh_token');
-        })
-        .finally(() => setLoading(false));
-    } else {
-      setLoading(false);
-    }
+  const refresh = useCallback(() => {
+    getMe()
+      .then(setUser)
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
   }, []);
 
-  return { user, loading, isAuthenticated: !!user, login, logout };
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const logout = useCallback(async () => {
+    await logoutApi();
+    setUser(null);
+  }, []);
+
+  return { user, loading, isAuthenticated: !!user, logout };
 }
 ```
 
-`ProtectedRoute` 컴포넌트로 미인증 사용자의 접근을 차단한다:
+> CORS 주의: 쿠키를 주고받으려면 백엔드 CORS에서 `AllowCredentials: true`와 함께 `AllowOrigins`를 **정확한 프론트 주소**로 지정해야 한다. 와일드카드 `*`와 credentials는 함께 쓸 수 없다.
 
-```tsx
-// components/ProtectedRoute.tsx
-export function ProtectedRoute({ isAuthenticated, children }: Props) {
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
-  return <>{children}</>;
-}
-```
+# 7. JWT vs 세션 비교
 
-# 6. 전체 플로우 시연
+두 구현 모두 OAuth 흐름은 같고, "인증 이후 상태 유지"만 다르다. 핵심 차이는 다음과 같다.
 
-## 6.1 docker-compose로 실행
+| 기준 | JWT (무상태) | 세션 (서버 상태) |
+|------|-------------|-----------------|
+| 상태 저장 | 클라이언트 보관, 서버 무상태 | 서버(SQLite 등)에 세션 저장 |
+| 서버측 로그아웃/강제 차단 | 어려움(만료 전까지 유효) | 쉬움(row 삭제로 즉시 무효화) |
+| 수평 확장 | 용이(공유 상태 불필요) | 세션 스토어 공유 필요 |
+| 탈취 시 영향 | 만료까지 유효, 회수 어려움 | 즉시 회수 가능 |
+| 저장 위치 보안 | localStorage(XSS) vs 쿠키 | HttpOnly 쿠키 |
+| 적합 | FE/BE 분리, MSA, 무상태 API | 단일/소규모, 즉시 무효화 중요 |
 
-```yaml
-# docker-compose.yml
-services:
-  backend:
-    build: ./backend
-    ports:
-      - "8080:8080"
-    environment:
-      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
-      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      - JWT_SECRET=${JWT_SECRET:-my-secret-key}
-      - FRONTEND_URL=http://localhost:3000
+## 선택 가이드
 
-  frontend:
-    build: ./frontend
-    ports:
-      - "3000:80"
-    depends_on:
-      - backend
-```
+- **세션이 잘 맞는 경우**: 서비스가 단일/소규모이고, "로그아웃하면 즉시 차단", "관리자가 특정 사용자 강제 로그아웃" 같은 **서버측 즉시 무효화**가 중요한 경우. 쿠키(HttpOnly)에 담기므로 토큰을 localStorage에 두는 것보다 XSS 노출 면에서도 다루기 쉽다.
+- **JWT가 잘 맞는 경우**: 여러 서비스/마이크로서비스가 공유 세션 스토어 없이 **수평 확장**해야 하고, 모바일 등 다양한 클라이언트에 무상태 API를 제공하는 경우.
 
-실행 방법:
+> **JWT는 필수가 아니다.** SNS 로그인이나 SPA를 만든다고 해서 반드시 JWT를 써야 하는 것은 아니다. 오히려 단일 백엔드 + 웹 프론트라면 서버 세션이 더 단순하고, 즉시 로그아웃 같은 요구사항도 자연스럽게 충족한다. "OAuth = JWT"라는 등식은 성립하지 않는다 — OAuth는 신원 위임이고, JWT/세션은 그 이후 상태 유지 방식 중 하나의 선택지일 뿐이다.
 
-```bash
-# .env 파일에 Google OAuth 정보 설정
-> cp .env.example .env
-> vi .env
+# 8. 마무리
 
-# 서비스 시작
-> docker compose up -d
+이 글에서는 OAuth 2.0 Authorization Code Flow로 Google 소셜 로그인을 구현하고, 인증 이후 상태 유지 방식을 JWT와 세션 두 가지로 나눠 비교했다. 핵심 포인트:
 
-# 접속 확인
-> curl http://localhost:8080/health
-{"status":"ok"}
-```
-
-| 서비스 | URL |
-|--------|-----|
-| Frontend | http://localhost:3000 |
-| Backend API | http://localhost:8080 |
-| Health Check | http://localhost:8080/health |
-
-## 6.2 회원가입 / 로그인 / 로그아웃 시연
-
-1. http://localhost:3000 에 접속하면 로그인 페이지로 리다이렉트된다
-2. **Google로 로그인** 버튼을 클릭한다
-3. Google 계정을 선택하고 동의한다
-4. 자동으로 콜백이 처리되고 프로필 페이지가 표시된다
-5. **로그아웃** 버튼을 클릭하면 토큰이 삭제되고 로그인 페이지로 돌아간다
-
-<!-- TODO: 스크린샷 삽입 - 로그인 플로우 -->
-
-SQLite에 저장된 사용자 데이터를 확인할 수 있다:
-
-```bash
-> sqlite3 backend/data/app.db "SELECT id, email, name, provider FROM users;"
-1|user@gmail.com|홍길동|google
-```
-
-## 6.3 CORS 설정
-
-Backend와 Frontend가 다른 포트에서 실행되므로 CORS 설정이 필요하다.
-
-```go
-// main.go
-e.Use(echoMiddleware.CORSWithConfig(echoMiddleware.CORSConfig{
-    AllowOrigins:     []string{cfg.FrontendURL}, // http://localhost:3000
-    AllowMethods:     []string{"GET", "POST", "PUT", "DELETE"},
-    AllowHeaders:     []string{"Authorization", "Content-Type"},
-    AllowCredentials: true,
-}))
-```
-
-- `AllowOrigins`: Frontend 주소만 허용한다 (와일드카드 `*` 사용 금지)
-- `AllowCredentials`: 쿠키/인증 헤더 전송을 허용한다
-
-# 7. 마무리
-
-이 글에서는 OAuth 2.0 Authorization Code Flow를 활용하여 Google 소셜 로그인을 구현했다. 핵심 포인트를 정리하면:
-
+- **OAuth와 상태 유지는 별개**: OAuth는 신원 위임, JWT/세션은 그 이후의 상태 유지 방식
 - **Authorization Code Flow**: 브라우저에는 일회성 Code만 노출, Access Token은 서버에서 안전하게 교환
 - **Provider 패턴**: 인터페이스를 정의하여 새로운 SNS 추가가 용이한 구조
-- **JWT 이중 토큰**: Access Token(단기) + Refresh Token(장기)으로 보안과 UX를 동시에 확보
+- **JWT 토큰 타입 구분**: `token_type` 클레임으로 access/refresh를 구분, 미들웨어에서 access만 허용
+- **세션 = 서버측 무효화**: 로그아웃이 세션 행 삭제로 즉시 반영
 - **state 파라미터**: CSRF 공격 방지를 위한 필수 보안 요소
 
 ### 프로덕션 환경에서 추가로 고려할 사항
@@ -634,12 +932,15 @@ e.Use(echoMiddleware.CORSWithConfig(echoMiddleware.CORSConfig{
 | 항목 | 설명 |
 |------|------|
 | **PKCE** | Authorization Code 가로채기 방지. `code_verifier`/`code_challenge` 쌍으로 Code 교환 시 검증 |
-| **Refresh Token Rotation** | Refresh Token 사용 시마다 새 토큰 발급. 탈취된 토큰의 재사용 감지/차단 |
+| **Refresh Token Rotation** | (JWT) Refresh Token 사용 시마다 새 토큰 발급. 탈취된 토큰의 재사용 감지/차단 |
 | **Rate Limiting** | 로그인/토큰 갱신 API에 요청 횟수 제한. 브루트포스 방지 |
-| **Secure Cookie** | JWT를 localStorage 대신 HttpOnly + Secure + SameSite 쿠키에 저장하여 XSS 방지 |
-| **HTTPS** | OAuth 리다이렉트 및 토큰 전송 시 중간자 공격(MITM) 방지 |
+| **Secure Cookie** | 쿠키에 `HttpOnly` + `Secure` + `SameSite` 적용하여 XSS/CSRF 방지 (세션 쿠키, 또는 JWT를 쿠키에 담는 경우) |
+| **HTTPS** | OAuth 리다이렉트 및 토큰/쿠키 전송 시 중간자 공격(MITM) 방지 |
+| **state 공유 저장소** | 다중 인스턴스 환경에서는 발급한 state를 Redis 등 공유 저장소나 서명 쿠키로 관리 |
 
-# 8. 참고
+> **한계(범위 밖)**: 이 글의 `findOrCreateUser`는 `provider` + `provider_id`로 사용자를 식별한다. **같은 이메일을 다른 provider(예: Google과 GitHub)로 가입하면** User 모델의 `Email uniqueIndex`에서 충돌이 날 수 있고, 이 경우 "여러 SNS 계정을 한 사용자로 연결(account linking)"하는 설계가 필요하다. 이는 별도 주제로 범위가 커서 이 글에서는 다루지 않는다.
+
+# 9. 참고
 
 - [Google OAuth 2.0 공식 문서](https://developers.google.com/identity/protocols/oauth2)
 - [OAuth 2.0 RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749)
@@ -647,3 +948,4 @@ e.Use(echoMiddleware.CORSWithConfig(echoMiddleware.CORSConfig{
 - [golang-jwt/jwt 패키지](https://github.com/golang-jwt/jwt)
 - [Echo 프레임워크 공식 문서](https://echo.labstack.com/)
 - [JWT.io](https://jwt.io/)
+- 샘플 코드: [web/sns-login-jwt](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-jwt) · [web/sns-login-session](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-session)

--- a/docs/read/go-google-oauth-로그인-구현-가이드/index.md
+++ b/docs/read/go-google-oauth-로그인-구현-가이드/index.md
@@ -59,6 +59,8 @@ sequenceDiagram
     FE->>U: 프로필 표시
 ```
 
+> 위는 개요이며, 실제 redirect 경로(프론트 vs 백엔드)는 버전별로 다르다 — JWT는 §5.1, 세션은 §6.1 참고.
+
 > 전체 소스 코드는 두 저장소에서 확인할 수 있다.
 > - JWT(무상태) 버전: [web/sns-login-jwt](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-jwt)
 > - 세션(서버 상태) 버전: [web/sns-login-session](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-session)
@@ -558,9 +560,13 @@ func (h *AuthHandler) HandleCallback(c echo.Context) error {
 | POST | `/api/auth/logout` | 로그아웃 (클라이언트가 토큰 삭제) | 불필요 |
 | GET | `/api/user/me` | 현재 사용자 정보 | 필요 (access 토큰) |
 
+> **"인증" 컬럼의 의미**: 여기서 "인증"은 **access 토큰 미들웨어(`JWTAuth`) 통과 필요 여부**를 뜻한다. `/api/auth/refresh`는 access 미들웨어를 거치지 않으므로 "불필요"지만, 본문에는 유효한 refresh 토큰이 필요하다 — 따라서 "불필요"와 "(refresh 토큰 필요)"는 서로 모순이 아니다.
+
+> **JWT 로그아웃은 클라이언트측이다**: JWT는 서버에 세션 상태가 없으므로, 로그아웃은 클라이언트가 보관한 토큰을 삭제하는 것으로 끝난다(서버측 무효화는 세션 방식의 §6.6 참고).
+
 ## 5.5 프론트엔드 연동
 
-Axios 인터셉터로 **모든 요청에 access 토큰을 자동 첨부**하고, 401 응답 시 refresh 토큰으로 갱신을 시도한다.
+Axios 인터셉터로 **모든 요청에 access 토큰을 자동 첨부**하고, 401 응답 시 refresh 토큰으로 갱신을 시도한다. 다만 localStorage에 저장한 토큰은 XSS에 노출될 수 있다. 비교와 대안(HttpOnly 쿠키)은 §7·§8에서 다룬다.
 
 ```typescript
 // services/authService.ts
@@ -909,7 +915,7 @@ export function useAuth() {
 | 저장 위치 보안 | localStorage(XSS) vs 쿠키 | HttpOnly 쿠키 |
 | 적합 | FE/BE 분리, MSA, 무상태 API | 단일/소규모, 즉시 무효화 중요 |
 
-## 선택 가이드
+## 7.1 선택 가이드
 
 - **세션이 잘 맞는 경우**: 서비스가 단일/소규모이고, "로그아웃하면 즉시 차단", "관리자가 특정 사용자 강제 로그아웃" 같은 **서버측 즉시 무효화**가 중요한 경우. 쿠키(HttpOnly)에 담기므로 토큰을 localStorage에 두는 것보다 XSS 노출 면에서도 다루기 쉽다.
 - **JWT가 잘 맞는 경우**: 여러 서비스/마이크로서비스가 공유 세션 스토어 없이 **수평 확장**해야 하고, 모바일 등 다양한 클라이언트에 무상태 API를 제공하는 경우.
@@ -927,7 +933,7 @@ export function useAuth() {
 - **세션 = 서버측 무효화**: 로그아웃이 세션 행 삭제로 즉시 반영
 - **state 파라미터**: CSRF 공격 방지를 위한 필수 보안 요소
 
-### 프로덕션 환경에서 추가로 고려할 사항
+## 8.1 프로덕션 환경에서 추가로 고려할 사항
 
 | 항목 | 설명 |
 |------|------|

--- a/docs/superpowers/plans/2026-06-03-sns-login-jwt-vs-session.md
+++ b/docs/superpowers/plans/2026-06-03-sns-login-jwt-vs-session.md
@@ -1,0 +1,1644 @@
+# SNS 로그인 JWT vs 세션 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Google OAuth 로그인 샘플을 JWT(무상태)·세션(SQLite) 두 구현으로 분리하고, 블로그를 하나의 글로 재구성해 JWT vs 세션 차이를 다룬다.
+
+**Architecture:** OAuth code 교환·회원가입은 공통, "인증 이후 상태 유지"만 다르다. JWT 버전은 프론트 redirect + Bearer 토큰(타입 구분), 세션 버전은 백엔드 redirect + `sessions` 테이블 + HttpOnly 쿠키(서버측 로그아웃).
+
+**Tech Stack:** Go 1.25, Echo v4, GORM, SQLite(mattn/go-sqlite3), golang-jwt/v5, React 19 + Vite + axios.
+
+**대상 저장소:** `tutorials-go`(코드), `blog-v2.advenoh.pe.kr`(블로그). 작업은 각 저장소의 feature 브랜치에서 진행한다.
+
+**참조 스펙:** `blog-v2.advenoh.pe.kr/docs/superpowers/specs/2026-06-03-sns-login-jwt-vs-session-design.md`
+
+---
+
+## 파일 구조
+
+### Phase 1 — `tutorials-go/web/sns-login-jwt/` (기존 `sns-login` rename + 수정)
+- Rename: `web/sns-login/` → `web/sns-login-jwt/` (git mv, 모듈 경로 갱신)
+- Modify: `backend/service/token_service.go` — 토큰 타입 클레임(B-4)
+- Modify: `backend/middleware/auth_middleware.go` — access 토큰만 허용(B-4)
+- Modify: `backend/service/auth_service.go` — 재로그인 프로필 갱신(A-3)
+- Modify: `backend/repository/user_repository.go` — `Update` 추가(A-3)
+- Modify: `backend/config/config.go` — redirect_uri 프론트로(C-9), 시크릿 기본값(B-7)
+- Modify: `docker-compose.yml` — env 정리(C-9/B-7)
+- Test: `backend/service/token_service_test.go`, `backend/middleware/auth_middleware_test.go`, `backend/service/auth_service_test.go`
+
+### Phase 2 — `tutorials-go/web/sns-login-session/` (신규)
+- Create: 전체 (Phase 1 복제 후 세션화)
+- Create: `backend/model/session.go` — Session 모델
+- Create: `backend/repository/session_repository.go` — 세션 CRUD
+- Create: `backend/service/session_service.go` — 세션 생성/검증/삭제
+- Create: `backend/middleware/session_middleware.go` — 쿠키 기반 인증
+- Modify: `backend/service/auth_service.go` — JWT 대신 세션 발급
+- Modify: `backend/handler/auth_handler.go` — 콜백에서 쿠키 설정 + 프론트 redirect, 로그아웃 시 세션 삭제
+- Remove: JWT 전용(`token_service.go`, JWT 미들웨어)
+- Modify: frontend — 토큰 보관 제거, `withCredentials`, OAuthCallback 단순화
+- Test: `backend/repository/session_repository_test.go`, `backend/service/session_service_test.go`, `backend/middleware/session_middleware_test.go`
+
+### Phase 3 — `blog-v2.advenoh.pe.kr` 블로그
+- Modify: `docs/read/go-google-oauth-로그인-구현-가이드/index.md` — 통합 글 재구성
+
+---
+
+## 사전 준비: Go 테스트 헬퍼 패턴
+
+여러 테스트에서 in-memory SQLite를 쓴다. 각 테스트 파일에서 아래 패턴을 사용한다(중복 정의 금지: 같은 패키지 내 한 번만 정의).
+
+```go
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("DB 연결 실패: %v", err)
+	}
+	return db
+}
+```
+
+---
+
+## Phase 1: sns-login-jwt
+
+### Task 1: 폴더 rename 및 모듈 경로 갱신
+
+**Files:**
+- Rename: `web/sns-login/` → `web/sns-login-jwt/`
+- Modify: `web/sns-login-jwt/backend/go.mod`, 모든 `.go` import 경로
+
+- [ ] **Step 1: git mv 로 폴더 이동**
+
+Run:
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go
+git checkout -b feat/sns-login-jwt-session
+git mv web/sns-login web/sns-login-jwt
+```
+
+- [ ] **Step 2: 모듈 경로 일괄 치환**
+
+Run:
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go/web/sns-login-jwt
+grep -rl 'web/sns-login/backend' backend | xargs sed -i '' 's#web/sns-login/backend#web/sns-login-jwt/backend#g'
+```
+
+- [ ] **Step 3: 빌드로 경로 검증**
+
+Run: `cd backend && go build ./...`
+Expected: 에러 없이 빌드 성공
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go
+git add -A
+git commit -m "refactor: sns-login → sns-login-jwt 폴더 및 모듈 경로 변경"
+```
+
+---
+
+### Task 2: 토큰 타입 클레임 추가 (B-4)
+
+`Claims`에 `TokenType` 필드를 추가하고, access/refresh를 구분해 발급·검증한다.
+
+**Files:**
+- Modify: `backend/service/token_service.go`
+- Test: `backend/service/token_service_test.go`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`backend/service/token_service_test.go`:
+```go
+package service
+
+import (
+	"testing"
+)
+
+func TestGenerateTokenPair_TokenTypes(t *testing.T) {
+	s := NewTokenService("test-secret")
+
+	pair, err := s.GenerateTokenPair(42)
+	if err != nil {
+		t.Fatalf("토큰 생성 실패: %v", err)
+	}
+
+	accessClaims, err := s.ValidateToken(pair.AccessToken)
+	if err != nil {
+		t.Fatalf("access 토큰 검증 실패: %v", err)
+	}
+	if accessClaims.TokenType != "access" {
+		t.Errorf("access 토큰 타입 기대값 access, 실제 %q", accessClaims.TokenType)
+	}
+	if accessClaims.UserID != 42 {
+		t.Errorf("UserID 기대값 42, 실제 %d", accessClaims.UserID)
+	}
+
+	refreshClaims, err := s.ValidateToken(pair.RefreshToken)
+	if err != nil {
+		t.Fatalf("refresh 토큰 검증 실패: %v", err)
+	}
+	if refreshClaims.TokenType != "refresh" {
+		t.Errorf("refresh 토큰 타입 기대값 refresh, 실제 %q", refreshClaims.TokenType)
+	}
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `cd backend && go test ./service/ -run TestGenerateTokenPair_TokenTypes -v`
+Expected: 컴파일 에러(`TokenType` 필드 없음)
+
+- [ ] **Step 3: 구현**
+
+`backend/service/token_service.go` 전체를 아래로 교체:
+```go
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	TokenTypeAccess  = "access"
+	TokenTypeRefresh = "refresh"
+)
+
+type TokenService struct {
+	secret        []byte
+	accessExpiry  time.Duration
+	refreshExpiry time.Duration
+}
+
+type TokenPair struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type Claims struct {
+	UserID    uint   `json:"user_id"`
+	TokenType string `json:"token_type"`
+	jwt.RegisteredClaims
+}
+
+func NewTokenService(secret string) *TokenService {
+	return &TokenService{
+		secret:        []byte(secret),
+		accessExpiry:  15 * time.Minute,
+		refreshExpiry: 7 * 24 * time.Hour, // 7일
+	}
+}
+
+func (s *TokenService) GenerateTokenPair(userID uint) (*TokenPair, error) {
+	accessToken, err := s.generateToken(userID, TokenTypeAccess, s.accessExpiry)
+	if err != nil {
+		return nil, err
+	}
+	refreshToken, err := s.generateToken(userID, TokenTypeRefresh, s.refreshExpiry)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenPair{AccessToken: accessToken, RefreshToken: refreshToken}, nil
+}
+
+func (s *TokenService) ValidateToken(tokenStr string) (*Claims, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("예상하지 못한 서명 방식: %v", t.Header["alg"])
+		}
+		return s.secret, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(*Claims)
+	if !ok || !token.Valid {
+		return nil, fmt.Errorf("유효하지 않은 토큰")
+	}
+	return claims, nil
+}
+
+func (s *TokenService) generateToken(userID uint, tokenType string, expiry time.Duration) (string, error) {
+	claims := &Claims{
+		UserID:    userID,
+		TokenType: tokenType,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiry)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secret)
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `cd backend && go test ./service/ -run TestGenerateTokenPair_TokenTypes -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add backend/service/token_service.go backend/service/token_service_test.go
+git commit -m "feat: JWT access/refresh 토큰 타입 클레임 추가 (B-4)"
+```
+
+---
+
+### Task 3: 미들웨어가 access 토큰만 허용 (B-4)
+
+**Files:**
+- Modify: `backend/middleware/auth_middleware.go`
+- Test: `backend/middleware/auth_middleware_test.go`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`backend/middleware/auth_middleware_test.go`:
+```go
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-jwt/backend/service"
+	"github.com/labstack/echo/v4"
+)
+
+func TestJWTAuth_RejectsRefreshToken(t *testing.T) {
+	ts := service.NewTokenService("test-secret")
+	pair, _ := ts.GenerateTokenPair(7)
+
+	e := echo.New()
+	handler := JWTAuth(ts)(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	// refresh 토큰으로 보호 API 호출 → 거부되어야 함
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+pair.RefreshToken)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	if err == nil {
+		t.Fatal("refresh 토큰이 거부되지 않음 (에러 nil)")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusUnauthorized {
+		t.Fatalf("401 기대, 실제 %v", err)
+	}
+}
+
+func TestJWTAuth_AcceptsAccessToken(t *testing.T) {
+	ts := service.NewTokenService("test-secret")
+	pair, _ := ts.GenerateTokenPair(7)
+
+	e := echo.New()
+	handler := JWTAuth(ts)(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+pair.AccessToken)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler(c); err != nil {
+		t.Fatalf("access 토큰이 거부됨: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("200 기대, 실제 %d", rec.Code)
+	}
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `cd backend && go test ./middleware/ -v`
+Expected: `TestJWTAuth_RejectsRefreshToken` FAIL (refresh 토큰이 통과됨)
+
+- [ ] **Step 3: 구현**
+
+`backend/middleware/auth_middleware.go`의 토큰 검증 직후 타입 확인을 추가. `ValidateToken` 호출 블록을 아래로 교체:
+```go
+			claims, err := tokenService.ValidateToken(parts[1])
+			if err != nil {
+				return echo.NewHTTPError(http.StatusUnauthorized, "유효하지 않은 토큰")
+			}
+
+			// access 토큰만 보호 API 접근 허용 (refresh 토큰 차단)
+			if claims.TokenType != service.TokenTypeAccess {
+				return echo.NewHTTPError(http.StatusUnauthorized, "access 토큰이 필요합니다")
+			}
+
+			c.Set("user_id", claims.UserID)
+			return next(c)
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `cd backend && go test ./middleware/ -v`
+Expected: 두 테스트 모두 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add backend/middleware/auth_middleware.go backend/middleware/auth_middleware_test.go
+git commit -m "feat: 미들웨어에서 access 토큰만 허용 (B-4)"
+```
+
+---
+
+### Task 4: 재로그인 시 프로필 갱신 (A-3)
+
+`findOrCreateUser`가 기존 사용자의 Name/AvatarURL을 최신 값으로 갱신한다.
+
+**Files:**
+- Modify: `backend/repository/user_repository.go` — `Update` 추가
+- Modify: `backend/service/auth_service.go` — `findOrCreateUser` 갱신 로직
+- Test: `backend/service/auth_service_test.go`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`backend/service/auth_service_test.go`:
+```go
+package service
+
+import (
+	"testing"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-jwt/backend/model"
+	"github.com/kenshin579/tutorials-go/web/sns-login-jwt/backend/provider"
+	"github.com/kenshin579/tutorials-go/web/sns-login-jwt/backend/repository"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("DB 연결 실패: %v", err)
+	}
+	if err := db.AutoMigrate(&model.User{}); err != nil {
+		t.Fatalf("마이그레이션 실패: %v", err)
+	}
+	return db
+}
+
+func TestFindOrCreateUser_UpdatesProfileOnRelogin(t *testing.T) {
+	db := newTestDB(t)
+	repo := repository.NewUserRepository(db)
+	s := &AuthService{userRepo: repo}
+
+	// 최초 로그인 → 생성
+	u1, err := s.findOrCreateUser(&provider.UserInfo{
+		Email: "a@gmail.com", Name: "홍길동", AvatarURL: "old.png",
+		Provider: "google", ProviderID: "g-1",
+	})
+	if err != nil {
+		t.Fatalf("최초 생성 실패: %v", err)
+	}
+
+	// 재로그인 → 이름/아바타 변경 반영, 같은 ID 유지
+	u2, err := s.findOrCreateUser(&provider.UserInfo{
+		Email: "a@gmail.com", Name: "홍길동2", AvatarURL: "new.png",
+		Provider: "google", ProviderID: "g-1",
+	})
+	if err != nil {
+		t.Fatalf("재로그인 실패: %v", err)
+	}
+	if u2.ID != u1.ID {
+		t.Errorf("동일 사용자 ID 기대 %d, 실제 %d", u1.ID, u2.ID)
+	}
+	if u2.Name != "홍길동2" || u2.AvatarURL != "new.png" {
+		t.Errorf("프로필 갱신 안 됨: name=%q avatar=%q", u2.Name, u2.AvatarURL)
+	}
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `cd backend && go test ./service/ -run TestFindOrCreateUser -v`
+Expected: FAIL (프로필 갱신 안 됨 / `Update` 없음)
+
+- [ ] **Step 3: repository에 Update 추가**
+
+`backend/repository/user_repository.go`에 메서드 추가:
+```go
+// Update는 사용자 정보를 저장한다
+func (r *UserRepository) Update(user *model.User) error {
+	return r.db.Save(user).Error
+}
+```
+
+- [ ] **Step 4: findOrCreateUser 갱신 로직 구현**
+
+`backend/service/auth_service.go`의 `findOrCreateUser`에서 기존 사용자 반환 부분을 교체:
+```go
+func (s *AuthService) findOrCreateUser(info *provider.UserInfo) (*model.User, error) {
+	user, err := s.userRepo.FindByProviderID(info.Provider, info.ProviderID)
+	if err == nil {
+		// 재로그인: 프로필 최신화 (A-3)
+		user.Name = info.Name
+		user.AvatarURL = info.AvatarURL
+		if err := s.userRepo.Update(user); err != nil {
+			return nil, err
+		}
+		return user, nil
+	}
+
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	newUser := &model.User{
+		Email:      info.Email,
+		Name:       info.Name,
+		AvatarURL:  info.AvatarURL,
+		Provider:   info.Provider,
+		ProviderID: info.ProviderID,
+	}
+	if err := s.userRepo.Create(newUser); err != nil {
+		return nil, err
+	}
+	return newUser, nil
+}
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `cd backend && go test ./service/ -v`
+Expected: 전체 PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add backend/repository/user_repository.go backend/service/auth_service.go backend/service/auth_service_test.go
+git commit -m "feat: 재로그인 시 사용자 프로필 갱신 (A-3)"
+```
+
+---
+
+### Task 5: redirect_uri 프론트 정렬(C-9) + 시크릿 기본값(B-7)
+
+JWT/SPA 플로우에서는 Google이 **프론트**로 redirect하고, 프론트가 code를 백엔드 API로 전달한다.
+따라서 `GoogleRedirectURL` 기본값을 프론트 콜백 라우트로 맞춘다.
+
+**Files:**
+- Modify: `backend/config/config.go`
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: config 기본값 수정**
+
+`backend/config/config.go`의 `Load()` 반환부에서 두 줄 교체:
+```go
+		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:3000/auth/callback"),
+		JWTSecret:          getEnv("JWT_SECRET", "dev-only-change-me"),
+```
+
+- [ ] **Step 2: docker-compose env 정리**
+
+`docker-compose.yml`의 backend `environment`에서 두 줄 교체:
+```yaml
+      - GOOGLE_REDIRECT_URL=http://localhost:3000/auth/callback
+      - JWT_SECRET=${JWT_SECRET:-dev-only-change-me}
+```
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `cd backend && go build ./... && go vet ./...`
+Expected: 에러 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add backend/config/config.go docker-compose.yml
+git commit -m "fix: JWT 버전 redirect_uri 프론트 정렬 및 시크릿 기본값 정리 (C-9/B-7)"
+```
+
+---
+
+### Task 6: Phase 1 전체 테스트
+
+- [ ] **Step 1: 전체 테스트 실행**
+
+Run: `cd /Users/user/src/workspace_blogv2/tutorials-go/web/sns-login-jwt/backend && go test ./...`
+Expected: 모든 패키지 PASS (no test 패키지는 `ok`/`no test files`)
+
+- [ ] **Step 2: 빌드**
+
+Run: `go build ./...`
+Expected: 성공
+
+---
+
+## Phase 2: sns-login-session
+
+### Task 7: 폴더 복제 및 모듈 경로 설정
+
+**Files:**
+- Create: `web/sns-login-session/` (sns-login-jwt 복제)
+
+- [ ] **Step 1: 복제 후 모듈 경로 변경**
+
+Run:
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go/web
+cp -R sns-login-jwt sns-login-session
+cd sns-login-session
+rm -rf backend/data backend/server frontend/node_modules frontend/dist
+grep -rl 'web/sns-login-jwt/backend' backend | xargs sed -i '' 's#web/sns-login-jwt/backend#web/sns-login-session/backend#g'
+# go.mod module 줄 갱신
+sed -i '' 's#web/sns-login-jwt/backend#web/sns-login-session/backend#' backend/go.mod
+# JWT 전용 테스트 제거 (세션 버전에서 새로 작성 → newTestDB 중복 정의 방지)
+rm -f backend/service/token_service_test.go backend/service/auth_service_test.go backend/middleware/auth_middleware_test.go
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `cd backend && go build ./...`
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go
+git add -A
+git commit -m "chore: sns-login-session 폴더 복제 (세션 구현 기반)"
+```
+
+---
+
+### Task 8: Session 모델
+
+**Files:**
+- Create: `backend/model/session.go`
+
+- [ ] **Step 1: 모델 작성**
+
+`backend/model/session.go`:
+```go
+package model
+
+import "time"
+
+// Session은 서버측 세션 (SQLite 저장)
+type Session struct {
+	ID        string    `gorm:"primarykey" json:"id"` // 랜덤 세션 토큰
+	UserID    uint      `gorm:"index;not null" json:"user_id"`
+	ExpiresAt time.Time `gorm:"not null" json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `cd backend && go build ./model/`
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add backend/model/session.go
+git commit -m "feat: Session 모델 추가 (세션)"
+```
+
+---
+
+### Task 9: Session repository (TDD)
+
+**Files:**
+- Create: `backend/repository/session_repository.go`
+- Test: `backend/repository/session_repository_test.go`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`backend/repository/session_repository_test.go`:
+```go
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("DB 연결 실패: %v", err)
+	}
+	if err := db.AutoMigrate(&model.User{}, &model.Session{}); err != nil {
+		t.Fatalf("마이그레이션 실패: %v", err)
+	}
+	return db
+}
+
+func TestSessionRepository_CreateFindDelete(t *testing.T) {
+	repo := NewSessionRepository(newTestDB(t))
+
+	sess := &model.Session{ID: "tok-1", UserID: 5, ExpiresAt: time.Now().Add(time.Hour)}
+	if err := repo.Create(sess); err != nil {
+		t.Fatalf("생성 실패: %v", err)
+	}
+
+	found, err := repo.FindByID("tok-1")
+	if err != nil {
+		t.Fatalf("조회 실패: %v", err)
+	}
+	if found.UserID != 5 {
+		t.Errorf("UserID 기대 5, 실제 %d", found.UserID)
+	}
+
+	if err := repo.Delete("tok-1"); err != nil {
+		t.Fatalf("삭제 실패: %v", err)
+	}
+	if _, err := repo.FindByID("tok-1"); err == nil {
+		t.Error("삭제 후에도 조회됨")
+	}
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `cd backend && go test ./repository/ -run TestSessionRepository -v`
+Expected: 컴파일 에러(`NewSessionRepository` 없음)
+
+- [ ] **Step 3: 구현**
+
+`backend/repository/session_repository.go`:
+```go
+package repository
+
+import (
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/model"
+	"gorm.io/gorm"
+)
+
+type SessionRepository struct {
+	db *gorm.DB
+}
+
+func NewSessionRepository(db *gorm.DB) *SessionRepository {
+	return &SessionRepository{db: db}
+}
+
+func (r *SessionRepository) Create(s *model.Session) error {
+	return r.db.Create(s).Error
+}
+
+func (r *SessionRepository) FindByID(id string) (*model.Session, error) {
+	var s model.Session
+	if err := r.db.First(&s, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *SessionRepository) Delete(id string) error {
+	return r.db.Delete(&model.Session{}, "id = ?", id).Error
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `cd backend && go test ./repository/ -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add backend/repository/session_repository.go backend/repository/session_repository_test.go
+git commit -m "feat: SessionRepository 추가 (세션 CRUD)"
+```
+
+---
+
+### Task 10: Session service (TDD)
+
+세션 생성(랜덤 ID + 만료) / 검증(만료 체크) / 삭제.
+
+**Files:**
+- Create: `backend/service/session_service.go`
+- Test: `backend/service/session_service_test.go`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`backend/service/session_service_test.go`:
+```go
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/model"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/repository"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("DB 연결 실패: %v", err)
+	}
+	if err := db.AutoMigrate(&model.User{}, &model.Session{}); err != nil {
+		t.Fatalf("마이그레이션 실패: %v", err)
+	}
+	return db
+}
+
+func TestSessionService_CreateAndValidate(t *testing.T) {
+	repo := repository.NewSessionRepository(newTestDB(t))
+	s := NewSessionService(repo, time.Hour)
+
+	sess, err := s.Create(11)
+	if err != nil {
+		t.Fatalf("세션 생성 실패: %v", err)
+	}
+	if sess.ID == "" {
+		t.Fatal("세션 ID가 비어있음")
+	}
+
+	userID, err := s.Validate(sess.ID)
+	if err != nil {
+		t.Fatalf("검증 실패: %v", err)
+	}
+	if userID != 11 {
+		t.Errorf("UserID 기대 11, 실제 %d", userID)
+	}
+}
+
+func TestSessionService_DeleteInvalidates(t *testing.T) {
+	repo := repository.NewSessionRepository(newTestDB(t))
+	s := NewSessionService(repo, time.Hour)
+
+	sess, _ := s.Create(11)
+	if err := s.Delete(sess.ID); err != nil {
+		t.Fatalf("삭제 실패: %v", err)
+	}
+	if _, err := s.Validate(sess.ID); err == nil {
+		t.Error("삭제 후에도 세션이 유효함 (서버측 로그아웃 실패)")
+	}
+}
+
+func TestSessionService_RejectsExpired(t *testing.T) {
+	repo := repository.NewSessionRepository(newTestDB(t))
+	s := NewSessionService(repo, -time.Minute) // 이미 만료
+
+	sess, _ := s.Create(11)
+	if _, err := s.Validate(sess.ID); err == nil {
+		t.Error("만료된 세션이 통과됨")
+	}
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `cd backend && go test ./service/ -run TestSessionService -v`
+Expected: 컴파일 에러(`NewSessionService` 없음)
+
+- [ ] **Step 3: 구현**
+
+`backend/service/session_service.go`:
+```go
+package service
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/model"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/repository"
+)
+
+type SessionService struct {
+	repo   *repository.SessionRepository
+	expiry time.Duration
+}
+
+func NewSessionService(repo *repository.SessionRepository, expiry time.Duration) *SessionService {
+	return &SessionService{repo: repo, expiry: expiry}
+}
+
+func (s *SessionService) Create(userID uint) (*model.Session, error) {
+	sess := &model.Session{
+		ID:        generateSessionID(),
+		UserID:    userID,
+		ExpiresAt: time.Now().Add(s.expiry),
+	}
+	if err := s.repo.Create(sess); err != nil {
+		return nil, err
+	}
+	return sess, nil
+}
+
+// Validate는 세션 ID로 사용자 ID를 반환한다. 만료/없음이면 에러.
+func (s *SessionService) Validate(id string) (uint, error) {
+	sess, err := s.repo.FindByID(id)
+	if err != nil {
+		return 0, err
+	}
+	if time.Now().After(sess.ExpiresAt) {
+		_ = s.repo.Delete(id) // 만료 세션 정리
+		return 0, errors.New("만료된 세션")
+	}
+	return sess.UserID, nil
+}
+
+func (s *SessionService) Delete(id string) error {
+	return s.repo.Delete(id)
+}
+
+func generateSessionID() string {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `cd backend && go test ./service/ -run TestSessionService -v`
+Expected: 3개 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add backend/service/session_service.go backend/service/session_service_test.go
+git commit -m "feat: SessionService 추가 (생성/검증/만료/삭제)"
+```
+
+---
+
+### Task 11: 세션 미들웨어 (TDD)
+
+쿠키에서 세션 ID를 읽어 검증하고 `user_id`를 컨텍스트에 주입한다.
+
+**Files:**
+- Create: `backend/middleware/session_middleware.go`
+- Test: `backend/middleware/session_middleware_test.go`
+- Remove: `backend/middleware/auth_middleware.go`, `auth_middleware_test.go` (JWT 전용)
+
+- [ ] **Step 1: JWT 미들웨어 제거**
+
+Run:
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go/web/sns-login-session/backend
+rm -f middleware/auth_middleware.go
+# auth_middleware_test.go 는 Task 7에서 이미 제거됨
+```
+
+- [ ] **Step 2: 실패하는 테스트 작성**
+
+`backend/middleware/session_middleware_test.go`:
+```go
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/model"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/repository"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/service"
+	"github.com/labstack/echo/v4"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSvc(t *testing.T) *service.SessionService {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("DB: %v", err)
+	}
+	db.AutoMigrate(&model.User{}, &model.Session{})
+	return service.NewSessionService(repository.NewSessionRepository(db), time.Hour)
+}
+
+func TestSessionAuth_NoCookie_Rejected(t *testing.T) {
+	e := echo.New()
+	h := SessionAuth(newSvc(t))(func(c echo.Context) error { return c.String(200, "ok") })
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := e.NewContext(req, httptest.NewRecorder())
+	if err := h(c); err == nil {
+		t.Fatal("쿠키 없는 요청이 통과됨")
+	}
+}
+
+func TestSessionAuth_ValidCookie_Passes(t *testing.T) {
+	svc := newSvc(t)
+	sess, _ := svc.Create(9)
+
+	e := echo.New()
+	h := SessionAuth(svc)(func(c echo.Context) error {
+		if c.Get("user_id").(uint) != 9 {
+			t.Errorf("user_id 기대 9")
+		}
+		return c.String(200, "ok")
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: sess.ID})
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := h(c); err != nil {
+		t.Fatalf("유효 쿠키가 거부됨: %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+Run: `cd backend && go test ./middleware/ -v`
+Expected: 컴파일 에러(`SessionAuth` 없음)
+
+- [ ] **Step 4: 구현**
+
+`backend/middleware/session_middleware.go`:
+```go
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/service"
+	"github.com/labstack/echo/v4"
+)
+
+const SessionCookieName = "session_id"
+
+// SessionAuth는 세션 쿠키를 검증하는 미들웨어
+func SessionAuth(sessionService *service.SessionService) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			cookie, err := c.Cookie(SessionCookieName)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusUnauthorized, "세션 쿠키가 필요합니다")
+			}
+			userID, err := sessionService.Validate(cookie.Value)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusUnauthorized, "유효하지 않은 세션")
+			}
+			c.Set("user_id", userID)
+			return next(c)
+		}
+	}
+}
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `cd backend && go test ./middleware/ -v`
+Expected: 2개 PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add backend/middleware/
+git commit -m "feat: 세션 쿠키 인증 미들웨어 추가, JWT 미들웨어 제거"
+```
+
+---
+
+### Task 12: auth_service를 세션 방식으로 전환
+
+JWT(`token_service`, `TokenPair`) 의존을 제거하고 세션을 발급한다.
+
+**Files:**
+- Modify: `backend/service/auth_service.go`
+- Remove: `backend/service/token_service.go`, `token_service_test.go`
+
+- [ ] **Step 1: token_service 제거**
+
+Run:
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go/web/sns-login-session/backend
+rm -f service/token_service.go
+# token_service_test.go 는 Task 7에서 이미 제거됨
+```
+
+- [ ] **Step 2: auth_service.go 재작성**
+
+`backend/service/auth_service.go` 전체 교체:
+```go
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/model"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/provider"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/repository"
+	"gorm.io/gorm"
+)
+
+type AuthService struct {
+	providers      map[string]provider.OAuthProvider
+	userRepo       *repository.UserRepository
+	sessionService *SessionService
+	states         sync.Map
+}
+
+func NewAuthService(
+	providers map[string]provider.OAuthProvider,
+	userRepo *repository.UserRepository,
+	sessionService *SessionService,
+) *AuthService {
+	return &AuthService{
+		providers:      providers,
+		userRepo:       userRepo,
+		sessionService: sessionService,
+	}
+}
+
+func (s *AuthService) GetAuthURL(providerName string) (string, error) {
+	p, ok := s.providers[providerName]
+	if !ok {
+		return "", errors.New("지원하지 않는 provider: " + providerName)
+	}
+	state := generateState()
+	s.states.Store(state, true)
+	return p.GetAuthURL(state), nil
+}
+
+// HandleCallback은 OAuth 콜백을 처리하고 세션을 생성, 세션 ID를 반환한다.
+func (s *AuthService) HandleCallback(ctx context.Context, providerName, code, state string) (*model.Session, *model.User, error) {
+	if _, ok := s.states.LoadAndDelete(state); !ok {
+		return nil, nil, errors.New("유효하지 않은 state")
+	}
+	p, ok := s.providers[providerName]
+	if !ok {
+		return nil, nil, errors.New("지원하지 않는 provider: " + providerName)
+	}
+	userInfo, err := p.ExchangeCode(ctx, code)
+	if err != nil {
+		return nil, nil, err
+	}
+	user, err := s.findOrCreateUser(userInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	sess, err := s.sessionService.Create(user.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sess, user, nil
+}
+
+func (s *AuthService) Logout(sessionID string) error {
+	return s.sessionService.Delete(sessionID)
+}
+
+func (s *AuthService) GetUser(userID uint) (*model.User, error) {
+	return s.userRepo.FindByID(userID)
+}
+
+func (s *AuthService) findOrCreateUser(info *provider.UserInfo) (*model.User, error) {
+	user, err := s.userRepo.FindByProviderID(info.Provider, info.ProviderID)
+	if err == nil {
+		user.Name = info.Name
+		user.AvatarURL = info.AvatarURL
+		if err := s.userRepo.Update(user); err != nil {
+			return nil, err
+		}
+		return user, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	newUser := &model.User{
+		Email:      info.Email,
+		Name:       info.Name,
+		AvatarURL:  info.AvatarURL,
+		Provider:   info.Provider,
+		ProviderID: info.ProviderID,
+	}
+	if err := s.userRepo.Create(newUser); err != nil {
+		return nil, err
+	}
+	return newUser, nil
+}
+
+func generateState() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+```
+
+- [ ] **Step 3: 빌드(핸들러 미수정으로 실패 예상)**
+
+Run: `cd backend && go build ./service/`
+Expected: `service` 패키지는 빌드 성공 (핸들러는 Task 13에서 수정)
+
+- [ ] **Step 4: 세션 버전 auth_service 테스트 신규 작성**
+
+Task 7에서 복제본 `auth_service_test.go`를 삭제했으므로, 세션 모듈 경로로 새로 작성한다. `newTestDB`는 `session_service_test.go`(Task 10)에 이미 정의되어 있으니 **여기서는 재정의하지 않고 재사용**한다.
+
+`backend/service/auth_service_test.go`:
+```go
+package service
+
+import (
+	"testing"
+
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/provider"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/repository"
+)
+
+func TestFindOrCreateUser_UpdatesProfileOnRelogin(t *testing.T) {
+	db := newTestDB(t) // session_service_test.go 정의 재사용
+	repo := repository.NewUserRepository(db)
+	s := &AuthService{userRepo: repo}
+
+	u1, err := s.findOrCreateUser(&provider.UserInfo{
+		Email: "a@gmail.com", Name: "홍길동", AvatarURL: "old.png",
+		Provider: "google", ProviderID: "g-1",
+	})
+	if err != nil {
+		t.Fatalf("최초 생성 실패: %v", err)
+	}
+
+	u2, err := s.findOrCreateUser(&provider.UserInfo{
+		Email: "a@gmail.com", Name: "홍길동2", AvatarURL: "new.png",
+		Provider: "google", ProviderID: "g-1",
+	})
+	if err != nil {
+		t.Fatalf("재로그인 실패: %v", err)
+	}
+	if u2.ID != u1.ID {
+		t.Errorf("동일 사용자 ID 기대 %d, 실제 %d", u1.ID, u2.ID)
+	}
+	if u2.Name != "홍길동2" || u2.AvatarURL != "new.png" {
+		t.Errorf("프로필 갱신 안 됨: name=%q avatar=%q", u2.Name, u2.AvatarURL)
+	}
+}
+```
+
+Run: `cd backend && go test ./service/ -run TestFindOrCreateUser -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add backend/service/
+git commit -m "feat: auth_service 세션 발급 방식으로 전환, token_service 제거"
+```
+
+---
+
+### Task 13: 핸들러를 쿠키+redirect 방식으로 전환
+
+콜백은 세션 쿠키를 설정하고 프론트로 302 redirect. 로그아웃은 세션 삭제 + 쿠키 만료.
+
+**Files:**
+- Modify: `backend/handler/auth_handler.go`
+- Modify: `backend/handler/user_handler.go` (변경 없음 — 확인만)
+- Modify: `backend/main.go`
+
+- [ ] **Step 1: auth_handler.go 재작성**
+
+`backend/handler/auth_handler.go` 전체 교체:
+```go
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	customMiddleware "github.com/kenshin579/tutorials-go/web/sns-login-session/backend/middleware"
+	"github.com/kenshin579/tutorials-go/web/sns-login-session/backend/service"
+	"github.com/labstack/echo/v4"
+)
+
+type AuthHandler struct {
+	authService *service.AuthService
+	frontendURL string
+}
+
+func NewAuthHandler(authService *service.AuthService, frontendURL string) *AuthHandler {
+	return &AuthHandler{authService: authService, frontendURL: frontendURL}
+}
+
+// GET /api/auth/:provider/url
+func (h *AuthHandler) GetAuthURL(c echo.Context) error {
+	url, err := h.authService.GetAuthURL(c.Param("provider"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	return c.JSON(http.StatusOK, map[string]string{"url": url})
+}
+
+// GET /api/auth/:provider/callback — Google이 직접 redirect (redirect_uri = 백엔드)
+func (h *AuthHandler) HandleCallback(c echo.Context) error {
+	providerName := c.Param("provider")
+	code := c.QueryParam("code")
+	state := c.QueryParam("state")
+	if code == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "code 파라미터가 필요합니다")
+	}
+
+	sess, _, err := h.authService.HandleCallback(c.Request().Context(), providerName, code, state)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// HttpOnly 세션 쿠키 설정 후 프론트로 redirect
+	c.SetCookie(&http.Cookie{
+		Name:     customMiddleware.SessionCookieName,
+		Value:    sess.ID,
+		Path:     "/",
+		Expires:  sess.ExpiresAt,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		// Secure: true,  // 프로덕션(HTTPS)에서 활성화
+	})
+	return c.Redirect(http.StatusFound, h.frontendURL)
+}
+
+// POST /api/auth/logout — 세션 삭제 + 쿠키 만료 (서버측 무효화)
+func (h *AuthHandler) Logout(c echo.Context) error {
+	if cookie, err := c.Cookie(customMiddleware.SessionCookieName); err == nil {
+		_ = h.authService.Logout(cookie.Value)
+	}
+	c.SetCookie(&http.Cookie{
+		Name:     customMiddleware.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		HttpOnly: true,
+	})
+	return c.JSON(http.StatusOK, map[string]string{"message": "로그아웃 성공"})
+}
+```
+
+- [ ] **Step 2: main.go 재배선**
+
+`backend/main.go`에서 변경할 부분:
+
+(a) import에서 `model.Session` 마이그레이션 추가 — AutoMigrate 줄 교체:
+```go
+	if err := db.AutoMigrate(&model.User{}, &model.Session{}); err != nil {
+		log.Fatal("마이그레이션 실패:", err)
+	}
+```
+
+(b) 서비스 배선 교체 (`tokenService`/`authService`/`authHandler`/JWT 미들웨어 부분):
+```go
+	userRepo := repository.NewUserRepository(db)
+	sessionRepo := repository.NewSessionRepository(db)
+	sessionService := service.NewSessionService(sessionRepo, 7*24*time.Hour) // 세션 7일
+	authService := service.NewAuthService(providers, userRepo, sessionService)
+
+	authHandler := handler.NewAuthHandler(authService, cfg.FrontendURL)
+	userHandler := handler.NewUserHandler(authService)
+```
+
+(c) 라우트에서 refresh 제거 + 보호 라우트 미들웨어 교체:
+```go
+	auth := api.Group("/auth")
+	auth.GET("/:provider/url", authHandler.GetAuthURL)
+	auth.GET("/:provider/callback", authHandler.HandleCallback)
+	auth.POST("/logout", authHandler.Logout)
+
+	user := api.Group("/user", customMiddleware.SessionAuth(sessionService))
+	user.GET("/me", userHandler.GetMe)
+```
+
+(d) import에 `"time"` 추가, 미사용 import 정리(`echoMiddleware`는 CORS에 계속 사용).
+
+- [ ] **Step 3: CORS에 credentials 허용 확인**
+
+`backend/main.go`의 CORS 설정에 이미 `AllowCredentials: true`가 있다. `AllowOrigins`가 `cfg.FrontendURL`인지 확인(와일드카드면 쿠키 전송 불가).
+
+- [ ] **Step 4: config redirect_uri를 백엔드로 (세션은 백엔드 redirect)**
+
+`backend/config/config.go`의 `GoogleRedirectURL` 기본값 교체:
+```go
+		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:8080/api/auth/google/callback"),
+```
+그리고 `JWTSecret` 필드는 세션 버전에서 미사용 → config에서 제거하고 `Load()`에서도 해당 줄 삭제. (참조하는 곳이 없어야 빌드됨)
+
+- [ ] **Step 5: 빌드 + 전체 테스트**
+
+Run: `cd backend && go build ./... && go test ./...`
+Expected: 빌드 성공, 모든 테스트 PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add backend/
+git commit -m "feat: 세션 쿠키 콜백/로그아웃 핸들러 및 main 배선"
+```
+
+---
+
+### Task 14: 프론트엔드 세션화
+
+토큰 보관을 제거하고 쿠키 기반으로 전환. Google이 백엔드로 redirect 후 다시 프론트("/")로 오므로 별도 콜백 페이지 불필요.
+
+**Files:**
+- Modify: `frontend/src/services/authService.ts`
+- Modify: `frontend/src/hooks/useAuth.ts`
+- Modify: `frontend/src/App.tsx`
+- Remove: `frontend/src/components/OAuthCallback.tsx`
+- Modify: `frontend/src/types/auth.ts`
+
+- [ ] **Step 1: authService.ts 재작성**
+
+`frontend/src/services/authService.ts`:
+```typescript
+import axios from 'axios';
+import type { User } from '../types/auth';
+
+const API_URL = import.meta.env.VITE_API_URL || '';
+
+// withCredentials: 쿠키를 교차 출처 요청에 포함
+const api = axios.create({ baseURL: API_URL, withCredentials: true });
+
+export async function getGoogleAuthURL(): Promise<string> {
+  const { data } = await api.get<{ url: string }>('/api/auth/google/url');
+  return data.url;
+}
+
+export async function getMe(): Promise<User> {
+  const { data } = await api.get<User>('/api/user/me');
+  return data;
+}
+
+export async function logout(): Promise<void> {
+  await api.post('/api/auth/logout');
+}
+```
+
+- [ ] **Step 2: useAuth.ts 재작성**
+
+`frontend/src/hooks/useAuth.ts`:
+```typescript
+import { useState, useEffect, useCallback } from 'react';
+import type { User } from '../types/auth';
+import { getMe, logout as logoutApi } from '../services/authService';
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(() => {
+    getMe()
+      .then(setUser)
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const logout = useCallback(async () => {
+    await logoutApi();
+    setUser(null);
+  }, []);
+
+  return { user, loading, isAuthenticated: !!user, logout };
+}
+```
+
+- [ ] **Step 3: App.tsx 재작성 (콜백 라우트 제거)**
+
+`frontend/src/App.tsx`:
+```tsx
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useAuth } from './hooks/useAuth';
+import { LoginButton } from './components/LoginButton';
+import { UserProfile } from './components/UserProfile';
+import { ProtectedRoute } from './components/ProtectedRoute';
+
+function App() {
+  const { user, loading, isAuthenticated, logout } = useAuth();
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: 'center', marginTop: '100px' }}>
+        <p>로딩 중...</p>
+      </div>
+    );
+  }
+
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route
+          path="/login"
+          element={isAuthenticated ? <Navigate to="/" replace /> : <LoginButton />}
+        />
+        <Route
+          path="/"
+          element={
+            <ProtectedRoute isAuthenticated={isAuthenticated}>
+              <UserProfile user={user!} onLogout={logout} />
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;
+```
+
+- [ ] **Step 4: OAuthCallback 제거 + types 정리**
+
+Run:
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go/web/sns-login-session/frontend
+rm src/components/OAuthCallback.tsx
+```
+`frontend/src/types/auth.ts`에서 `TokenPair`, `AuthResponse` 제거(User만 남김):
+```typescript
+export interface User {
+  id: number;
+  email: string;
+  name: string;
+  avatar_url: string;
+  provider: string;
+}
+```
+
+- [ ] **Step 5: 프론트 빌드 확인**
+
+Run: `cd frontend && npm install && npm run build`
+Expected: 타입 에러 없이 빌드 성공
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go
+git add web/sns-login-session/frontend
+git commit -m "feat: 프론트엔드 세션 쿠키 방식으로 전환 (토큰 보관 제거)"
+```
+
+---
+
+### Task 15: 세션 버전 docker-compose 정리
+
+**Files:**
+- Modify: `web/sns-login-session/docker-compose.yml`
+
+- [ ] **Step 1: env에서 JWT 제거, redirect 백엔드로**
+
+`docker-compose.yml`의 backend `environment` 교체:
+```yaml
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/google/callback
+      - FRONTEND_URL=http://localhost:3000
+      - SERVER_PORT=8080
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add web/sns-login-session/docker-compose.yml
+git commit -m "chore: 세션 버전 docker-compose env 정리"
+```
+
+---
+
+### Task 16: Phase 2 통합 검증
+
+- [ ] **Step 1: 백엔드 전체 테스트/빌드**
+
+Run: `cd /Users/user/src/workspace_blogv2/tutorials-go/web/sns-login-session/backend && go test ./... && go build ./...`
+Expected: 전부 PASS / 빌드 성공
+
+- [ ] **Step 2: (수동) 실제 OAuth 플로우 확인 메모**
+
+`.env`에 Google 자격증명 설정 후 `docker compose up -d`로 다음 확인(자동화 불가, 수동):
+- 로그인 → `/api/user/me` 200, `sessions` 테이블에 row 생성
+- 로그아웃 → 같은 쿠키로 `/api/user/me` 호출 시 401 (서버측 무효화 검증)
+
+```bash
+sqlite3 backend/data/app.db "SELECT id, user_id, expires_at FROM sessions;"
+```
+
+---
+
+## Phase 3: 블로그 재구성
+
+### Task 17: index.md 통합 글로 재작성
+
+**Files:**
+- Modify: `blog-v2.advenoh.pe.kr/docs/read/go-google-oauth-로그인-구현-가이드/index.md`
+
+스펙 §4 목차를 따른다. 아래 내용을 반드시 반영한다(나머지 기존 본문은 유지/이동):
+
+1. **프론트매터 tags**: `session`, `cookie`, `jwt-vs-session` 추가
+2. **들어가며**: "OAuth(신원 위임)와 세션 유지 방식(JWT/세션)은 별개"라는 문장 추가
+3. **3장 Google Console**: 승인된 redirect URI를 **두 개** 등록하도록 수정
+   - JWT 버전: `http://localhost:3000/auth/callback` (프론트)
+   - 세션 버전: `http://localhost:8080/api/auth/google/callback` (백엔드)
+   - 각 URI가 왜 다른지(플로우 차이) 설명
+4. **공통 구현 절**: `findOrCreateUser` 코드 스니펫 추가(A-1), state 저장/검증(`sync.Map` + `LoadAndDelete`) 코드 추가(B-6)
+5. **JWT 절**: SPA 토큰 플로우 다이어그램 + 토큰 타입 구분(B-4) 설명. `google.go` 스니펫은 실제 코드처럼 `io.ReadAll`+`json.Unmarshal`+에러 처리로 교체(D-10). 콜백 스니펫에 `code == ""` 검증 포함(D-11)
+6. **세션 절(신규)**: 서버 redirect 플로우 다이어그램 + `Session` 모델/미들웨어/쿠키 코드 + "로그아웃 = 세션 삭제(서버측 무효화)" 강조(B-5)
+7. **JWT vs 세션 비교표**: 스펙 §4 표 삽입 + 선택 가이드. "왜 JWT가 필수가 아닌지"(B-8) 명시
+8. **마무리**: 프로덕션 고려사항 유지 + **A-2 한계 각주**("같은 이메일을 다른 provider로 가입 시 계정 연결은 이 글 범위 밖")
+9. **GitHub 링크**: `web/sns-login` → `web/sns-login-jwt`, `web/sns-login-session` 두 개로 갱신. JWT 시크릿 기본값/포트 표기 통일(B-7/D-12)
+
+- [ ] **Step 1: 위 9개 항목을 반영해 index.md 수정**
+
+(편집 작업. 각 코드 스니펫은 Phase 1/2에서 확정된 실제 파일 내용과 1:1 일치시킨다.)
+
+- [ ] **Step 2: 인코딩 확인**
+
+Run: `file -I "docs/read/go-google-oauth-로그인-구현-가이드/index.md"`
+Expected: `charset=utf-8`
+
+- [ ] **Step 3: 코드-블로그 일치 점검**
+
+블로그의 모든 Go/TS 스니펫을 해당 실제 파일과 대조(토큰 타입, 세션 미들웨어, 콜백 redirect, findOrCreate). 불일치 0건.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blogv2/blog-v2.advenoh.pe.kr
+git add "docs/read/go-google-oauth-로그인-구현-가이드/index.md"
+git commit -m "docs: SNS 로그인 글 재구성 — JWT/세션 두 구현 및 비교"
+```
+
+---
+
+## Phase 4: 마무리
+
+### Task 18: PR 생성
+
+- [ ] **Step 1: tutorials-go PR**
+
+```bash
+cd /Users/user/src/workspace_blogv2/tutorials-go
+git push -u origin feat/sns-login-jwt-session
+gh pr create --base master --assignee kenshin579 --title "feat: SNS 로그인 JWT/세션 두 구현 분리" --body "$(cat <<'EOF'
+## Summary
+- `web/sns-login` → `web/sns-login-jwt`로 rename, JWT 토큰 타입 구분(B-4)·프로필 갱신(A-3)·redirect_uri 정렬(C-9)·시크릿 정리(B-7)
+- `web/sns-login-session` 신규: SQLite `sessions` 테이블 + HttpOnly 쿠키, 서버측 로그아웃
+
+## Test plan
+- [x] sns-login-jwt: `go test ./...` PASS
+- [x] sns-login-session: `go test ./...` PASS
+- [ ] (수동) 실제 Google OAuth 로그인/로그아웃 플로우 확인
+EOF
+)"
+```
+
+- [ ] **Step 2: blog-v2 PR**
+
+```bash
+cd /Users/user/src/workspace_blogv2/blog-v2.advenoh.pe.kr
+git push -u origin docs/sns-login-jwt-session-spec
+gh pr create --base main --assignee kenshin579 --title "docs: SNS 로그인 JWT vs 세션 글 재구성" --body "$(cat <<'EOF'
+## Summary
+- 설계/계획 문서 추가, 기존 글을 JWT/세션 통합 구성으로 재작성
+- JWT vs 세션 비교표, 두 구현 GitHub 링크
+
+## Test plan
+- [x] 인코딩 UTF-8 확인
+- [x] 모든 코드 스니펫이 실제 샘플 코드와 일치
+EOF
+)"
+```
+
+---
+
+## Self-Review 결과
+
+- **스펙 커버리지**: §2 구조→T1/T7, §3.2 JWT→T2~T5, §3.3 세션→T8~T15, §3.4 A-2 보류→T17 각주, §4 블로그→T17, §5 순서→Phase 구성, §6 완료기준→T6/T16/T17 검증. 누락 없음.
+- **D-10/D-11**: 실제 코드는 이미 충족 → 블로그 스니펫 정렬(T17)로만 처리. 코드 태스크에서 제외(중복 방지).
+- **타입 일관성**: `Claims.TokenType`, `service.TokenTypeAccess`, `SessionCookieName`, `SessionService.Create/Validate/Delete`, `AuthService.HandleCallback`(세션 버전은 `*model.Session` 반환) — 태스크 간 시그니처 일치 확인.
+- **중복 `newTestDB`**: 같은 패키지 내 1회 정의 규칙 명시(T10에서 정의, T4/T12 주의 노트 포함).

--- a/docs/superpowers/specs/2026-06-03-sns-login-jwt-vs-session-design.md
+++ b/docs/superpowers/specs/2026-06-03-sns-login-jwt-vs-session-design.md
@@ -1,0 +1,133 @@
+# SNS 로그인: JWT vs 세션 — 두 구현 분리 및 블로그 재구성 설계
+
+- 작성일: 2026-06-03
+- 대상 저장소
+  - `tutorials-go` — 샘플 코드 (`web/sns-login-jwt`, `web/sns-login-session`)
+  - `blog-v2.advenoh.pe.kr` — 블로그 글 (`docs/read/go-google-oauth-로그인-구현-가이드/index.md`)
+
+## 1. 배경 / 목표
+
+기존 글 "Go + React로 Google OAuth 2.0 로그인 구현하기"는 OAuth 흐름은 잘 다루지만,
+**인증 이후 상태 유지 방식**으로 JWT만 보여주고, 회원가입 구현·일부 보안 메커니즘 코드가 누락되어 있다.
+또한 콜백(redirect_uri) 설계가 백엔드/프론트 모델이 섞여 **따라 하면 동작하지 않는 모순**이 있다.
+
+목표:
+
+1. 샘플 코드를 **두 구현으로 분리**한다 — `sns-login-jwt`(무상태 JWT) / `sns-login-session`(서버 세션 + SQLite).
+2. 블로그를 **하나의 글**로 재구성해 OAuth 공통 흐름을 한 번 설명하고, "JWT vs 세션" 비교와 두 구현을 함께 다룬다.
+3. 리뷰에서 발견한 정확성·보안 결함 중 비용 대비 가치가 높은 항목을 함께 수정한다.
+
+핵심 메시지: **OAuth(신원 위임)와 세션 유지 방식(JWT/세션)은 별개이며, 트레이드오프가 다르다.**
+
+## 2. 디렉토리 구조
+
+```
+tutorials-go/web/
+├── sns-login-jwt/        # 기존 web/sns-login 을 git mv 로 rename
+│   ├── backend/          # Echo + GORM + SQLite, JWT 무상태
+│   └── frontend/         # React, code → BE 전달(SPA 토큰 플로우)
+└── sns-login-session/    # 신규 (sns-login-jwt 복제 후 세션 방식으로 개조)
+    ├── backend/          # Echo + GORM + SQLite, sessions 테이블 + HttpOnly 쿠키
+    └── frontend/         # React, 쿠키 기반(토큰 보관 없음)
+```
+
+두 폴더는 각각 자체 완결(독립적으로 읽고 실행 가능). 공통부(`provider/google.go`, OAuth 교환 로직)는 동일하고,
+**차이는 "인증 이후 상태 유지"에만** 있다.
+
+## 3. 구현 설계
+
+### 3.1 공통 (두 버전 동일)
+
+- Google OAuth Provider (`provider/google.go`): Authorization Code → Access Token → UserInfo
+- `OAuthProvider` 인터페이스로 향후 SNS 확장 가능
+- User 모델(GORM/SQLite): `findOrCreateUser`로 최초 로그인 시 자동 회원가입
+- **state 파라미터 CSRF 방지**: 발급 시 저장 → 콜백에서 검증·삭제 (코드 명시)
+
+### 3.2 JWT 버전 (`sns-login-jwt`)
+
+콜백 흐름 — **SPA 토큰 플로우**:
+
+```
+FE: "Google 로그인" → GET /api/auth/google/url → Google redirect
+Google → 프론트 라우트(/auth/callback)로 redirect (redirect_uri = 프론트)
+FE: URL의 code/state 추출 → GET /api/auth/google/callback?code&state (BE)
+BE: code 교환 → findOrCreate → JWT(access/refresh) JSON 반환
+FE: localStorage 저장, 이후 Authorization: Bearer 로 API 호출
+```
+
+포함할 수정 (리뷰 항목):
+
+- **B-4**: Access/Refresh 토큰에 `token_type` 클레임 추가. `JWTAuth` 미들웨어는 **access 토큰만** 허용
+  (refresh 토큰으로 보호 API 호출 차단).
+- **B-7**: JWT 시크릿 기본값을 `config.go`/docker-compose에서 통일하고, "프로덕션에서 반드시 교체" 경고.
+- **D-10**: `google.go`의 JSON 디코딩 에러를 무시하지 않고 처리(실제 코드와 일치).
+- **D-11**: 콜백 핸들러에 `code == ""` 검증 포함.
+- **A-3**: `findOrCreateUser`에서 재로그인 시 Name/AvatarURL 갱신(1줄 Update).
+
+### 3.3 세션 버전 (`sns-login-session`)
+
+콜백 흐름 — **클래식 서버 세션 플로우**:
+
+```
+FE: "Google 로그인" → GET /api/auth/google/url → Google redirect
+Google → 백엔드 /api/auth/google/callback 로 redirect (redirect_uri = 백엔드)
+BE: code 교환 → findOrCreate → sessions row 생성 → Set-Cookie(HttpOnly) → 프론트로 302 redirect
+FE: 쿠키 자동 전송 → GET /api/user/me 로 사용자 정보 로드
+```
+
+세션 저장 설계:
+
+- `sessions` 테이블(GORM/SQLite): `id`(랜덤 토큰, PK), `user_id`, `expires_at`, `created_at`
+- 로그인 성공 시 세션 row 생성, 세션 ID를 **HttpOnly + SameSite + (프로덕션)Secure 쿠키**에 저장
+- 세션 미들웨어: 쿠키의 세션 ID로 DB 조회 → 만료/유효성 확인 → `user_id`를 컨텍스트에 주입
+- **로그아웃 = 세션 row 삭제**(서버측 즉시 무효화) — JWT 대비 핵심 차별점
+- 구현은 라이브러리 없이 직접(Echo `c.SetCookie`/`c.Cookie`). `echo-contrib/session`은 SQLite 백엔드에
+  커스텀 스토어가 필요해 더 복잡하므로 채택하지 않음.
+
+### 3.4 보류 항목
+
+- **A-2** (같은 이메일을 다른 provider로 가입 시 `Email` uniqueIndex 충돌 / 계정 연결):
+  별도 주제로 범위가 큼. **구현 보류**, 블로그에 "한계" 각주 한 줄만 추가.
+
+## 4. 블로그 재구성 (`index.md`)
+
+하나의 글로 통합. 제안 목차:
+
+1. 들어가며 — SNS 로그인의 이점, "OAuth와 세션 유지는 별개"
+2. OAuth 2.0 핵심 개념 (기존 유지)
+3. Google Cloud Console 설정 — redirect URI **두 개** 등록(프론트용/백엔드용)과 각 용도 설명
+4. 공통 구현 — Provider, code 교환, findOrCreate(회원가입), state/CSRF (코드 수록)
+5. **상태 유지 방식 ①: JWT (무상태)** — `sns-login-jwt` 흐름·코드, 토큰 타입 구분
+6. **상태 유지 방식 ②: 세션 (서버 상태 + SQLite)** — `sns-login-session` 흐름·코드, 서버측 로그아웃
+7. **JWT vs 세션 비교** — 표 + 선택 가이드
+8. 마무리 — 프로덕션 고려사항(PKCE, Rotation, Secure Cookie, A-2 한계 각주)
+9. 참고
+
+JWT vs 세션 비교표(초안):
+
+| 기준 | JWT (무상태) | 세션 (서버 상태) |
+|------|-------------|-----------------|
+| 상태 저장 | 클라이언트 보관, 서버 무상태 | 서버(SQLite 등)에 세션 저장 |
+| 서버측 로그아웃/강제 차단 | 어려움(만료 전까지 유효) | 쉬움(row 삭제로 즉시 무효화) |
+| 수평 확장 | 용이(공유 상태 불필요) | 세션 스토어 공유 필요 |
+| 탈취 시 영향 | 만료까지 유효, 회수 어려움 | 즉시 회수 가능 |
+| 저장 위치 보안 | localStorage(XSS) vs 쿠키 | HttpOnly 쿠키 |
+| 적합 | FE/BE 분리, MSA, 무상태 API | 단일/소규모, 즉시 무효화 중요 |
+
+GitHub 링크: 두 폴더(`web/sns-login-jwt`, `web/sns-login-session`) 모두 연결.
+기존 `web/sns-login` 링크는 rename에 맞춰 갱신.
+
+## 5. 작업 순서 (코드 먼저 → 블로그)
+
+1. `tutorials-go`: `web/sns-login` → `web/sns-login-jwt` rename, JWT 버전 리뷰 수정(B-4/B-7/D-10/D-11/A-3) 적용, 빌드/테스트 통과
+2. `tutorials-go`: `web/sns-login-session` 신규 구현(세션 테이블·쿠키·미들웨어·서버 로그아웃), 빌드/실행 확인
+3. `blog-v2`: `index.md` 재구성(통합 글 + 비교표 + 두 링크 + A-2 각주)
+4. 각 단계 feature 브랜치 → PR → 머지
+
+## 6. 완료 기준
+
+- 두 폴더가 각각 `docker compose up` 또는 로컬 실행으로 로그인→보호 API→로그아웃이 동작
+- JWT 버전: refresh 토큰으로 보호 API 호출이 차단됨(B-4 검증)
+- 세션 버전: 로그아웃 후 동일 쿠키로 보호 API 호출이 거부됨(서버측 무효화 검증)
+- 블로그의 모든 코드 스니펫이 실제 샘플 코드와 일치
+- 블로그에서 redirect_uri 설명이 각 버전의 실제 흐름과 일치(C-9 해소)


### PR DESCRIPTION
## Summary
- 기존 "Go + React Google OAuth 로그인" 글을 **JWT vs 세션** 두 구현을 함께 다루는 하나의 글로 재구성
  - 공통(OAuth 흐름) 1회 설명 + `findOrCreateUser`(회원가입)·state CSRF 코드 수록
  - JWT 절(SPA 토큰 플로우, token_type 구분) / 세션 절(서버 redirect, SQLite 세션, 서버측 로그아웃)
  - JWT vs 세션 비교표 + 선택 가이드("JWT는 필수가 아니다")
  - redirect_uri 모순(C-9) 해소, 코드 스니펫을 실제 샘플과 1:1 일치, A-2(계정 연결) 한계 각주
- 설계 문서/구현 계획서 추가 (`docs/superpowers/specs`, `docs/superpowers/plans`)
- 연동 샘플: [web/sns-login-jwt](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-jwt), [web/sns-login-session](https://github.com/kenshin579/tutorials-go/tree/master/web/sns-login-session) (tutorials-go PR #718)

## Test plan
- [x] 인코딩 UTF-8 확인
- [x] 모든 Go/TS 스니펫이 실제 샘플 코드와 일치(스펙 리뷰 검증)
- [x] Mermaid 다이어그램 규칙 준수(`<br/>`/ASCII art 없음)
- [ ] (수동) 렌더링 미리보기에서 다이어그램/표 확인
- [ ] (후속) §3 스크린샷 TODO 3곳 채우기

🤖 Generated with [Claude Code](https://claude.com/claude-code)