### PR TITLE
feat: 영어 번역 skill 추가 (translate-article-en)

### DIFF
--- a/.claude/skills/translate-article-en/README.md
+++ b/.claude/skills/translate-article-en/README.md
@@ -1,0 +1,49 @@
+# translate-article-en 사용법
+
+한국어 블로그 글(`contents/{category}/{slug}/index.md`)을 영어로 번역해 같은 폴더에 `index_en.md`를 생성하는 스킬이다. 로컬에서 **수동으로** 실행한다(빌드 타임 자동 번역 아님).
+
+## 실행 방법
+
+블로그 저장소(`blog-v2.advenoh.pe.kr/`)에서 Claude Code 세션을 띄운 뒤 그 안에서 호출한다. `.claude/skills/`의 프로젝트 스킬이라 이 디렉토리에서 실행하면 자동 인식된다.
+
+### 1) 슬래시로 호출
+```
+/translate-article-en go/타입-변환-type-conversion
+```
+
+### 2) 자연어로 호출
+```
+translate-article-en 스킬로 contents/go/jq-명령어-json-처리기-사용법 글을 영어로 번역해줘
+```
+
+## 대상 지정 방법
+
+| 지정 | 예시 | 동작 |
+|------|------|------|
+| 글 slug | `go/타입-변환-type-conversion` | 해당 글 1건 번역 |
+| `index.md` 경로 | `contents/go/.../index.md` | 그 글 1건 번역 |
+| 카테고리 폴더 | `contents/mac` | 폴더 내 글 일괄 번역 — **한 번에 최대 5개** |
+
+- **폴더 지정 시**: `index_en.md`가 없는 글을 우선해 최대 5개만 번역하고, 남은 글 목록을 보고한다. 다시 실행하면 이어서 번역된다.
+- 이미 `index_en.md`가 있으면 덮어쓰기 전에 확인한다.
+
+## 동작 흐름
+
+1. 대상 `index.md`를 읽는다
+2. 규칙대로 영어로 번역한다 (자세한 규칙은 `SKILL.md` 참고)
+3. 같은 폴더에 `index_en.md`로 저장한다 (이미지·링크 공유)
+4. `npm run generate:manifest`로 매니페스트에 영어 항목 반영
+5. (발행 전) `npm run build`로 `/en/{slug}/` 렌더 확인
+
+## 번역 규칙 요약
+
+자세한 내용은 같은 폴더의 `SKILL.md` 참고.
+
+- **번역**: 본문, `title`/`description`, 섹션 heading, Mermaid 노드 텍스트, **코드 안의 한글(주석·한글 문자열)**
+- **보존**: 코드 로직·식별자·문법, `tags`/`date`/`update`/`series`, 이미지/링크/URL, 문단·빈 줄·들여쓰기
+- 코드 내 **기능적으로 의미 있는 한글값**(매칭 키, 테스트 기대 출력 등)은 보존
+
+## 주의
+
+- 출력 파일명은 반드시 `index_en.md`(언더스코어). `index.en.md` 아님.
+- 한 번에 모든 글을 자동 번역하지 않는다 — 코드 보존·품질을 글마다 확인하기 위한 수동 방식.

