### PR TITLE
feat: 다국어 UI/네비 현지화 (Plan 2)

### DIFF
--- a/app/en/[slug]/page.tsx
+++ b/app/en/[slug]/page.tsx
@@ -150,6 +150,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
           seriesName={manifestArticle.series}
           articles={seriesEpisodes}
           currentSlug={manifestArticle.slug}
+          basePath="/en"
         />
       )}
 
@@ -180,12 +181,12 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
       {/* Prev/Next (only when series article and has prev or next) */}
       {(prev || next) && (
         <div className="mx-auto max-w-prose px-6 md:px-0">
-          <PrevNext prev={prev} next={next} />
+          <PrevNext prev={prev} next={next} basePath="/en" />
         </div>
       )}
 
       {/* Related cards (all articles) */}
-      <RelatedCards articles={related} />
+      <RelatedCards articles={related} basePath="/en" />
     </main>
   );
 }

--- a/app/en/category/[name]/page.tsx
+++ b/app/en/category/[name]/page.tsx
@@ -1,0 +1,177 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import {
+  getAllArticles,
+  getArticlesByCategory,
+  getArticleTitleFromSlug,
+} from '@/lib/articles';
+import { formatDate } from '@/lib/utils';
+import { Breadcrumb } from '@/components/breadcrumb';
+import { categorySlug } from '@/lib/url';
+
+interface PageProps {
+  params: Promise<{ name: string }>;
+}
+
+export const dynamicParams = false;
+
+const TINTS = ['bg-bento-sage', 'bg-bento-butter', 'bg-bento-rose', 'bg-bento-lavender'] as const;
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
+
+export async function generateStaticParams() {
+  const all = await getAllArticles('en');
+  const cats = Array.from(new Set(all.map((a) => a.category.toLowerCase())));
+  return cats.map((name) => ({ name }));
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { name } = await params;
+  const decoded = decodeURIComponent(name);
+  const displayName = decoded.charAt(0).toUpperCase() + decoded.slice(1);
+  return {
+    title: `${displayName} | Frank's IT Blog`,
+    description: `A collection of posts in the ${displayName} category`,
+  };
+}
+
+export default async function CategoryPage({ params }: PageProps) {
+  const { name } = await params;
+  const decoded = decodeURIComponent(name).toLowerCase();
+
+  const all = await getAllArticles('en');
+  const matchedCategory = all.find(
+    (a) => a.category.toLowerCase() === decoded,
+  )?.category;
+  if (!matchedCategory) notFound();
+
+  const articles = (await getArticlesByCategory(matchedCategory, 'en')).sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+  if (articles.length === 0) notFound();
+
+  const countByCat = new Map<string, number>();
+  for (const a of all) countByCat.set(a.category, (countByCat.get(a.category) ?? 0) + 1);
+  const otherCats = Array.from(countByCat.entries())
+    .filter(([cat]) => cat !== matchedCategory)
+    .map(([cat, count]) => ({ name: cat, count }))
+    .sort((a, b) => b.count - a.count);
+
+  return (
+    <main className="min-h-screen bg-bento-bg pb-20">
+      <Breadcrumb
+        items={[
+          { label: 'Home', href: '/en' },
+          { label: 'Posts', href: '/en/posts' },
+          { label: matchedCategory },
+        ]}
+      />
+
+      {/* Hero: 2-col (dark + cream sidebar) */}
+      <section className="mx-auto grid max-w-canvas grid-cols-12 gap-4 px-6 md:px-10">
+        <div className="relative col-span-12 overflow-hidden rounded-card-xl bg-bento-hero-dark p-8 text-white md:col-span-8 md:p-12">
+          <div
+            aria-hidden="true"
+            className="absolute -right-32 -top-32 h-[420px] w-[420px] rounded-full opacity-55"
+            style={{ background: 'radial-gradient(circle, rgb(var(--bento-accent)) 0%, transparent 70%)' }}
+          />
+          <div className="relative">
+            <p className="text-[12px] uppercase tracking-[0.12em] text-white/70">Category</p>
+            <div className="my-4 text-[56px] font-bold capitalize leading-[0.95] tracking-tightest md:text-[88px]">
+              {matchedCategory}.
+            </div>
+            <div className="flex gap-6 text-xs text-white/70">
+              <span><strong className="text-base text-white">{articles.length}</strong> posts</span>
+            </div>
+          </div>
+        </div>
+
+        <aside className="col-span-12 rounded-card-lg bg-bento-cream p-5 md:col-span-4">
+          <div className="mb-3 text-[11px] uppercase tracking-wider text-bento-dim">
+            Other categories
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {otherCats.map((c) => (
+              <Link
+                key={c.name}
+                href={`/en/category/${encodeURIComponent(categorySlug(c.name))}`}
+                className={[
+                  'inline-flex items-center gap-1.5 rounded-full bg-bento-card px-3.5 py-2 text-[13px] text-bento-ink no-underline',
+                  FOCUS_RING,
+                ].join(' ')}
+              >
+                <span className="capitalize">{c.name}</span>
+                <span className="text-[11px] text-bento-dim">{c.count}</span>
+              </Link>
+            ))}
+          </div>
+        </aside>
+      </section>
+
+      {/* Article Bento grid (variable col-span) */}
+      <section className="mx-auto mt-8 grid max-w-canvas grid-cols-12 gap-3 px-6 md:gap-4 md:px-10">
+        {articles.map((a, i) => {
+          const isFirst = i === 0;
+          const colSpan = isFirst
+            ? 'col-span-12'
+            : i % 3 === 1
+              ? 'col-span-12 md:col-span-7'
+              : i % 3 === 2
+                ? 'col-span-12 md:col-span-5'
+                : 'col-span-6 md:col-span-4';
+          const bg = isFirst
+            ? 'bg-bento-hero-dark text-white'
+            : `${TINTS[i % TINTS.length]} text-bento-ink`;
+          const minH = isFirst ? 'min-h-[220px] md:min-h-[260px]' : 'min-h-[160px] md:min-h-[200px]';
+          const dimColor = isFirst ? 'text-white/60' : 'text-bento-dim';
+          return (
+            <Link
+              key={a.slug}
+              href={`/en/${encodeURIComponent(getArticleTitleFromSlug(a.slug))}`}
+              className={[
+                'flex flex-col justify-between rounded-card-lg p-5 no-underline md:p-6',
+                colSpan,
+                bg,
+                minH,
+                FOCUS_RING,
+              ].join(' ')}
+            >
+              <div>
+                <div className={['mb-2 text-[10px] uppercase tracking-wider', dimColor].join(' ')}>
+                  <span className="capitalize">{a.category}</span> · {formatDate(a.date)}
+                </div>
+                <h3
+                  className={[
+                    'font-bold leading-tight tracking-tighter',
+                    isFirst ? 'text-2xl md:text-3xl' : 'text-base md:text-lg',
+                  ].join(' ')}
+                >
+                  {a.title}
+                </h3>
+                {isFirst && a.excerpt && (
+                  <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/75">{a.excerpt}</p>
+                )}
+              </div>
+              {a.tags && a.tags.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {a.tags.slice(0, 2).map((t) => (
+                    <span
+                      key={t}
+                      className={[
+                        'rounded-full px-2 py-0.5 text-[10px]',
+                        isFirst ? 'bg-white/10 text-white/85' : 'bg-bento-ink/[0.06] text-bento-ink',
+                      ].join(' ')}
+                    >
+                      #{t}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </Link>
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/app/en/posts/page.tsx
+++ b/app/en/posts/page.tsx
@@ -37,7 +37,7 @@ export default async function PostsPage() {
         </header>
 
         <Suspense fallback={<div className="py-20 text-center text-sm text-bento-dim">Loading…</div>}>
-          <PostsPageClient articles={articles} categories={categories} />
+          <PostsPageClient articles={articles} categories={categories} basePath="/en" />
         </Suspense>
       </div>
     </main>

--- a/app/en/series/[slug]/page.tsx
+++ b/app/en/series/[slug]/page.tsx
@@ -1,0 +1,188 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import {
+  getAllSeries,
+  getArticlesBySeries,
+  getArticleTitleFromSlug,
+} from '@/lib/articles';
+import { seriesSlug } from '@/lib/url';
+import { formatDate } from '@/lib/utils';
+import { Breadcrumb } from '@/components/breadcrumb';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export const dynamicParams = false;
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
+
+const OTHER_TINTS = ['bg-bento-sage', 'bg-bento-rose', 'bg-bento-butter'] as const;
+
+export async function generateStaticParams() {
+  const names = await getAllSeries('en');
+  return names.map((name) => ({ slug: seriesSlug(name) }));
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const decoded = decodeURIComponent(slug);
+  const names = await getAllSeries('en');
+  const matched = names.find((n) => seriesSlug(n) === decoded);
+  if (!matched) return { title: 'Series not found' };
+  return {
+    title: `${matched} | Frank's IT Blog`,
+    description: `${matched} series — episode collection`,
+  };
+}
+
+export default async function SeriesDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+  const decoded = decodeURIComponent(slug);
+
+  const names = await getAllSeries('en');
+  const matched = names.find((n) => seriesSlug(n) === decoded);
+  if (!matched) notFound();
+
+  const eps = await getArticlesBySeries(matched, 'en');
+  const sorted = eps.slice().sort((a, b) => {
+    const ao = a.seriesOrder ?? Number.POSITIVE_INFINITY;
+    const bo = b.seriesOrder ?? Number.POSITIVE_INFINITY;
+    if (ao !== bo) return ao - bo;
+    return new Date(a.date).getTime() - new Date(b.date).getTime();
+  });
+  if (sorted.length === 0) notFound();
+
+  const firstEpisode = sorted[0];
+  const blurb = firstEpisode.excerpt || '';
+
+  const others = await Promise.all(
+    names
+      .filter((n) => n !== matched)
+      .sort((a, b) => a.localeCompare(b, 'en'))
+      .slice(0, 3)
+      .map(async (name) => {
+        const list = await getArticlesBySeries(name, 'en');
+        return { name, count: list.length, slug: seriesSlug(name) };
+      }),
+  );
+
+  return (
+    <main className="min-h-screen bg-bento-bg pb-20">
+      <Breadcrumb
+        items={[
+          { label: 'Home', href: '/en' },
+          { label: 'Series', href: '/en/series' },
+          { label: matched },
+        ]}
+      />
+
+      {/* Hero: 2-col (lavender main + white/50 mini card) */}
+      <section className="mx-auto max-w-canvas px-6 md:px-10">
+        <div className="grid grid-cols-12 gap-4 rounded-card-xl bg-bento-lavender p-6 text-bento-ink md:p-10">
+          <div className="col-span-12 md:col-span-8">
+            <p className="text-[12px] uppercase tracking-[0.12em] opacity-60">Series</p>
+            <h1 className="my-4 text-4xl font-bold leading-[1.05] tracking-tightest md:text-6xl">
+              {matched}.
+            </h1>
+            {blurb && (
+              <p className="mb-7 max-w-xl text-base leading-relaxed opacity-75 md:text-lg">
+                {blurb}
+              </p>
+            )}
+            <Link
+              href={`/en/${encodeURIComponent(getArticleTitleFromSlug(firstEpisode.slug))}`}
+              className={[
+                'inline-flex items-center gap-2 rounded-full bg-bento-ink px-5 py-3 text-sm font-semibold text-white no-underline transition hover:bg-bento-ink/90',
+                FOCUS_RING,
+              ].join(' ')}
+            >
+              Read from the start
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+
+          <aside className="col-span-12 rounded-card-lg bg-white/50 p-6 text-center md:col-span-4">
+            <div className="text-[11px] uppercase tracking-wider text-bento-dim">Total</div>
+            <div className="mt-2 text-6xl font-bold leading-none tracking-tightest md:text-7xl">
+              {sorted.length}
+            </div>
+            <div className="mt-2 text-sm text-bento-dim">posts published</div>
+            <div className="mt-4 border-t border-bento-ink/10 pt-3 text-xs text-bento-dim">
+              <div className="uppercase tracking-wider">Latest</div>
+              <div className="mt-1 line-clamp-1 font-medium text-bento-ink">{sorted[sorted.length - 1].title}</div>
+              <div className="mt-1 text-[11px]">{formatDate(sorted[sorted.length - 1].date)}</div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      {/* Episodes timeline */}
+      <section className="mx-auto mt-12 max-w-3xl px-6 md:px-0">
+        <h2 className="mb-5 text-2xl font-bold tracking-tighter text-bento-ink md:text-3xl">Episodes</h2>
+        <ol className="flex flex-col">
+          {sorted.map((ep, i) => {
+            const epNum = ep.seriesOrder ?? i + 1;
+            const isLast = i === sorted.length - 1;
+            return (
+              <li key={ep.slug} className="grid grid-cols-[44px_1fr] gap-5">
+                <div className="flex flex-col items-center">
+                  <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-bento-ink text-sm font-bold text-white">
+                    {epNum}
+                  </div>
+                  {!isLast && (
+                    <div className="my-1 min-h-[40px] w-0.5 flex-1 bg-bento-ink/10" />
+                  )}
+                </div>
+                <Link
+                  href={`/en/${encodeURIComponent(getArticleTitleFromSlug(ep.slug))}`}
+                  className={[
+                    'mb-4 block rounded-card border border-bento-ink/10 bg-bento-card p-5 no-underline transition hover:bg-bento-ink/[0.03] dark:border-white/10 dark:hover:bg-white/[0.03]',
+                    FOCUS_RING,
+                  ].join(' ')}
+                >
+                  <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider text-bento-dim">
+                    <span>EP {String(epNum).padStart(2, '0')}</span>
+                    <span>·</span>
+                    <span>{formatDate(ep.date)}</span>
+                  </div>
+                  <h3 className="mt-2 text-lg font-bold tracking-tighter text-bento-ink md:text-xl">
+                    {ep.title}
+                  </h3>
+                  {ep.excerpt && (
+                    <p className="mt-2 text-sm leading-relaxed text-bento-dim line-clamp-2">{ep.excerpt}</p>
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+
+      {/* Other series */}
+      {others.length > 0 && (
+        <section className="mx-auto mt-16 max-w-canvas px-6 md:px-10">
+          <h3 className="mb-4 text-xl font-bold tracking-tighter text-bento-ink md:text-2xl">Other series</h3>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3 md:gap-4">
+            {others.map((s, i) => (
+              <Link
+                key={s.name}
+                href={`/en/series/${encodeURIComponent(s.slug)}`}
+                className={[
+                  'flex flex-col gap-3 rounded-card-lg p-6 no-underline text-bento-ink',
+                  OTHER_TINTS[i % OTHER_TINTS.length],
+                  FOCUS_RING,
+                ].join(' ')}
+              >
+                <div className="text-[11px] uppercase tracking-wider text-bento-dim opacity-80">Series</div>
+                <div className="text-lg font-bold leading-snug tracking-tighter md:text-xl">{s.name}</div>
+                <div className="mt-auto text-xs text-bento-dim">{s.count} posts</div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/app/en/series/page.tsx
+++ b/app/en/series/page.tsx
@@ -1,0 +1,92 @@
+import Link from 'next/link';
+import { getAllSeries, getArticlesBySeries } from '@/lib/articles';
+import { seriesSlug } from '@/lib/url';
+import { formatDate } from '@/lib/utils';
+
+export const metadata = {
+  title: "Series | Frank's IT Blog",
+  description: 'A collection of tech blog posts organized by series',
+};
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
+
+export default async function SeriesPage() {
+  const seriesNames = await getAllSeries('en');
+
+  const seriesData = await Promise.all(
+    seriesNames.map(async (name) => {
+      const eps = await getArticlesBySeries(name, 'en');
+      const sorted = eps.slice().sort(
+        (a, b) => (a.seriesOrder ?? 0) - (b.seriesOrder ?? 0),
+      );
+      const byDateDesc = eps.slice().sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      );
+      const latest = byDateDesc[0];
+      return {
+        name,
+        slug: seriesSlug(name),
+        count: sorted.length,
+        latestTitle: latest?.title ?? '',
+        latestDate: latest?.date ?? '',
+      };
+    }),
+  );
+
+  seriesData.sort((a, b) => new Date(b.latestDate).getTime() - new Date(a.latestDate).getTime());
+
+  return (
+    <main className="min-h-screen bg-bento-bg pb-20">
+      <header className="mx-auto max-w-canvas px-6 pt-8 md:px-10">
+        <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-bento-dim">
+          Series
+        </p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tighter text-bento-ink md:text-4xl">
+          Series
+        </h1>
+        <p className="mt-2 text-sm text-bento-dim">
+          {seriesData.length} series
+        </p>
+      </header>
+
+      {seriesData.length === 0 ? (
+        <section className="mx-auto max-w-canvas px-6 py-20 text-center text-bento-dim md:px-10">
+          No series available.
+        </section>
+      ) : (
+        <section className="mx-auto mt-8 grid max-w-canvas grid-cols-12 gap-3 px-6 md:gap-4 md:px-10">
+          {seriesData.map((s) => (
+            <Link
+              key={s.name}
+              href={`/en/series/${encodeURIComponent(s.slug)}`}
+              className={[
+                'col-span-12 flex flex-col rounded-card-xl bg-bento-lavender p-6 text-bento-ink no-underline md:col-span-6 md:p-7',
+                FOCUS_RING,
+              ].join(' ')}
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-[11px] uppercase tracking-[0.1em] opacity-60">Series</span>
+                <span className="text-xs text-bento-dim">{s.count} posts</span>
+              </div>
+              <h2 className="mb-4 text-xl font-bold tracking-tighter md:text-2xl">{s.name}</h2>
+              {s.latestTitle && (
+                <div className="mt-auto border-t border-bento-ink/10 pt-3">
+                  <div className="text-[10px] uppercase tracking-wider text-bento-dim">Latest</div>
+                  <div className="mt-1 line-clamp-2 text-[13px] font-medium leading-snug">
+                    {s.latestTitle}
+                  </div>
+                  {s.latestDate && (
+                    <div className="mt-1 text-[11px] text-bento-dim">
+                      {formatDate(s.latestDate)}
+                    </div>
+                  )}
+                </div>
+              )}
+            </Link>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/app/en/tags/[name]/page.tsx
+++ b/app/en/tags/[name]/page.tsx
@@ -1,0 +1,131 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import {
+  getAllArticles,
+  getArticlesByTag,
+  getArticleTitleFromSlug,
+} from '@/lib/articles';
+import { PostsList } from '@/components/posts/posts-list';
+import { Breadcrumb } from '@/components/breadcrumb';
+
+interface PageProps {
+  params: Promise<{ name: string }>;
+}
+
+export const dynamicParams = false;
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
+
+export async function generateStaticParams() {
+  const all = await getAllArticles('en');
+  const tags = new Set<string>();
+  for (const a of all) {
+    if (!a.tags) continue;
+    for (const t of a.tags) tags.add(t);
+  }
+  return Array.from(tags).map((tag) => ({ name: tag }));
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { name } = await params;
+  const decoded = decodeURIComponent(name);
+  return {
+    title: `#${decoded} | Frank's IT Blog`,
+    description: `A collection of posts tagged #${decoded}`,
+  };
+}
+
+export default async function TagDetailPage({ params }: PageProps) {
+  const { name } = await params;
+  const decoded = decodeURIComponent(name);
+
+  const matched = await getArticlesByTag(decoded, 'en');
+  if (matched.length === 0) notFound();
+
+  const sorted = matched
+    .slice()
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  const articles = sorted.map((a) => ({
+    slug: getArticleTitleFromSlug(a.slug),
+    title: a.title,
+    category: a.category,
+    date: a.date,
+  }));
+
+  // Related tags: aggregate from all articles, exclude current, top 12 by count
+  const all = await getAllArticles('en');
+  const counts = new Map<string, number>();
+  for (const a of all) {
+    if (!a.tags) continue;
+    for (const t of a.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
+  }
+  const related = Array.from(counts.entries())
+    .filter(([t]) => t !== decoded)
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 12);
+
+  return (
+    <main className="min-h-screen bg-bento-bg pb-20">
+      <Breadcrumb
+        items={[
+          { label: 'Home', href: '/en' },
+          { label: 'Tags', href: '/en/tags' },
+          { label: `#${decoded}` },
+        ]}
+      />
+
+      {/* Hero: 2-col (dark + cream sidebar) */}
+      <section className="mx-auto grid max-w-canvas grid-cols-12 gap-4 px-6 md:px-10">
+        <div className="relative col-span-12 overflow-hidden rounded-card-xl bg-bento-hero-dark p-8 text-white md:col-span-8 md:p-12">
+          <div
+            aria-hidden="true"
+            className="absolute -right-32 -top-32 h-[420px] w-[420px] rounded-full opacity-55"
+            style={{ background: 'radial-gradient(circle, rgb(var(--bento-accent)) 0%, transparent 70%)' }}
+          />
+          <div className="relative">
+            <p className="text-[12px] uppercase tracking-[0.12em] text-white/70">Tag</p>
+            <div className="my-4 text-[48px] font-bold leading-[0.95] tracking-tightest md:text-[80px]">
+              <span className="text-bento-accent">#</span>
+              {decoded}
+            </div>
+            <div className="flex gap-6 text-xs text-white/70">
+              <span><strong className="text-base text-white">{articles.length}</strong> posts</span>
+            </div>
+          </div>
+        </div>
+
+        {related.length > 0 && (
+          <aside className="col-span-12 rounded-card-lg bg-bento-cream p-5 md:col-span-4">
+            <div className="mb-3 text-[11px] uppercase tracking-wider text-bento-dim">
+              Related tags
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {related.map((t) => (
+                <Link
+                  key={t.tag}
+                  href={`/en/tags/${encodeURIComponent(t.tag)}`}
+                  className={[
+                    'inline-flex items-center gap-1.5 rounded-full bg-bento-card px-3.5 py-2 text-[13px] text-bento-ink no-underline',
+                    FOCUS_RING,
+                  ].join(' ')}
+                >
+                  <span className="text-bento-accent">#</span>
+                  {t.tag}
+                  <span className="text-[11px] text-bento-dim">{t.count}</span>
+                </Link>
+              ))}
+            </div>
+          </aside>
+        )}
+      </section>
+
+      {/* Article list */}
+      <section className="mx-auto mt-8 max-w-canvas px-6 md:px-10">
+        <PostsList articles={articles} basePath="/en" />
+      </section>
+    </main>
+  );
+}

--- a/app/en/tags/page.tsx
+++ b/app/en/tags/page.tsx
@@ -159,7 +159,7 @@ export default async function TagsPage() {
       </section>
 
       {/* Bento grid (sortable) */}
-      {entries.length > 0 && <TagsBentoGrid entries={entries} />}
+      {entries.length > 0 && <TagsBentoGrid entries={entries} basePath="/en" />}
     </main>
   );
 }

--- a/app/en/tags/page.tsx
+++ b/app/en/tags/page.tsx
@@ -1,0 +1,165 @@
+import Link from 'next/link';
+import { getAllArticles } from '@/lib/articles';
+import { Breadcrumb } from '@/components/breadcrumb';
+import { TagsBentoGrid, type TagEntry } from '@/components/tags-bento-grid';
+
+export const metadata = {
+  title: "Tags | Frank's IT Blog",
+  description: 'A collection of tech blog posts organized by tag',
+};
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
+
+export default async function TagsPage() {
+  const all = await getAllArticles('en');
+
+  // tag별 count + 관련 카테고리 + 최근 사용일 집계
+  type Agg = { count: number; categories: Map<string, number>; lastUsed: string };
+  const agg = new Map<string, Agg>();
+
+  for (const a of all) {
+    if (!a.tags) continue;
+    for (const t of a.tags) {
+      const existing = agg.get(t) ?? { count: 0, categories: new Map(), lastUsed: '' };
+      existing.count += 1;
+      existing.categories.set(a.category, (existing.categories.get(a.category) ?? 0) + 1);
+      if (a.date > existing.lastUsed) existing.lastUsed = a.date;
+      agg.set(t, existing);
+    }
+  }
+
+  const entries: TagEntry[] = Array.from(agg.entries()).map(([tag, v]) => ({
+    tag,
+    count: v.count,
+    categories: Array.from(v.categories.entries())
+      .sort((x, y) => y[1] - x[1])
+      .map(([cat]) => cat),
+    lastUsed: v.lastUsed,
+  }));
+
+  const totalUses = entries.reduce((s, e) => s + e.count, 0);
+  const byCount = [...entries].sort(
+    (a, b) => b.count - a.count || a.tag.localeCompare(b.tag, 'en'),
+  );
+  const top5 = byCount.slice(0, 5);
+  const heroCloud = byCount.slice(0, 24);
+
+  return (
+    <main className="min-h-screen bg-bento-bg pb-20">
+      <Breadcrumb items={[{ label: 'Home', href: '/en' }, { label: 'Tags' }]} />
+
+      {/* Hero — two columns */}
+      <section className="mx-auto max-w-canvas px-6 md:px-10">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[2fr_1fr]">
+          {/* Left: dark hero with inline tag cloud */}
+          <div className="relative overflow-hidden rounded-card-xl bg-bento-hero-dark p-8 text-white md:p-12">
+            <div
+              aria-hidden="true"
+              className="absolute -right-32 -top-32 h-[420px] w-[420px] rounded-full opacity-55"
+              style={{
+                background:
+                  'radial-gradient(circle, rgb(var(--bento-accent)) 0%, transparent 70%)',
+              }}
+            />
+            <div className="relative">
+              <p className="text-[12px] uppercase tracking-[0.12em] text-white/70">
+                Index
+              </p>
+              <h1 className="my-4 text-[56px] font-bold leading-[0.95] tracking-tightest md:text-[88px]">
+                Tags.
+              </h1>
+              <p className="max-w-lg text-base leading-relaxed text-white/75 md:text-lg">
+                Topics that cut across categories. The same #{top5[0]?.tag ?? 'tag'} tag can be
+                found spanning multiple categories.
+              </p>
+
+              {heroCloud.length > 0 && (
+                <div className="mt-8 flex flex-wrap gap-x-3 gap-y-2 leading-tight">
+                  {heroCloud.map((e, i) => {
+                    const size =
+                      i < 3
+                        ? 'text-[36px] font-extrabold text-white md:text-[44px]'
+                        : i < 7
+                          ? 'text-[24px] font-bold text-white/85 md:text-[28px]'
+                          : 'text-[16px] font-medium text-white/55 md:text-[18px]';
+                    return (
+                      <Link
+                        key={e.tag}
+                        href={`/en/tags/${encodeURIComponent(e.tag)}`}
+                        className={[
+                          'no-underline tracking-tight transition hover:text-white',
+                          size,
+                          FOCUS_RING,
+                        ].join(' ')}
+                      >
+                        #{e.tag}
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right: stats + top 5 */}
+          <div className="flex flex-col gap-4">
+            <div className="rounded-card-xl bg-bento-butter p-7 text-bento-ink">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-bento-ink/60">
+                At a glance
+              </p>
+              <div className="mt-4 grid grid-cols-2 gap-4">
+                <div>
+                  <div className="text-4xl font-extrabold leading-none md:text-[44px]">
+                    {entries.length}
+                  </div>
+                  <div className="mt-1 text-[12px] text-bento-ink/70">Total tags</div>
+                </div>
+                <div>
+                  <div className="text-4xl font-extrabold leading-none md:text-[44px]">
+                    {totalUses}
+                  </div>
+                  <div className="mt-1 text-[12px] text-bento-ink/70">Total uses</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex-1 rounded-card-xl bg-bento-card p-6 text-bento-ink">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-bento-ink/60">
+                Top 5 — Most written
+              </p>
+              <ol className="mt-4 space-y-2.5">
+                {top5.map((e, i) => (
+                  <li key={e.tag}>
+                    <Link
+                      href={`/en/tags/${encodeURIComponent(e.tag)}`}
+                      className={[
+                        'flex items-center justify-between gap-3 rounded-card-sm px-2 py-1.5 no-underline transition hover:bg-bento-ink/5',
+                        FOCUS_RING,
+                      ].join(' ')}
+                    >
+                      <span className="flex items-center gap-3">
+                        <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-bento-ink text-[10px] font-bold text-white">
+                          {i + 1}
+                        </span>
+                        <span className="text-[14px] font-medium text-bento-ink">
+                          #{e.tag}
+                        </span>
+                      </span>
+                      <span className="font-mono text-[11px] text-bento-dim">
+                        {e.count} posts
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Bento grid (sortable) */}
+      {entries.length > 0 && <TagsBentoGrid entries={entries} />}
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Script from 'next/script';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
+import { LangRedirect } from '@/components/lang-redirect';
 import { SiteHeader } from '@/components/site-header';
 import { SiteFooter } from '@/components/site-footer';
 import { ChatButton } from '@/components/chat/ChatButton';
@@ -112,6 +113,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <LangRedirect />
           <div className="min-h-screen flex flex-col">
             <SiteHeader />
             <main className="flex-1">{children}</main>

--- a/components/article/prev-next.tsx
+++ b/components/article/prev-next.tsx
@@ -8,19 +8,20 @@ type Article = {
 type Props = {
   prev: Article | null;
   next: Article | null;
+  basePath?: string;
 };
 
 const FOCUS_RING =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
 
-export function PrevNext({ prev, next }: Props) {
+export function PrevNext({ prev, next, basePath = '' }: Props) {
   if (!prev && !next) return null;
 
   return (
     <section className="mx-auto mt-6 grid max-w-prose grid-cols-1 gap-3 px-6 md:grid-cols-2 md:px-0">
       {prev ? (
         <Link
-          href={`/${encodeURIComponent(prev.slug)}`}
+          href={`${basePath}/${encodeURIComponent(prev.slug)}`}
           className={[
             'rounded-card bg-bento-cream p-4 no-underline text-bento-ink transition hover:bg-bento-cream/80',
             FOCUS_RING,
@@ -34,7 +35,7 @@ export function PrevNext({ prev, next }: Props) {
       )}
       {next ? (
         <Link
-          href={`/${encodeURIComponent(next.slug)}`}
+          href={`${basePath}/${encodeURIComponent(next.slug)}`}
           className={[
             'rounded-card bg-bento-ink p-4 no-underline text-white transition hover:bg-bento-ink/90',
             FOCUS_RING,

--- a/components/article/related-cards.tsx
+++ b/components/article/related-cards.tsx
@@ -16,6 +16,7 @@ type Article = {
 
 type Props = {
   articles: Article[];
+  basePath?: string;
 };
 
 const TONES: Tone[] = ['sage', 'butter', 'rose'];
@@ -23,7 +24,7 @@ const TONES: Tone[] = ['sage', 'butter', 'rose'];
 const FOCUS_RING =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
 
-export function RelatedCards({ articles }: Props) {
+export function RelatedCards({ articles, basePath = '' }: Props) {
   if (articles.length === 0) return null;
 
   return (
@@ -35,7 +36,7 @@ export function RelatedCards({ articles }: Props) {
         {articles.slice(0, 3).map((a, i) => (
           <Link
             key={a.slug}
-            href={`/${encodeURIComponent(a.slug)}`}
+            href={`${basePath}/${encodeURIComponent(a.slug)}`}
             className={[
               'flex min-h-[140px] flex-col justify-between rounded-card-lg p-5 text-bento-ink no-underline transition hover:opacity-90 md:min-h-[180px]',
               TONE_BG[TONES[i % TONES.length]],

--- a/components/article/series-navigation.tsx
+++ b/components/article/series-navigation.tsx
@@ -17,6 +17,7 @@ interface SeriesNavigationProps {
   seriesName: string;
   articles: ManifestArticle[];
   currentSlug: string;
+  basePath?: string;
 }
 
 const FOCUS_RING =
@@ -26,6 +27,7 @@ export function SeriesNavigation({
   seriesName,
   articles,
   currentSlug,
+  basePath = '',
 }: SeriesNavigationProps) {
   return (
     <section className="mx-auto mt-12 max-w-prose px-6 md:px-0">
@@ -40,7 +42,7 @@ export function SeriesNavigation({
             return (
               <li key={article.slug}>
                 <Link
-                  href={`/${encodeURIComponent(articleTitle)}`}
+                  href={`${basePath}/${encodeURIComponent(articleTitle)}`}
                   aria-current={isCurrent ? 'page' : undefined}
                   className={[
                     'flex items-center gap-3 rounded-card-sm p-2.5 no-underline text-bento-ink transition',

--- a/components/lang-redirect.tsx
+++ b/components/lang-redirect.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { getLangFromPathname } from '@/lib/i18n/lang';
+
+export function LangRedirect() {
+  const pathname = usePathname();
+  const router = useRouter();
+  useEffect(() => {
+    let pref: string | null = null;
+    try { pref = localStorage.getItem('preferred-lang'); } catch {}
+    if (!pref) return;
+    const current = getLangFromPathname(pathname);
+    if (pref === current) return;
+    if (pref === 'en' && current === 'ko') {
+      router.replace(pathname === '/' ? '/en' : `/en${pathname}`);
+    } else if (pref === 'ko' && current === 'en') {
+      router.replace(pathname.replace(/^\/en(?=\/|$)/, '') || '/');
+    }
+  }, [pathname, router]);
+  return null;
+}

--- a/components/posts/category-rail.tsx
+++ b/components/posts/category-rail.tsx
@@ -11,19 +11,20 @@ type Props = {
   categories: CategoryEntry[];
   totalCount: number;
   selectedCategory: string | null;
+  basePath?: string;
 };
 
 const FOCUS_RING =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
 
-export function CategoryRail({ categories, totalCount, selectedCategory }: Props) {
+export function CategoryRail({ categories, totalCount, selectedCategory, basePath = '' }: Props) {
   return (
     <>
       {/* Desktop sticky rail */}
       <aside className="hidden md:block">
         <div className="sticky top-24 flex flex-col gap-1">
           <CategoryItem
-            href="/posts"
+            href={`${basePath}/posts`}
             name="All"
             count={totalCount}
             active={selectedCategory === null}
@@ -31,7 +32,7 @@ export function CategoryRail({ categories, totalCount, selectedCategory }: Props
           {categories.map((c) => (
             <CategoryItem
               key={c.name}
-              href={`/posts?cat=${encodeURIComponent(c.name)}`}
+              href={`${basePath}/posts?cat=${encodeURIComponent(c.name)}`}
               name={c.name}
               count={c.count}
               active={selectedCategory === c.name}
@@ -43,7 +44,7 @@ export function CategoryRail({ categories, totalCount, selectedCategory }: Props
       {/* Mobile horizontal chip rail */}
       <div className="-mx-6 flex gap-2 overflow-x-auto px-6 pb-2 no-scrollbar md:hidden">
         <CategoryChip
-          href="/posts"
+          href={`${basePath}/posts`}
           name="All"
           count={totalCount}
           active={selectedCategory === null}
@@ -51,7 +52,7 @@ export function CategoryRail({ categories, totalCount, selectedCategory }: Props
         {categories.map((c) => (
           <CategoryChip
             key={c.name}
-            href={`/posts?cat=${encodeURIComponent(c.name)}`}
+            href={`${basePath}/posts?cat=${encodeURIComponent(c.name)}`}
             name={c.name}
             count={c.count}
             active={selectedCategory === c.name}

--- a/components/posts/posts-list.tsx
+++ b/components/posts/posts-list.tsx
@@ -9,6 +9,7 @@ type Article = {
 
 type Props = {
   articles: Article[];
+  basePath?: string;
 };
 
 const FOCUS_RING =
@@ -25,7 +26,7 @@ function shortDate(iso: string): string {
   return `${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
 }
 
-export function PostsList({ articles }: Props) {
+export function PostsList({ articles, basePath = '' }: Props) {
   if (articles.length === 0) {
     return (
       <div className="py-20 text-center text-sm text-bento-dim">
@@ -53,7 +54,7 @@ export function PostsList({ articles }: Props) {
             {byYear.get(year)!.map((a) => (
               <li key={a.slug}>
                 <Link
-                  href={`/${encodeURIComponent(a.slug)}`}
+                  href={`${basePath}/${encodeURIComponent(a.slug)}`}
                   className={[
                     'group grid grid-cols-[44px_72px_1fr] items-baseline gap-3 rounded-card-sm px-2 py-2.5 no-underline text-bento-ink transition hover:bg-bento-ink/[0.04] dark:hover:bg-white/[0.04]',
                     FOCUS_RING,

--- a/components/posts/posts-page-client.tsx
+++ b/components/posts/posts-page-client.tsx
@@ -20,9 +20,10 @@ type CategoryEntry = {
 type Props = {
   articles: Article[];
   categories: CategoryEntry[];
+  basePath?: string;
 };
 
-export function PostsPageClient({ articles, categories }: Props) {
+export function PostsPageClient({ articles, categories, basePath = '' }: Props) {
   const params = useSearchParams();
   const cat = params.get('cat');
   const selectedCategory = cat && cat.trim() ? cat : null;
@@ -38,6 +39,7 @@ export function PostsPageClient({ articles, categories }: Props) {
         categories={categories}
         totalCount={articles.length}
         selectedCategory={selectedCategory}
+        basePath={basePath}
       />
       <div>
         {selectedCategory && (
@@ -45,7 +47,7 @@ export function PostsPageClient({ articles, categories }: Props) {
             <span className="capitalize">{selectedCategory}</span> · {filtered.length}편
           </p>
         )}
-        <PostsList articles={filtered} />
+        <PostsList articles={filtered} basePath={basePath} />
       </div>
     </div>
   );

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -14,12 +14,14 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { CommandK } from '@/components/command-k';
+import { getLangFromPathname, localizeHref, type Lang } from '@/lib/i18n/lang';
+import { getDictionary } from '@/lib/i18n/dictionaries';
 
 const NAV = [
-  { name: 'Home', href: '/' },
-  { name: 'Posts', href: '/posts' },
-  { name: 'Series', href: '/series' },
-  { name: 'Tags', href: '/tags' },
+  { key: 'home', href: '/' },
+  { key: 'posts', href: '/posts' },
+  { key: 'series', href: '/series' },
+  { key: 'tags', href: '/tags' },
 ] as const;
 
 const FOCUS_RING = 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
@@ -34,6 +36,11 @@ export function SiteHeader() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
   const pathname = usePathname();
+  const lang: Lang = getLangFromPathname(pathname);
+  const t = getDictionary(lang);
+
+  const koHref = pathname.replace(/^\/en(?=\/|$)/, '') || '/';
+  const enHref = lang === 'en' ? pathname : (pathname === '/' ? '/en' : `/en${pathname}`);
 
   const toggleTheme = () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
 
@@ -54,7 +61,7 @@ export function SiteHeader() {
         <div className="mx-auto flex max-w-canvas items-center justify-between gap-4 px-6 py-4 md:px-10">
           {/* Logo + wordmark */}
           <Link
-            href="/"
+            href={localizeHref('/', lang)}
             className={`flex items-center gap-3 no-underline text-bento-ink ${FOCUS_RING}`}
             aria-label="frank.blog 홈"
           >
@@ -72,11 +79,12 @@ export function SiteHeader() {
             className="hidden gap-1 rounded-full bg-bento-ink/[0.06] p-1 dark:bg-white/10 md:flex"
           >
             {NAV.map((n) => {
-              const active = isActive(pathname, n.href);
+              const href = localizeHref(n.href, lang);
+              const active = isActive(pathname, href);
               return (
                 <Link
-                  key={n.name}
-                  href={n.href}
+                  key={n.key}
+                  href={href}
                   aria-current={active ? 'page' : undefined}
                   className={[
                     'rounded-full px-4 py-1.5 text-[13px] font-medium no-underline transition',
@@ -86,7 +94,7 @@ export function SiteHeader() {
                     FOCUS_RING,
                   ].join(' ')}
                 >
-                  {n.name}
+                  {t.nav[n.key]}
                 </Link>
               );
             })}
@@ -117,6 +125,38 @@ export function SiteHeader() {
             >
               <Search aria-hidden="true" className="h-5 w-5" />
             </Button>
+
+            {/* Language toggle (desktop) */}
+            <div
+              className="hidden items-center gap-1.5 px-1 text-[13px] md:flex"
+              aria-label="Language"
+            >
+              <Link
+                href={enHref}
+                onClick={() => { try { localStorage.setItem('preferred-lang', 'en'); } catch {} }}
+                aria-current={lang === 'en' ? 'true' : undefined}
+                className={[
+                  'no-underline transition hover:text-bento-ink dark:hover:text-white',
+                  lang === 'en' ? 'font-bold text-bento-ink dark:text-white' : 'text-bento-dim',
+                  FOCUS_RING,
+                ].join(' ')}
+              >
+                EN
+              </Link>
+              <span aria-hidden className="text-bento-dim">│</span>
+              <Link
+                href={koHref}
+                onClick={() => { try { localStorage.setItem('preferred-lang', 'ko'); } catch {} }}
+                aria-current={lang === 'ko' ? 'true' : undefined}
+                className={[
+                  'no-underline transition hover:text-bento-ink dark:hover:text-white',
+                  lang === 'ko' ? 'font-bold text-bento-ink dark:text-white' : 'text-bento-dim',
+                  FOCUS_RING,
+                ].join(' ')}
+              >
+                KR
+              </Link>
+            </div>
 
             {/* Theme toggle */}
             <Button
@@ -170,11 +210,12 @@ export function SiteHeader() {
                 </SheetHeader>
                 <nav aria-label="모바일 메뉴" className="mt-6 flex flex-col gap-1">
                   {NAV.map((n) => {
-                    const active = isActive(pathname, n.href);
+                    const href = localizeHref(n.href, lang);
+                    const active = isActive(pathname, href);
                     return (
                       <Link
-                        key={n.name}
-                        href={n.href}
+                        key={n.key}
+                        href={href}
                         onClick={() => setMobileNavOpen(false)}
                         aria-current={active ? 'page' : undefined}
                         className={[
@@ -185,10 +226,48 @@ export function SiteHeader() {
                           FOCUS_RING,
                         ].join(' ')}
                       >
-                        {n.name}
+                        {t.nav[n.key]}
                       </Link>
                     );
                   })}
+
+                  {/* Language toggle (mobile) */}
+                  <div
+                    className="mt-4 flex items-center gap-1.5 border-t border-bento-ink/10 px-4 pt-4 text-sm dark:border-white/10"
+                    aria-label="Language"
+                  >
+                    <Link
+                      href={enHref}
+                      onClick={() => {
+                        try { localStorage.setItem('preferred-lang', 'en'); } catch {}
+                        setMobileNavOpen(false);
+                      }}
+                      aria-current={lang === 'en' ? 'true' : undefined}
+                      className={[
+                        'no-underline',
+                        lang === 'en' ? 'font-bold text-bento-ink dark:text-white' : 'text-bento-dim',
+                        FOCUS_RING,
+                      ].join(' ')}
+                    >
+                      EN
+                    </Link>
+                    <span aria-hidden className="text-bento-dim">│</span>
+                    <Link
+                      href={koHref}
+                      onClick={() => {
+                        try { localStorage.setItem('preferred-lang', 'ko'); } catch {}
+                        setMobileNavOpen(false);
+                      }}
+                      aria-current={lang === 'ko' ? 'true' : undefined}
+                      className={[
+                        'no-underline',
+                        lang === 'ko' ? 'font-bold text-bento-ink dark:text-white' : 'text-bento-dim',
+                        FOCUS_RING,
+                      ].join(' ')}
+                    >
+                      KR
+                    </Link>
+                  </div>
                 </nav>
               </SheetContent>
             </Sheet>

--- a/components/tags-bento-grid.tsx
+++ b/components/tags-bento-grid.tsx
@@ -40,7 +40,13 @@ function tierFor(rank: number): 'xl' | 'lg' | 'md' | 'sm' {
   return 'sm';
 }
 
-export function TagsBentoGrid({ entries }: { entries: TagEntry[] }) {
+export function TagsBentoGrid({
+  entries,
+  basePath = '',
+}: {
+  entries: TagEntry[];
+  basePath?: string;
+}) {
   const [sortMode, setSortMode] = useState<SortMode>('count');
 
   const sorted = useMemo(() => {
@@ -79,12 +85,16 @@ export function TagsBentoGrid({ entries }: { entries: TagEntry[] }) {
         </div>
       </div>
 
-      {useBento ? <BentoLayout sorted={sorted} /> : <FlatLayout sorted={sorted} />}
+      {useBento ? (
+        <BentoLayout sorted={sorted} basePath={basePath} />
+      ) : (
+        <FlatLayout sorted={sorted} basePath={basePath} />
+      )}
     </section>
   );
 }
 
-function BentoLayout({ sorted }: { sorted: TagEntry[] }) {
+function BentoLayout({ sorted, basePath }: { sorted: TagEntry[]; basePath: string }) {
   const xl = sorted.slice(0, 2);
   const lg = sorted.slice(2, 5);
   const md = sorted.slice(5, 11);
@@ -96,7 +106,7 @@ function BentoLayout({ sorted }: { sorted: TagEntry[] }) {
       {xl.length > 0 && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {xl.map((e, i) => (
-            <TagCard key={e.tag} entry={e} rank={i} tier="xl" />
+            <TagCard key={e.tag} entry={e} rank={i} tier="xl" basePath={basePath} />
           ))}
         </div>
       )}
@@ -104,7 +114,7 @@ function BentoLayout({ sorted }: { sorted: TagEntry[] }) {
       {lg.length > 0 && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {lg.map((e, i) => (
-            <TagCard key={e.tag} entry={e} rank={i + 2} tier="lg" />
+            <TagCard key={e.tag} entry={e} rank={i + 2} tier="lg" basePath={basePath} />
           ))}
         </div>
       )}
@@ -112,7 +122,7 @@ function BentoLayout({ sorted }: { sorted: TagEntry[] }) {
       {md.length > 0 && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {md.map((e, i) => (
-            <TagCard key={e.tag} entry={e} rank={i + 5} tier="md" />
+            <TagCard key={e.tag} entry={e} rank={i + 5} tier="md" basePath={basePath} />
           ))}
         </div>
       )}
@@ -120,7 +130,7 @@ function BentoLayout({ sorted }: { sorted: TagEntry[] }) {
       {sm.length > 0 && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
           {sm.map((e, i) => (
-            <TagCard key={e.tag} entry={e} rank={i + 11} tier="sm" />
+            <TagCard key={e.tag} entry={e} rank={i + 11} tier="sm" basePath={basePath} />
           ))}
         </div>
       )}
@@ -128,11 +138,11 @@ function BentoLayout({ sorted }: { sorted: TagEntry[] }) {
   );
 }
 
-function FlatLayout({ sorted }: { sorted: TagEntry[] }) {
+function FlatLayout({ sorted, basePath }: { sorted: TagEntry[]; basePath: string }) {
   return (
     <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
       {sorted.map((e, i) => (
-        <TagCard key={e.tag} entry={e} rank={i} tier="sm" />
+        <TagCard key={e.tag} entry={e} rank={i} tier="sm" basePath={basePath} />
       ))}
     </div>
   );
@@ -142,10 +152,12 @@ function TagCard({
   entry,
   rank,
   tier,
+  basePath,
 }: {
   entry: TagEntry;
   rank: number;
   tier: 'xl' | 'lg' | 'md' | 'sm';
+  basePath: string;
 }) {
   const color = colorFor(rank);
 
@@ -182,7 +194,7 @@ function TagCard({
 
   return (
     <Link
-      href={`/tags/${encodeURIComponent(entry.tag)}`}
+      href={`${basePath}/tags/${encodeURIComponent(entry.tag)}`}
       className={[
         'group flex flex-col justify-between rounded-card no-underline transition hover:-translate-y-0.5 hover:shadow-md',
         color,

--- a/contents/cloud/ksqldb-소개/index_en.md
+++ b/contents/cloud/ksqldb-소개/index_en.md
@@ -10,6 +10,7 @@ tags:
   - sql
   - kstream
   - stream
+series: "Apache Kafka"
 ---
 
 

--- a/docs/superpowers/plans/2026-06-03-blog-i18n-ui.md
+++ b/docs/superpowers/plans/2026-06-03-blog-i18n-ui.md
@@ -1,0 +1,373 @@
+# Blog 다국어 UI/네비 (Plan 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/en` 영어 경험을 완성한다 — 헤더 EN│KR 토글, UI 문자열 현지화, 공유 컴포넌트의 `/en` 링크 prefix, `/en` 목록 미러(series/tags/category), 브라우저 언어 감지.
+
+**Architecture:** 활성 언어는 경로(`/en` prefix)에서 파생한다. 클라이언트 컴포넌트는 `usePathname()`, 서버 컴포넌트/페이지는 명시적 `lang`/`basePath` prop으로 전달. UI 문자열은 `lib/i18n` 사전으로 분리. 공유 링크 컴포넌트에 선택적 `basePath`(기본 `''`) prop을 추가해 한국어는 무변경, 영어 페이지만 `/en`을 넘긴다. 브라우저 언어 감지는 정적 export 제약상 Netlify 엣지 리다이렉트로 처리하고 `localStorage`로 수동 선택을 기억한다.
+
+**Tech Stack:** Next.js App Router(static export), TypeScript, next-themes 패턴(클라이언트), Netlify redirects. 테스트 러너 없음 → 검증은 `npm run check`(tsc), `npm run build`(out/ 확인), `npm run dev` 수동 확인.
+
+**Plan 1에서 이어짐:** `lib/articles.ts`는 lang 인자 지원. `/en`, `/en/posts`, `/en/[slug]`, `app/en/layout.tsx` 존재. `lib/url.ts`에 `seriesSlug`/`categorySlug` 존재.
+
+---
+
+## File Structure
+
+- `lib/i18n/lang.ts` — 생성: `Lang` 타입, `getLangFromPathname`, `localizeHref`
+- `lib/i18n/dictionaries.ts` — 생성: ko/en UI 문자열 사전 + `getDictionary(lang)`
+- `components/site-header.tsx` — 수정: pathname→lang, 네비 href localize, EN│KR 토글, 사전 적용
+- `components/article/related-cards.tsx` — 수정: `basePath` prop
+- `components/article/prev-next.tsx` — 수정: `basePath` prop
+- `components/article/series-navigation.tsx` — 수정: `basePath` prop
+- `components/posts/posts-list.tsx` — 수정: `basePath` prop
+- `components/posts/category-rail.tsx` — 수정: `basePath` prop
+- `app/en/[slug]/page.tsx`, `app/en/posts/page.tsx` — 수정: 위 컴포넌트에 `basePath="/en"` 전달
+- `app/en/series/page.tsx`, `app/en/series/[slug]/page.tsx` — 생성: 영어 시리즈 목록/상세
+- `app/en/tags/page.tsx`, `app/en/tags/[name]/page.tsx` — 생성: 영어 태그 목록/상세
+- `app/en/category/[name]/page.tsx` — 생성: 영어 카테고리 목록
+- `public/_redirects` (또는 `netlify.toml`) — 수정: `/` 언어 감지 리다이렉트
+- `components/site-header.tsx` 또는 신규 `components/lang-init.tsx` — localStorage 언어 기억(클라이언트)
+
+---
+
+## Task 1: 언어 헬퍼 (lib/i18n/lang.ts)
+
+**Files:**
+- Create: `lib/i18n/lang.ts`
+
+- [ ] **Step 1: 헬퍼 작성**
+
+```ts
+export type Lang = 'ko' | 'en';
+
+/** pathname 앞부분이 /en 이면 'en', 아니면 'ko' */
+export function getLangFromPathname(pathname: string): Lang {
+  return pathname === '/en' || pathname.startsWith('/en/') ? 'en' : 'ko';
+}
+
+/** 한국어 루트 기준 경로를 활성 언어 경로로 변환. ko는 그대로, en은 /en prefix. */
+export function localizeHref(href: string, lang: Lang): string {
+  if (lang === 'ko') return href;
+  if (href === '/') return '/en';
+  return `/en${href.startsWith('/') ? '' : '/'}${href}`;
+}
+```
+
+- [ ] **Step 2: 타입 체크**
+
+Run: `npm run check`
+Expected: 통과
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add lib/i18n/lang.ts
+git commit -m "feat: i18n 언어 헬퍼(lang 파싱/href localize) 추가"
+```
+
+---
+
+## Task 2: UI 문자열 사전 (lib/i18n/dictionaries.ts)
+
+**Files:**
+- Create: `lib/i18n/dictionaries.ts`
+- Read first: `components/site-header.tsx` (NAV 라벨), `components/breadcrumb.tsx`(있으면) — 어떤 문자열이 UI에 쓰이는지 확인
+
+- [ ] **Step 1: 현재 하드코딩된 UI 문자열 수집**
+
+Run: `grep -rnE "'(Home|Posts|Series|Tags)'|관련 글|이전|다음|목차|전체 글|시리즈|태그|카테고리" components app | grep -v node_modules | head -40`
+목적: 사전에 넣을 키 후보 파악. (라벨이 더 있으면 사전에 추가)
+
+- [ ] **Step 2: 사전 작성 (최소 키 집합)**
+
+```ts
+import type { Lang } from './lang';
+
+type Dict = {
+  nav: { home: string; posts: string; series: string; tags: string };
+  article: { related: string; prev: string; next: string; toc: string };
+  posts: { all: string; categories: string };
+  language: { ko: string; en: string };
+};
+
+const ko: Dict = {
+  nav: { home: '홈', posts: '글', series: '시리즈', tags: '태그' },
+  article: { related: '관련 글', prev: '이전 글', next: '다음 글', toc: '목차' },
+  posts: { all: '전체 글', categories: '카테고리' },
+  language: { ko: '한국어', en: 'English' },
+};
+
+const en: Dict = {
+  nav: { home: 'Home', posts: 'Posts', series: 'Series', tags: 'Tags' },
+  article: { related: 'Related posts', prev: 'Previous', next: 'Next', toc: 'Contents' },
+  posts: { all: 'All posts', categories: 'Categories' },
+  language: { ko: '한국어', en: 'English' },
+};
+
+const dictionaries: Record<Lang, Dict> = { ko, en };
+
+export function getDictionary(lang: Lang): Dict {
+  return dictionaries[lang];
+}
+```
+
+- [ ] **Step 3: 타입 체크 + 커밋**
+
+Run: `npm run check`
+```bash
+git add lib/i18n/dictionaries.ts
+git commit -m "feat: i18n UI 문자열 사전(ko/en) 추가"
+```
+
+---
+
+## Task 3: 헤더 — 언어 판별 + 네비 localize + EN│KR 토글
+
+**Files:**
+- Modify: `components/site-header.tsx`
+
+- [ ] **Step 1: 전체 헤더 읽기**
+
+Run: `cat components/site-header.tsx`
+목적: NAV 구성, 로고 href, 모바일 시트 구조, 토글 버튼 배치 지점 파악.
+
+- [ ] **Step 2: 언어/사전 적용**
+
+상단 import에 추가:
+```ts
+import { getLangFromPathname, localizeHref, type Lang } from '@/lib/i18n/lang';
+import { getDictionary } from '@/lib/i18n/dictionaries';
+```
+컴포넌트 본문에서 `pathname` 직후:
+```ts
+const lang: Lang = getLangFromPathname(pathname);
+const t = getDictionary(lang);
+```
+`NAV` 상수를 라벨 키 기반으로 바꾸고 렌더 시 localize:
+```ts
+const NAV = [
+  { key: 'home', href: '/' },
+  { key: 'posts', href: '/posts' },
+  { key: 'series', href: '/series' },
+  { key: 'tags', href: '/tags' },
+] as const;
+```
+각 NAV 렌더에서 `href={localizeHref(item.href, lang)}`, 라벨 `{t.nav[item.key]}`. 로고 `href`도 `localizeHref('/', lang)`. `isActive`는 localize된 href와 pathname을 비교하도록 인자를 localize된 값으로 넘긴다.
+
+- [ ] **Step 3: EN│KR 토글 추가**
+
+테마 토글 버튼 옆에 언어 토글을 추가한다. 현재 경로에서 반대 언어의 동일 경로로 이동한다. pathname에서 `/en` prefix를 떼거나 붙이는 방식:
+```tsx
+const koHref = pathname.replace(/^\/en(?=\/|$)/, '') || '/';
+const enHref = lang === 'en' ? pathname : (pathname === '/' ? '/en' : `/en${pathname}`);
+```
+렌더(데스크톱 + 모바일 시트 양쪽):
+```tsx
+<div className="flex items-center gap-1 text-sm" aria-label="Language">
+  <Link href={enHref} aria-current={lang === 'en' ? 'true' : undefined}
+    className={lang === 'en' ? 'font-bold' : 'text-muted-foreground'}>EN</Link>
+  <span aria-hidden>│</span>
+  <Link href={koHref} aria-current={lang === 'ko' ? 'true' : undefined}
+    className={lang === 'ko' ? 'font-bold' : 'text-muted-foreground'}>KR</Link>
+</div>
+```
+토글 클릭 시 선택 언어를 localStorage에 기록(Task 7에서 init과 짝). onClick 핸들러:
+```tsx
+onClick={() => { try { localStorage.setItem('preferred-lang', 'en'); } catch {} }}
+```
+(KR 링크는 'ko' 저장)
+
+- [ ] **Step 4: 타입 체크 + dev 확인**
+
+Run: `npm run check`
+`npm run dev` 후 `/`와 `/en/`에서 헤더 네비 라벨/링크가 각 언어로 바뀌고 토글이 반대 언어 동일 경로로 이동하는지 확인. (예: `/en/posts/`에서 KR 클릭 → `/posts/`)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add components/site-header.tsx
+git commit -m "feat: 헤더 언어 판별 + 네비 현지화 + EN│KR 토글"
+```
+
+---
+
+## Task 4: 공유 컴포넌트에 basePath prop 추가
+
+**Files:**
+- Modify: `components/article/related-cards.tsx`, `components/article/prev-next.tsx`, `components/article/series-navigation.tsx`, `components/posts/posts-list.tsx`, `components/posts/category-rail.tsx`
+
+각 컴포넌트의 Props에 `basePath?: string` (기본 `''`)를 추가하고, 모든 내부 링크 href 앞에 `${basePath}`를 붙인다. 한국어 페이지는 prop 미전달 → `''` → 기존 동작 유지.
+
+- [ ] **Step 1: related-cards.tsx**
+
+Props에 `basePath?: string;` 추가, 시그니처 `{ articles, basePath = '' }`. 38행 `href={`/${encodeURIComponent(a.slug)}`}` → `href={`${basePath}/${encodeURIComponent(a.slug)}`}`.
+
+- [ ] **Step 2: prev-next.tsx**
+
+Props에 `basePath?: string;`, 시그니처 `{ prev, next, basePath = '' }`. 두 href(23,37행) 모두 `${basePath}` prefix.
+
+- [ ] **Step 3: series-navigation.tsx**
+
+`SeriesNavigationProps`에 `basePath?: string;`, 구조분해에 `basePath = ''` 추가. 43행 href `${basePath}` prefix.
+
+- [ ] **Step 4: posts-list.tsx**
+
+Props에 `basePath?: string;`, 시그니처 `{ articles, basePath = '' }`. 56행 href `${basePath}` prefix.
+
+- [ ] **Step 5: category-rail.tsx** ('use client')
+
+Props에 `basePath?: string;`, 시그니처에 `basePath = ''` 추가. 모든 href: `"/posts"` → `` `${basePath}/posts` ``, `` `/posts?cat=${...}` `` → `` `${basePath}/posts?cat=${...}` `` (26,34,46,54행 및 내부 helper의 href 인자도 호출부에서 prefix).
+
+- [ ] **Step 6: 타입 체크**
+
+Run: `npm run check`
+Expected: 통과 (기본값 `''`로 기존 호출 무영향)
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add components/article/related-cards.tsx components/article/prev-next.tsx components/article/series-navigation.tsx components/posts/posts-list.tsx components/posts/category-rail.tsx
+git commit -m "feat: 공유 링크 컴포넌트에 basePath prop 추가 (기본 빈 문자열)"
+```
+
+---
+
+## Task 5: /en 페이지에서 basePath 전달
+
+**Files:**
+- Modify: `app/en/[slug]/page.tsx`, `app/en/posts/page.tsx`
+
+- [ ] **Step 1: en 글 상세에 basePath 전달**
+
+`app/en/[slug]/page.tsx`에서 `RelatedCards`, `PrevNext`, `SeriesNavigation` 렌더에 `basePath="/en"` 추가.
+
+- [ ] **Step 2: en posts에 basePath 전달**
+
+`app/en/posts/page.tsx`에서 `PostsList`/`CategoryRail`(사용 시) 렌더에 `basePath="/en"` 추가.
+
+- [ ] **Step 3: 타입 체크 + dev 확인**
+
+Run: `npm run check`
+`npm run dev` 후 `/en/ksqldb-소개/`의 관련/이전·다음/시리즈 링크가 `/en/...`을 가리키는지 확인.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add "app/en/[slug]/page.tsx" app/en/posts/page.tsx
+git commit -m "feat: /en 페이지에서 공유 컴포넌트에 basePath=/en 전달"
+```
+
+---
+
+## Task 6: /en 목록 미러 (series / tags / category)
+
+**Files:**
+- Create: `app/en/series/page.tsx`, `app/en/series/[slug]/page.tsx`, `app/en/tags/page.tsx`, `app/en/tags/[name]/page.tsx`, `app/en/category/[name]/page.tsx`
+- Read first: `app/series/page.tsx`, `app/series/[slug]/page.tsx`, `app/tags/page.tsx`, `app/tags/[name]/page.tsx`, `app/category/[name]/page.tsx`
+
+- [ ] **Step 1: 각 한국어 목록 페이지 읽기**
+
+Run: `for f in app/series/page.tsx "app/series/[slug]/page.tsx" app/tags/page.tsx "app/tags/[name]/page.tsx" "app/category/[name]/page.tsx"; do echo "== $f =="; cat "$f"; done`
+
+- [ ] **Step 2: 각 페이지를 /en 으로 미러**
+
+각 한국어 페이지를 그대로 복제하되:
+- 모든 데이터 조회에 `'en'` 전달(`getAllSeries('en')`, `getArticlesBySeries(s,'en')`, `getAllTags('en')`, `getArticlesByTag(t,'en')`, `getArticlesByCategory(c,'en')`, `getAllCategories('en')` 등)
+- `generateStaticParams`도 `'en'` 기준으로 생성(영어 글이 있는 series/tag/category만)
+- 내부 링크는 `/en/` prefix (글 링크, 카테고리/시리즈/태그 링크)
+- 공유 컴포넌트 사용 시 `basePath="/en"` 전달
+- `dynamicParams = false` 유지
+
+- [ ] **Step 3: 타입 체크 + 빌드**
+
+Run: `npm run generate:manifest && npm run check && npm run build`
+Expected: 빌드 성공. 영어 글(ksqlDB)이 속한 카테고리(`cloud`)에 대해 `out/en/category/cloud/index.html` 생성. (ksqlDB는 series "Apache Kafka" 보유 → `out/en/series/...` 생성, tags 다수 → `out/en/tags/...` 생성)
+검증: `ls out/en/category/ out/en/series/ out/en/tags/ 2>/dev/null`
+
+- [ ] **Step 4: dev 확인**
+
+`/en/`에서 헤더 Posts/Series/Tags 클릭 시 각각 `/en/posts`,`/en/series`,`/en/tags`로 이동하고 404가 없는지 확인.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/en/series app/en/tags app/en/category
+git commit -m "feat: /en 목록 미러(series/tags/category) 추가"
+```
+
+---
+
+## Task 7: 브라우저 언어 감지 + localStorage 기억
+
+**Files:**
+- Modify: `netlify.toml` (또는 Create: `public/_redirects`)
+- Create: `components/lang-redirect.tsx` (클라이언트 — localStorage 기반 보정)
+- Modify: `app/layout.tsx` (lang-redirect 마운트)
+
+- [ ] **Step 1: Netlify 엣지 언어 리다이렉트**
+
+`netlify.toml`에 `/` 루트 접근 시 Accept-Language가 한국어가 아니면 `/en/`으로 보내는 리다이렉트 추가(엣지, 깜빡임 없음). 기존 `[[redirects]]`(404) 위에 추가:
+```toml
+[[redirects]]
+  from = "/"
+  to = "/en/"
+  status = 302
+  conditions = { Language = ["en"] }
+  force = false
+```
+(주의: `force=false`로 두어 실제 파일이 있는 다른 경로는 영향 없음. `/` 한정.)
+
+- [ ] **Step 2: localStorage 수동 선택 보정 (클라이언트)**
+
+엣지 감지는 첫 진입만 처리하므로, 사용자가 토글로 고른 언어를 기억해 우선 적용한다. `components/lang-redirect.tsx`:
+```tsx
+'use client';
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { getLangFromPathname } from '@/lib/i18n/lang';
+
+export function LangRedirect() {
+  const pathname = usePathname();
+  const router = useRouter();
+  useEffect(() => {
+    let pref: string | null = null;
+    try { pref = localStorage.getItem('preferred-lang'); } catch {}
+    if (!pref) return;
+    const current = getLangFromPathname(pathname);
+    if (pref === current) return;
+    if (pref === 'en' && current === 'ko') {
+      router.replace(pathname === '/' ? '/en' : `/en${pathname}`);
+    } else if (pref === 'ko' && current === 'en') {
+      router.replace(pathname.replace(/^\/en(?=\/|$)/, '') || '/');
+    }
+  }, [pathname, router]);
+  return null;
+}
+```
+
+- [ ] **Step 3: 루트 레이아웃에 마운트**
+
+`app/layout.tsx`의 `<body>` 내부(ThemeProvider 안, 헤더 위)에서 `<LangRedirect />` 렌더. import 추가.
+
+- [ ] **Step 4: 타입 체크 + 빌드 + dev 확인**
+
+Run: `npm run check && npm run build`
+dev에서: `/en/`에서 KR 토글 → `/`로 이동하고 localStorage `preferred-lang=ko` 저장됨. 새로고침으로 `/en/` 직접 진입해도 localStorage가 ko면 `/`로 보정되는지 확인. (엣지 리다이렉트는 Netlify 배포 환경에서만 동작 — 로컬에선 localStorage 보정만 확인)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add netlify.toml components/lang-redirect.tsx app/layout.tsx
+git commit -m "feat: 브라우저 언어 감지(Netlify) + localStorage 선택 기억"
+```
+
+---
+
+## Self-Review 결과 (작성자 점검)
+
+- **Spec coverage:** Plan 2 범위(UI 사전, 헤더 토글, 공유 컴포넌트 /en 링크, /en 목록 미러, 언어 감지)를 Task 1~7로 커버. hreflang/sitemap/언어별 RSS, 제목 중복 이슈, 번역 skill은 Plan 3/별도로 이연.
+- **Placeholder scan:** 각 코드 스텝에 실제 코드 포함. Task 6은 한국어 페이지 복제 작업이라 Step 1에서 원본을 읽도록 강제하고 변경점(‘en’ 조회·/en 링크·basePath)을 명시.
+- **Type consistency:** `Lang` 타입을 `lib/i18n/lang.ts` 단일 출처로 사용. `basePath?: string` 기본 `''` 패턴을 5개 컴포넌트에 동일 적용. `getDictionary(lang)` 반환 `Dict` 키를 헤더에서 사용하는 키와 일치.
+- **Scope check:** Plan 2 종료 시 `/en` 네비·링크·목록이 일관되게 동작(404 없음). SEO 강화는 Plan 3.
+- **의존성:** Task 3(헤더 토글)이 가리키는 `/en/series`·`/en/tags`는 Task 6에서 생성되므로, 실행 순서는 1→2→4→5→6→3→7 권장(헤더 토글 dev 확인 전 미러 존재). 단 타입체크/빌드는 순서 무관. 안전하게 Task 6을 Task 3보다 먼저 실행해도 됨.

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -1,0 +1,28 @@
+import type { Lang } from './lang';
+
+type Dict = {
+  nav: { home: string; posts: string; series: string; tags: string };
+  article: { related: string; prev: string; next: string; toc: string };
+  posts: { all: string; categories: string };
+  language: { ko: string; en: string };
+};
+
+const ko: Dict = {
+  nav: { home: '홈', posts: '글', series: '시리즈', tags: '태그' },
+  article: { related: '관련 글', prev: '이전 글', next: '다음 글', toc: '목차' },
+  posts: { all: '전체 글', categories: '카테고리' },
+  language: { ko: '한국어', en: 'English' },
+};
+
+const en: Dict = {
+  nav: { home: 'Home', posts: 'Posts', series: 'Series', tags: 'Tags' },
+  article: { related: 'Related posts', prev: 'Previous', next: 'Next', toc: 'Contents' },
+  posts: { all: 'All posts', categories: 'Categories' },
+  language: { ko: '한국어', en: 'English' },
+};
+
+const dictionaries: Record<Lang, Dict> = { ko, en };
+
+export function getDictionary(lang: Lang): Dict {
+  return dictionaries[lang];
+}

--- a/lib/i18n/lang.ts
+++ b/lib/i18n/lang.ts
@@ -1,0 +1,13 @@
+export type Lang = 'ko' | 'en';
+
+/** pathname 앞부분이 /en 이면 'en', 아니면 'ko' */
+export function getLangFromPathname(pathname: string): Lang {
+  return pathname === '/en' || pathname.startsWith('/en/') ? 'en' : 'ko';
+}
+
+/** 한국어 루트 기준 경로를 활성 언어 경로로 변환. ko는 그대로, en은 /en prefix. */
+export function localizeHref(href: string, lang: Lang): string {
+  if (lang === 'ko') return href;
+  if (href === '/') return '/en';
+  return `/en${href.startsWith('/') ? '' : '/'}${href}`;
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,13 @@
   ignore = "/bin/bash -c '[[ \"$CONTEXT\" == \"deploy-preview\" ]] && exit 0 || exit 1'"
 
 [[redirects]]
+  from = "/"
+  to = "/en/"
+  status = 302
+  force = false
+  conditions = {Language = ["en"]}
+
+[[redirects]]
   from = "/*"
   to = "/404.html"
   status = 404


### PR DESCRIPTION
## Summary
다국어 지원 Plan 2 — `/en` 영어 경험을 완성한다. (Plan 1 기반 위에 UI/네비 현지화 추가)

- i18n 헬퍼(`lib/i18n/lang.ts`) + UI 문자열 사전(`lib/i18n/dictionaries.ts`, ko/en)
- 헤더: pathname으로 언어 판별 + 네비 현지화 + **EN│KR 토글** (데스크톱·모바일)
- 공유 링크 컴포넌트에 `basePath` prop(기본 `''`) 추가 → 한국어 무변경, `/en` 페이지만 `/en` prefix
  - related-cards, prev-next, series-navigation, posts-list, category-rail, posts-page-client, tags-bento-grid
- `/en` 목록 미러: `/en/series`(+상세), `/en/tags`(+상세), `/en/category/[name]`
- Netlify 엣지 언어 감지(`/`→`/en/`, Accept-Language) + `localStorage` 수동 선택 기억(`LangRedirect`)

## 설계 문서
- plan: `docs/superpowers/plans/2026-06-03-blog-i18n-ui.md`

## 후속 (Plan 3, 이번 범위 밖)
- hreflang / sitemap / 언어별 RSS
- 글 제목 중복(`| Frank's IT Blog` ×2) 선행 이슈 수정
- 번역 skill (로컬 수동)
- 영어 홈 위젯 완전 현지화(현재 최소 구성)

## 참고
- `contents/cloud/ksqldb-소개/index_en.md`에 누락됐던 `series: "Apache Kafka"` frontmatter 추가 (정적 export에서 빈 generateStaticParams가 빌드 에러라 필요)

## Test plan
- [x] `npm run check` (tsc) 통과
- [x] `npm run build` 성공 — `/en`, `/en/posts`, `/en/series`(+apache-kafka), `/en/tags`(+6 태그), `/en/category/cloud` 생성
- [ ] 로컬 `npm run dev`: `/`↔`/en/` 토글, 네비 현지화, `/en` 내부 링크가 `/en`을 가리키는지 확인
- [ ] 한국어 라우트 회귀 없음(공유 컴포넌트 basePath 기본값 `''`)
- [ ] Netlify 배포 후 영어 브라우저로 `/` 진입 시 `/en/` 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)