--- a/.claude/skills/translate-article-en/SKILL.md
+++ b/.claude/skills/translate-article-en/SKILL.md
@@ -14,6 +14,14 @@ description: Use when translating a Korean blog article (contents/{category}/{sl
 - 특정 글의 영어 버전을 만들 때 (`contents/.../index.md` → 같은 폴더 `index_en.md`)
 - 이미 `index_en.md`가 있으면 덮어쓰기 전에 사용자에게 확인
 
+## 대상 지정
+
+- **단일 글**: slug(`go/타입-변환-type-conversion`) 또는 `index.md` 경로
+- **폴더(카테고리)**: 그 안의 글들을 순회하되 **한 번에 최대 5개까지만** 번역한다.
+  - `index_en.md`가 아직 없는 글을 우선 대상으로 한다(이미 번역된 글은 건너뜀).
+  - 5개를 초과하면 처음 5개만 처리하고, **남은 글 목록과 "다시 실행하면 이어서 번역됨"을 사용자에게 보고**한다.
+  - 사용자가 "전부 번역해줘"라고 명시해도, 한 번에 5개씩 끊어서 진행 상황을 보고하며 처리한다(코드 보존·품질을 배치마다 확인하기 위함).
+
 ## Procedure
 
 1. 대상 `contents/{category}/{slug}/index.md`를 읽는다.

--- a/.claude/skills/translate-article-en/SKILL.md
+++ b/.claude/skills/translate-article-en/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: translate-article-en
+description: Use when translating a Korean blog article (contents/{category}/{slug}/index.md) into English to create its index_en.md counterpart for the multilingual blog
+---
+
+# Translate Article to English (index_en.md)
+
+## Overview
+
+이 블로그는 한국어 원문 `index.md`와 영어 번역본 `index_en.md`를 같은 디렉토리에 둔다(이미지 공유). 이 스킬은 한국어 `index.md`를 받아 같은 디렉토리에 `index_en.md`를 생성한다. 핵심 원칙: **콘텐츠·의미는 영어로, 코드 로직과 식별자는 보존, 코드 안의 한글은 영어로**.
+
+## When to Use
+
+- 특정 글의 영어 버전을 만들 때 (`contents/.../index.md` → 같은 폴더 `index_en.md`)
+- 이미 `index_en.md`가 있으면 덮어쓰기 전에 사용자에게 확인
+
+## Procedure
+
+1. 대상 `contents/{category}/{slug}/index.md`를 읽는다.
+2. 아래 규칙에 따라 영어로 번역한다.
+3. 같은 디렉토리에 `index_en.md`로 저장한다 (이미지·경로 그대로).
+4. `npm run generate:manifest`를 실행해 매니페스트에 영어 항목이 잡히는지 확인한다.
+5. (선택) `npm run build`로 `/en/{slug}/` 렌더 확인.
+
+## Translation Rules
+
+| 항목 | 처리 |
+|------|------|
+| 본문 산문 | 영어로 번역 (자연스러운 기술문서 톤) |
+| frontmatter `title` / `description` | 영어로 번역 |
+| frontmatter `tags` | **그대로 유지** (번역/추가/삭제 안 함 — 검색 일관성) |
+| frontmatter `date` / `update` / `series` / `seriesOrder` | **원본 값 유지** |
+| 섹션 heading | 영어로 번역 (`# 참고` → `# References`, `# 들어가며` → `# Introduction` 등) |
+| 코드 블록의 코드/식별자/문법 | **보존** (변수명·함수명·키워드 변경 금지) |
+| 코드 블록 안의 한글 (주석·한글 문자열·한글 샘플데이터) | **영어로 번역** |
+| Mermaid 노드 텍스트 | 영어로 번역 (`<br/>` 등 HTML 태그 추가 금지 — 파서 에러) |
+| 이미지 참조 `![](...)` / `<img>` / 링크 / URL | **그대로 보존** (이미지 공유) |
+| GitHub 등 외부 링크 | 그대로 유지 |
+| 문단 구조·빈 줄·코드 들여쓰기(탭/스페이스) | **원문 그대로 보존** (재배치·정규화 금지) |
+
+`title`과 `description`이 원문에서 동일하더라도, 영어본에서는 `title`은 간결한 제목, `description`은 한 문장 요약으로 자연스럽게 작성한다(둘이 같아도 무방하나 description은 검색 스니펫이므로 의미를 담는 편이 좋다).
+
+## 코드 블록 처리 (가장 주의)
+
+코드는 동작이 깨지면 안 된다. **로직·식별자·문법은 한 글자도 바꾸지 말 것.** 다만 코드 안의 한글만 영어로 바꾼다.
+
+```go
+// 예제에서는 int 형을 변환한다   →   // Convert an int value in this example
+var 결과 = 1  // (식별자가 한글이면) 그대로 둘지 신중히 — 출력/매칭에 쓰이면 보존, 단순 지역변수면 영어화 가능하나 기본은 보존
+```
+
+- 주석(`//`, `#`, `/* */`): 한글 → 영어
+- 한글 문자열 리터럴: 영어로 번역하되, **기능적으로 의미 있는 값**(매칭 키, 테스트 기대 출력, `//Output:` 블록의 기대값)은 보존. 애매하면 원문을 주석으로 병기.
+- 식별자(변수·함수명)에 한글이 있으면 기본 보존(다른 코드/링크와의 정합성). 확실히 안전할 때만 영어화.
+
+## Frontmatter 예시
+
+원문:
+```yaml
+title: "타입 변환 (Type Conversion)"
+description: "타입 변환 (Type Conversion)"
+tags:
+  - golang
+  - 형변환
+```
+영어본:
+```yaml
+title: "Type Conversion in Go"
+description: "How explicit type conversion works in Go."
+tags:
+  - golang
+  - 형변환
+```
+(tags는 그대로. title/description은 자연스러운 영어로 — 원문이 단순 반복이면 의미를 살려 의역.)
+
+## Common Mistakes
+
+- ❌ 코드 식별자/로직을 영어로 바꿔 예제가 깨짐 → ✅ 코드는 보존, 한글 주석만 번역
+- ❌ tags를 영어로 번역 → ✅ 그대로 유지
+- ❌ `index.en.md`로 저장 → ✅ **`index_en.md`** (언더스코어)
+- ❌ 이미지 파일명을 영어로 바꿈 → ✅ 원본 경로 그대로 (이미지 공유)
+- ❌ Mermaid 노드에 `<br/>` 추가 → ✅ 줄바꿈 필요 시 노드 분리/단순화
+- ❌ 리스트 항목 끝에 마침표 추가 → ✅ 이 블로그 컨벤션상 리스트 항목 끝 마침표 없음
+- ❌ 번역 후 매니페스트 갱신 누락 → ✅ `npm run generate:manifest` 실행
+
+## After Translating
+
+```bash
+npm run generate:manifest
+node -e "const m=require('./public/content-manifest.json'); console.log(m.articles.filter(a=>a.lang==='en').map(a=>a.slug))"
+```
+영어 항목 목록에 새 slug이 보이면 성공. 발행 전 `npm run build`로 `/en/{slug}/` 렌더를 확인한다.

--- a/contents/go/타입-변환-type-conversion/index_en.md
+++ b/contents/go/타입-변환-type-conversion/index_en.md
@@ -1,0 +1,57 @@
+---
+title: "Type Conversion in Go"
+description: "How explicit type conversion works in Go and why Go only supports it."
+date: 2021-01-16
+update: 2021-01-16
+tags:
+  - golang
+  - type
+  - conversion
+  - cast
+  - casting
+  - 형변환
+  - 타입변환
+  - 타입
+  - 변환
+  - 명시적
+  - 캐스팅
+---
+
+Type conversion means changing a value's data type. Java supports both explicit type conversion and implicit type conversion, but Go supports only explicit type conversion.
+
+The type conversion syntax converts the value `val` to type `T`, as shown below.
+
+```go
+T(val)
+```
+
+In the example, an `int` value is converted to the `float64` and `uint32` types.
+
+```go
+func Example_TypeConversion() {
+	var i = 52
+	var j float64 = float64(i)
+	var k = uint32(j)
+
+	fmt.Println(i)
+	fmt.Println(j)
+	fmt.Println(k)
+
+	//Output:
+	//52
+	//52
+	//52
+}
+```
+
+
+
+You can find the code written in this post on [github](https://github.com/kenshin579/tutorials-go/tree/master/go-type-conversion).
+
+# References
+
+- Go type conversion
+    - https://tour.golang.org/basics/13
+    - https://www.geeksforgeeks.org/type-casting-or-type-conversion-in-golang/
+- Java type conversion
+    - https://opentutorials.org/course/1223/5330


### PR DESCRIPTION
## Summary
한국어 글을 영어로 번역해 `index_en.md`를 생성하는 로컬 수동 실행 skill을 추가한다. 다국어 인프라(Plan 1~3) 완성 후, 영어 글을 실제로 늘리기 위한 도구.

- `.claude/skills/translate-article-en/SKILL.md` — 번역 규칙 정의
  - 번역: 본문·`title`·`description`·섹션 heading·Mermaid 노드·**코드 내 한글(주석/문자열)**
  - 보존: 코드 로직·식별자·문법, `tags`·`date`·`update`·`series`, 이미지/링크/URL, 문단·빈 줄·들여쓰기
  - 출력: 같은 디렉토리 `index_en.md`(언더스코어), 이후 `npm run generate:manifest`
- 실제 글 `go/타입-변환-type-conversion`에 적용·검증 → `index_en.md` 생성 (영어 글 2건으로 증가)

## 검증 (TDD for skills)
- subagent가 SKILL.md만 읽고 실제 글을 번역 → 규칙 준수 결과 확인 (코드/탭/`//Output:` 값 보존, tags/date 유지, `# 참고`→`# References`, 링크 보존)
- subagent가 짚은 모호함(공백 보존, title/description 지침)을 스킬에 보강

## Test plan
- [x] 스킬 적용 결과 규칙 준수 확인
- [x] `npm run check` (tsc) 통과, `npm run build` 성공
- [x] `/en/타입-변환-type-conversion/` 렌더, 매니페스트 영어 항목 2건
- [ ] 추가 글 번역 시 코드 내 기능적 한글값(매칭 키/기대 출력) 보존 동작 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)