### PR TITLE
feat: AI 카테고리 글 5개 영어 번역본 추가

### DIFF
--- a/contents/ai/claude-code-mcp-추천-가이드/index_en.md
+++ b/contents/ai/claude-code-mcp-추천-가이드/index_en.md
@@ -1,0 +1,596 @@
+---
+title: "Recommended MCP Servers for Claude Code: A Guide"
+description: "A category-by-category overview of MCP servers you can use with the Claude Code CLI, along with setup methods and recommended combinations."
+date: 2026-03-04
+update: 2026-03-04
+tags:
+  - Claude Code
+  - MCP
+  - Model Context Protocol
+  - AI
+  - AI코딩도구
+  - 개발도구
+  - GitHub MCP
+  - Playwright
+  - Context7
+  - Anthropic
+---
+
+# 1. Overview
+
+Claude Code is an AI-powered CLI tool made by Anthropic that can read and modify code and perform a wide range of development tasks from the terminal. It is powerful with its built-in features alone, but connecting **MCP (Model Context Protocol) servers** lets you handle tasks like creating GitHub PRs, running browser tests, querying databases, and searching the latest documentation with a single line of natural language.
+
+This article covers the basic concept of MCP, how to set it up in Claude Code, and recommends MCP servers that are genuinely useful to developers, organized by category.
+
+# 2. What Is MCP
+
+## 2.1 MCP Overview
+
+MCP (Model Context Protocol) is an open standard developed by Anthropic that connects AI models with external tools, data, and services through a standardized interface. It is often described as **"the USB-C of AI"**: just as USB-C connects various devices through a single port, MCP connects various external services to AI through a single protocol.
+
+```mermaid
+flowchart LR
+    CC[Claude Code] <-->|MCP Protocol| GH[GitHub Server]
+    CC <-->|MCP Protocol| PW[Playwright Server]
+    CC <-->|MCP Protocol| C7[Context7 Server]
+```
+
+## 2.2 Core Components
+
+MCP consists of three core components.
+
+| Component | Description | Examples |
+|---------|------|------|
+| **Tools** | Functions the AI can call | Create a PR, search files, run a SQL query |
+| **Resources** | Data the AI can read | File contents, DB schema, API responses |
+| **Prompts** | Predefined prompt templates | Code review template, commit message generation |
+
+## 2.3 Why MCP Is Powerful in Claude Code
+
+Claude Code already has built-in tools such as file read/write, Bash execution, and code search. Adding MCP servers on top of this **extends Claude Code's capabilities to external services**.
+
+- With **GitHub MCP** connected: "Create a PR with these changes" creates a PR in a single sentence
+- With **Playwright MCP** connected: "Take a screenshot of the login page" automates the browser in a single sentence
+- With **Context7 MCP** connected: "Show me how to use useActionState in React 19" references the latest documentation in a single sentence
+
+# 3. Setting Up MCP Servers in Claude Code
+
+## 3.1 Transport Types
+
+MCP servers communicate with Claude Code in two ways.
+
+| Transport | Description | When to Use |
+|-----------|------|----------|
+| **HTTP** | Connects to a remote server over HTTP | Cloud-based services (GitHub, Context7, etc.) |
+| **stdio** | Runs a local process and communicates via standard input/output | Servers that run locally (Playwright, MySQL, etc.) |
+
+> There is also an SSE (Server-Sent Events) method, but it has been deprecated, so using HTTP is recommended.
+
+## 3.2 Setting Up via the CLI
+
+The simplest way to add an MCP server in Claude Code is the `claude mcp add` command.
+
+```bash
+# HTTP transport (remote server)
+claude mcp add --transport http <name> <url>
+
+# stdio transport (local process)
+claude mcp add --transport stdio <name> -- <command> [args...]
+
+# Including environment variables
+claude mcp add --transport stdio --env API_KEY=your_key <name> -- npx -y @package/name
+
+# Configure directly in JSON format
+claude mcp add-json <name> '<json_config>'
+
+# Import Claude Desktop configuration
+claude mcp add-from-claude-desktop
+```
+
+## 3.3 Configuration File Scopes
+
+By default, the `claude mcp add` command saves to the **Local scope**. That is, it does not create a project file (`.mcp.json`); instead it saves to `~/.claude.json`. You can change the save location with the `--scope` option.
+
+```bash
+# Local (default) - saved to ~/.claude.json, used only in the current project
+claude mcp add --transport http github https://api.githubcopilot.com/mcp/
+
+# Project - creates/modifies the .mcp.json file, can be shared with the team
+claude mcp add --scope project --transport http github https://api.githubcopilot.com/mcp/
+
+# User - saved to ~/.claude.json, used across all projects
+claude mcp add --scope user --transport http github https://api.githubcopilot.com/mcp/
+```
+
+MCP configuration is managed in four scopes, with a priority order of Local > Project > User.
+
+| Scope | Location | Purpose |
+|--------|------|------|
+| **Local** (default) | `~/.claude.json` (under the project path) | Personal use only, current project only |
+| **Project** | `.mcp.json` (project root) | Shared with the team (version controlled) |
+| **User** | `~/.claude.json` | Used across all projects |
+| **Managed** (enterprise) | `/Library/Application Support/ClaudeCode/managed-mcp.json` | Centrally managed by IT |
+
+In team projects, you can add servers with `--scope project` or write `.mcp.json` directly and commit it to Git so that all team members share the same MCP environment.
+
+## 3.4 .mcp.json Configuration Example
+
+You can create a `.mcp.json` file in the project root to manage MCP servers declaratively.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    },
+    "nanobanana": {
+      "command": "uvx",
+      "args": ["nanobanana-mcp-server@latest"],
+      "env": {
+        "GEMINI_API_KEY": "${NANOBANANA_MCP_GOOGLE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+> Environment variables can be referenced with the `${VAR}` or `${VAR:-default}` syntax. Secrets like API keys must be managed via environment variables and should never be included directly in `.mcp.json`.
+
+## 3.5 Server Management Commands
+
+```bash
+claude mcp list           # List configured servers
+claude mcp get <name>     # Show details for a specific server
+claude mcp remove <name>  # Remove a server
+```
+
+Within Claude Code, you can check the status of currently connected servers with the `/mcp` command.
+
+# 4. Recommended Essential MCP Servers for Development
+
+## 4.1 Version Control & Code Collaboration
+
+### 4.1.1 GitHub MCP Server
+
+This is the most essential MCP server in a development workflow. Claude Code can interact directly with GitHub to create PRs, perform code reviews, and manage issues.
+
+| Item | Details |
+|------|------|
+| GitHub | [github/github-mcp-server](https://github.com/github/github-mcp-server) |
+| Transport | HTTP |
+
+**Setup:**
+
+```bash
+claude mcp add --transport http github https://api.githubcopilot.com/mcp/
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}
+```
+
+**Key Features:**
+- Repository management (browse files, create branches)
+- Create, review, and merge Pull Requests
+- Create, search, and comment on Issues
+- Code search (at the organization/repo level)
+- Check CI/CD workflow status
+
+**Usage Examples:**
+
+```
+> Create a PR with the current changes. Assign kenshin579 as the reviewer
+> Add a "Fixed" comment to issue #42
+> Search this repo for code containing the keyword "deprecated"
+```
+
+### 4.1.2 GitHub Enterprise MCP Server
+
+If you work in an enterprise environment that uses an on-premises GitHub Enterprise Server (GHES), you can use the same GitHub MCP server with an Enterprise configuration.
+
+| Item | Details |
+|------|------|
+| GitHub | [github/github-mcp-server](https://github.com/github/github-mcp-server) (same server) |
+| Transport | stdio |
+
+**Setup:**
+
+```bash
+claude mcp add --transport stdio github-enterprise \
+  -- docker run -i --rm \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN \
+  -e GITHUB_HOST=github.your-company.com \
+  ghcr.io/github/github-mcp-server
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "github-enterprise": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "-e", "GITHUB_HOST",
+        "ghcr.io/github/github-mcp-server"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_ENTERPRISE_PAT}",
+        "GITHUB_HOST": "github.your-company.com"
+      }
+    }
+  }
+}
+```
+
+> Specify the Enterprise Server URL with the `GITHUB_HOST` environment variable and authenticate with a PAT (Personal Access Token). To use public GitHub and Enterprise at the same time, register the two servers under different names.
+
+## 4.2 Browser Automation & Testing
+
+### 4.2.1 Playwright MCP Server (Official Microsoft)
+
+This is the browser automation MCP server officially provided by Microsoft. It analyzes web pages based on the **Accessibility Tree** rather than screenshots, making it more accurate and efficient.
+
+| Item | Details |
+|------|------|
+| GitHub | [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) |
+| Transport | stdio |
+
+**Setup:**
+
+```bash
+claude mcp add playwright -- npx @playwright/mcp@latest
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+**Key Features:**
+- Web page navigation, clicking, form input
+- Screenshot capture
+- Automatic test code generation (Codegen mode)
+- Manipulating elements inside iframes
+- Saving PDFs, checking console logs
+
+**Usage Examples:**
+
+```
+> Go to http://localhost:3000 and take a screenshot of the login page
+> Fill in test data on the sign-up form and submit it
+> Check the accessibility issues on the current page
+```
+
+## 4.3 Documentation & Library References
+
+### 4.3.1 Context7 MCP Server
+
+It solves the problem of AI models having stale training data that does not match the latest library documentation. It fetches **the accurate, latest documentation of the library you are using** in real time and incorporates it into responses.
+
+| Item | Details |
+|------|------|
+| GitHub | [upstash/context7](https://github.com/upstash/context7) |
+| Transport | HTTP |
+
+**Setup:**
+
+```bash
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+**Key Features:**
+- Look up the latest documentation for libraries/frameworks
+- Provide accurate, version-specific API references
+- Include code examples
+
+**Usage Examples:**
+
+```
+> use context7. Show me how to use useActionState in React 19
+> use context7. Show me how to set up relations in Drizzle ORM
+> use context7. Show me a DataChannel example for Pion WebRTC
+```
+
+> If you include `use context7` in your prompt, Context7 automatically searches the latest documentation and uses it in the response.
+
+## 4.4 Databases
+
+### 4.4.1 Supabase MCP Server
+
+If your project uses Supabase as a backend, this is an essential MCP server. It provides more than 20 tools, handling everything from table design to migrations, queries, and type generation in one place.
+
+| Item | Details |
+|------|------|
+| Docs | [supabase.com/docs/guides/ai/mcp](https://supabase.com/docs/guides/ai/mcp) |
+| Transport | stdio |
+
+**Setup:**
+
+```bash
+claude mcp add supabase \
+  -- npx -y @anthropic-ai/mcp-remote@latest https://mcp.supabase.com
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/mcp-remote@latest", "https://mcp.supabase.com"]
+    }
+  }
+}
+```
+
+**Key Features:**
+- Table design and migration generation
+- SQL query execution
+- Automatic TypeScript type generation
+- Edge Function management
+- View/modify project settings
+
+### 4.4.2 MySQL MCP Server
+
+This is an MCP server that lets you query a MySQL database in natural language and explore its schema. It supports a read-only mode so you can explore data safely.
+
+| Item | Details |
+|------|------|
+| GitHub | [benborla/mcp-server-mysql](https://github.com/benborla/mcp-server-mysql) |
+| Transport | stdio |
+
+**Setup:**
+
+```bash
+claude mcp add --transport stdio \
+  --env MYSQL_HOST=localhost \
+  --env MYSQL_USER=root \
+  --env MYSQL_PASSWORD=password \
+  --env MYSQL_DATABASE=mydb \
+  mysql -- npx -y @benborla29/mcp-server-mysql
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "mysql": {
+      "command": "npx",
+      "args": ["-y", "@benborla29/mcp-server-mysql"],
+      "env": {
+        "MYSQL_HOST": "localhost",
+        "MYSQL_USER": "root",
+        "MYSQL_PASSWORD": "${MYSQL_PASSWORD}",
+        "MYSQL_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+**Key Features:**
+- Run SQL queries in natural language
+- Analyze table schemas and structures
+- Read-only mode support
+
+**Usage Examples:**
+
+```
+> Show me the schema of the users table
+> Count how many users signed up in the last 7 days
+> Analyze the relationship between the orders table and the products table
+```
+
+## 4.5 Search & Research
+
+### 4.5.1 Brave Search MCP Server
+
+It lets you use Brave Search, a privacy-focused web search engine, from within Claude Code. It is useful when you need additional searching beyond Claude Code's built-in WebSearch tool.
+
+| Item | Details |
+|------|------|
+| GitHub | [brave/brave-search-mcp-server](https://github.com/brave/brave-search-mcp-server) |
+| Transport | stdio |
+
+**Setup:**
+
+```bash
+claude mcp add --transport stdio \
+  --env BRAVE_API_KEY=your_api_key \
+  brave-search -- npx -y @anthropic-ai/mcp-remote@latest https://mcp.bravesearch.com/sse
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/mcp-remote@latest", "https://mcp.bravesearch.com/sse"],
+      "env": {
+        "BRAVE_API_KEY": "${BRAVE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+> You can get a Brave Search API key for free at [brave.com/search/api](https://brave.com/search/api/).
+
+## 4.6 Knowledge Management & Documentation
+
+### 4.6.1 Notion MCP Server
+
+You can browse and edit project documents, meeting notes, and technical specs stored in Notion directly from Claude Code. Connecting your development context with documentation boosts productivity.
+
+| Item | Details |
+|------|------|
+| GitHub | [makenotion/notion-mcp-server](https://github.com/makenotion/notion-mcp-server) |
+| Transport | stdio |
+
+**Setup:**
+
+```bash
+claude mcp add --transport stdio notion \
+  -- npx -y @notionhq/notion-mcp-server
+```
+
+> A Notion Internal Integration Token is required. After creating an Integration at [Notion Developers](https://developers.notion.com/), you must connect it to the pages/databases you want to access.
+
+**Key Features:**
+- Read and write pages/databases
+- Search pages
+- Manage comments
+- Edit content at the block level
+
+**Usage Examples:**
+
+```
+> Find the "API Design Document" page in Notion and show me its contents
+> Create a meeting notes page for today and add the attendee list
+> Add a new item to the "Technical Debt" database
+```
+
+## 4.7 Image Generation
+
+### 4.7.1 NanoBanana MCP Server
+
+This is an MCP server that uses Google Gemini models to generate and edit AI images. You can create blog thumbnails, diagrams, prototype images, and more from natural language.
+
+| Item | Details |
+|------|------|
+| GitHub | [YCSE/nanobanana-mcp](https://github.com/YCSE/nanobanana-mcp) |
+| Transport | stdio |
+
+**Setup:**
+
+Configure it in `.mcp.json` as follows.
+
+```json
+{
+  "mcpServers": {
+    "nanobanana": {
+      "command": "uvx",
+      "args": ["nanobanana-mcp-server@latest"],
+      "env": {
+        "GEMINI_API_KEY": "${NANOBANANA_MCP_GOOGLE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+> You need to obtain a Gemini API key from Google AI Studio and set it as an environment variable.
+
+**Usage Examples:**
+
+```
+> Generate an architecture diagram image showing the MCP server connection structure
+> Create a blog thumbnail image with an AI coding tool theme
+```
+
+## 4.8 Advanced Reasoning
+
+### 4.8.1 Sequential Thinking MCP Server
+
+This is an MCP server that helps break down complex tasks into logical steps for systematic thinking. It is used for architecture design, multi-step planning, complex bug analysis, and more.
+
+| Item | Details |
+|------|------|
+| Package | `@modelcontextprotocol/server-sequential-thinking` |
+| Transport | stdio |
+
+**Setup:**
+
+```bash
+claude mcp add sequential-thinking \
+  -- npx -y @modelcontextprotocol/server-sequential-thinking
+```
+
+When configuring via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}
+```
+
+**Usage Examples:**
+
+```
+> Lay out a step-by-step plan for splitting this monorepo into microservices
+> Analyze the root cause of this performance bottleneck
+```
+
+# 5. Where to Find MCP Servers
+
+Here is a summary of the major registries and marketplaces where you can find the MCP servers you need.
+
+| Registry | URL | Description |
+|-----------|-----|------|
+| **Official MCP Registry** | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/) | Official Anthropic registry |
+| **Smithery** | [smithery.ai](https://smithery.ai) | 2,200+ servers, automatic installation guides |
+| **MCP.so** | [mcp.so](https://mcp.so) | 3,000+ servers, quality ratings |
+| **PulseMCP** | [pulsemcp.com/servers](https://www.pulsemcp.com/servers) | 8,230+ servers, updated daily |
+| **awesome-mcp-servers** | [github.com/punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) | Curated GitHub list |
+
+# 6. Conclusion
+
+MCP is a powerful mechanism for extending Claude Code's capabilities to external services. We recommend starting with the **GitHub + Context7 + Playwright** trio and adding DB, search, and documentation management servers as needed.
+
+The MCP ecosystem is growing rapidly, with new servers constantly appearing. Checking the [Official MCP Registry](https://registry.modelcontextprotocol.io/) and [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) periodically will help you discover useful servers.
+
+# 7. References
+
+- [Claude Code MCP Official Documentation](https://docs.anthropic.com/en/docs/claude-code/mcp)
+- [Model Context Protocol Official Site](https://modelcontextprotocol.io/)
+- [modelcontextprotocol/servers GitHub](https://github.com/modelcontextprotocol/servers)
+- [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)

--- a/contents/ai/claude-code-plugin-hooks-완벽-가이드/index_en.md
+++ b/contents/ai/claude-code-plugin-hooks-완벽-가이드/index_en.md
@@ -1,0 +1,945 @@
+---
+title: "Complete Guide to Claude Code Plugins & Hooks: From Packaging Extensions to Event Automation"
+description: "An in-depth look at Claude Code's Plugin system and Hooks, covering Plugin structure, Marketplace, event-driven automation, and practical examples."
+date: 2026-03-19
+update: 2026-03-19
+tags:
+  - Claude Code
+  - Plugin
+  - Hooks
+  - Marketplace
+  - AI
+  - AI코딩도구
+  - 워크플로우자동화
+  - Anthropic
+series: "Claude Code 완벽 가이드"
+---
+
+# 1. Overview
+
+In the previous article, [Claude Code 확장 기능 완벽 가이드: Command, Skill, Subagent](/article/claude-code-확장-기능-완벽-가이드-command-skill-subagent), we covered the concepts and practical usage of Claude Code's three core extension features: Command, Skill, and Subagent. In this article, **without overlap**, we organize new content centered on the next steps: **Hooks** (event-driven automation) and the **Plugin system** (packaging and distributing extensions).
+
+## 1.1 Standalone Configuration vs Plugin
+
+Individual extensions can be configured directly in the `.claude/` directory and used immediately. However, if you want to share them with your team or distribute them to the community, packaging them as a **Plugin** is more efficient.
+
+| Criteria | Standalone Configuration | Plugin |
+|------|-----------|--------|
+| **Suitable for** | Personal workflows, project-specific | Team sharing, community distribution |
+| **Version control** | Managed directly with Git | `version` field in `plugin.json` |
+| **Namespace** | None (name collisions possible) | Separated with `/plugin-name:skill-name` format |
+| **Install/update** | Manual copy | One-click via `/plugins` command |
+| **MCP/LSP integration** | Requires separate setup | Bundled in Plugin and distributed at once |
+
+> In this article, we first cover the concept and practical usage of Hooks, then explain how to package all extensions into one with the Plugin system.
+
+# 2. Hooks (Event-Driven Automation)
+
+## 2.1 What Are Hooks
+
+Hooks are an automation mechanism that executes **deterministically** in response to specific Claude Code events. The key point is that, rather than relying on the LLM's judgment, they **always behave identically** according to predefined rules.
+
+Key characteristics:
+- **Deterministic execution**: The LLM does not decide "whether or not" to run. If conditions match, it always executes
+- **Event-driven**: Can intervene at 14 points such as before/after tool calls, session start/end, etc.
+- **Blocking capability**: Certain Hooks can block dangerous operations before they execute
+- **Three handler types**: shell command (`command`), LLM single turn (`prompt`), subagent (`agent`)
+
+For example, if you want to "prevent accidentally running `rm -rf /`," you could write "do not use rm -rf" in CLAUDE.md, but the LLM may ignore it. With Hooks, you can inspect the command before the Bash tool call and block it with **100% certainty**.
+
+```mermaid
+flowchart LR
+    A["Event occurs\n(e.g. Bash call)"] --> B{"matcher pattern\nmatches?"}
+    B -- No --> C["Skip Hook"]
+    B -- Yes --> D["Run Hook\n(command/prompt/agent)"]
+    D --> E{"Check exit code"}
+    E -- "0 (success)" --> F["Continue event"]
+    E -- "2 (block)" --> G["Block event\n+ stderr feedback"]
+
+    style G fill:#fce8e6,stroke:#d93025
+    style F fill:#d4edda,stroke:#28a745
+```
+
+## 2.2 The 14 Hook Events
+
+Claude Code provides 14 events across the full session lifecycle. Each event falls into one of two categories depending on **whether it can block**.
+
+| Event | When it fires | Blockable | Main use |
+|---|---|---|---|
+| `SessionStart` | On session start/resume | No | Environment initialization, logging |
+| `UserPromptSubmit` | On user prompt submission | Yes | Input validation, prompt transformation |
+| `PreToolUse` | Before a tool call | Yes | Block dangerous commands, validate input |
+| `PermissionRequest` | When permission dialog is shown | Yes | Auto-approve/deny |
+| `PostToolUse` | After a tool call succeeds | No | Linting, formatting, logging |
+| `PostToolUseFailure` | After a tool call fails | No | Error logging, recovery attempts |
+| `Notification` | When a notification is sent | No | Notification customization |
+| `SubagentStart` | When a subagent is created | No | Monitoring, logging |
+| `SubagentStop` | When a subagent ends | Yes | Result validation |
+| `Stop` | When Claude finishes a response | Yes | Task completion validation, post-processing |
+| `TeammateIdle` | When a teammate agent is idle | Yes | Assign additional work |
+| `TaskCompleted` | When a task is marked complete | Yes | Validate completion criteria |
+| `PreCompact` | Before context compaction | No | Save information before compaction |
+| `SessionEnd` | When a session ends | No | Cleanup tasks, final logging |
+
+When a Hook returns exit code `2` on a **blocking** event, that operation is aborted and the contents of stderr are passed to Claude as feedback.
+
+Common fields in the stdin JSON passed to a Hook:
+
+```json
+{
+  "session_id": "abc123",
+  "cwd": "/home/user/my-project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm test"
+  }
+}
+```
+
+## 2.3 How to Configure Hooks
+
+### 2.3.1 Configuration Format
+
+Hooks are configured in JSON format. The structure is `event → matcher → hooks array`.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-dangerous-commands.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/auto-lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 2.3.2 matcher Patterns
+
+`matcher` is a regular expression pattern that filters which tool names the Hook reacts to.
+
+| matcher pattern | Description |
+|---|---|
+| `"Bash"` | Reacts only to the Bash tool |
+| `"Write\|Edit"` | Reacts to the Write or Edit tool |
+| `"mcp__.*"` | Reacts to all MCP tools |
+| `"mcp__memory__.*"` | Reacts to all tools of the memory MCP server |
+| `null` (omitted) | Reacts to all tools of that event |
+
+### 2.3.3 Configuration Locations & Scope
+
+Hooks can be configured in 4 locations, each with a different scope of application.
+
+| Location | File path | Scope | Team sharing |
+|---|---|---|---|
+| **User global** | `~/.claude/settings.json` | All projects | No |
+| **Project** | `.claude/settings.json` | Current project | Yes (Git commit) |
+| **Project local** | `.claude/settings.local.json` | Current project | No (gitignore) |
+| **Plugin** | `<plugin>/hooks/hooks.json` | When Plugin is enabled | Yes |
+
+Hooks from all scopes are merged and executed. If multiple Hooks are configured for the same event, they all run in order.
+
+## 2.4 The Three Hook Handler Types
+
+When a Hook is triggered, you can choose among 3 handlers depending on **what to execute**.
+
+### 2.4.1 command (Shell Command)
+
+The most basic handler, which directly runs a shell command. Event data is passed **as JSON via stdin**.
+
+```json
+{
+  "type": "command",
+  "command": "bash .claude/hooks/block-rm.sh"
+}
+```
+
+- **exit code 0**: Success (event continues)
+- **exit code 2**: Block (blocking events only). stderr content is passed to Claude as feedback
+- **stdout output**: Passed to Claude as additional context (useful in non-blocking Hooks)
+- **Timeout**: Default 600 seconds, adjustable via the `timeout` field (prompt is 30 seconds, agent is 60 seconds)
+- **Async execution**: Setting `"async": true` proceeds without waiting for the Hook to complete
+- **Environment variables**: `$CLAUDE_PROJECT_DIR` (project root) and `${CLAUDE_PLUGIN_ROOT}` (Plugin root) are available
+
+### 2.4.2 prompt (LLM Single Turn)
+
+A handler that requests a single-turn evaluation from the LLM. It analyzes and judges the event data without using tools.
+
+```json
+{
+  "type": "prompt",
+  "prompt": "Review the result of the following task and judge whether the goal was achieved. If not achieved, tell me what is missing."
+}
+```
+
+- The LLM receives the event context and generates a single response
+- Since it cannot use tools, it is suitable for **reading/analysis** purposes
+- Useful when combined with the `Stop` event to judge whether a task is complete
+
+### 2.4.3 agent (Subagent Multi-Turn)
+
+A handler that creates a subagent to perform multi-turn validation tasks.
+
+```json
+{
+  "type": "agent",
+  "prompt": "Read the file that was just modified, check the code style guide, and report any violations."
+}
+```
+
+- The subagent can use tools to read files, search, etc.
+- More costly than `prompt`, but suitable for complex validation
+- Useful when you need to read and analyze multiple files
+
+| Handler | Execution method | Tool use | Cost | Suitable for |
+|--------|-----------|-----------|------|-------------|
+| `command` | Directly runs a shell command | None | Minimal | Linting, formatting, simple validation |
+| `prompt` | LLM single-turn evaluation | None | Medium | Judging task completion, evaluating results |
+| `agent` | Subagent multi-turn | Yes | High | File inspection, complex validation |
+
+## 2.5 Practical Examples
+
+### 2.5.1 Blocking Dangerous Commands (PreToolUse + Bash)
+
+Block dangerous commands like `rm -rf /` and `git push --force` before the Bash tool call.
+
+`settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-dangerous-commands.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`.claude/hooks/block-dangerous-commands.sh`:
+
+```bash
+#!/bin/bash
+# Event data is passed as JSON via stdin
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Check for dangerous command patterns
+dangerous_patterns=(
+  "rm -rf /"
+  "rm -rf ~"
+  "git push.*--force.*main"
+  "git push.*--force.*master"
+  "DROP TABLE"
+  "DROP DATABASE"
+)
+
+for pattern in "${dangerous_patterns[@]}"; do
+  if echo "$command" | grep -qE "$pattern"; then
+    echo "Dangerous command blocked: $command" >&2
+    echo "This command was blocked by security policy." >&2
+    exit 2  # exit code 2 = block
+  fi
+done
+
+exit 0  # exit code 0 = allow
+```
+
+**Behavior scenario**: When Claude tries to run `rm -rf /tmp/build`, the Hook inspects the command and allows it since it does not match a dangerous pattern. On the other hand, if it tries `git push --force origin main`, it is blocked with exit code 2, and the feedback "This command was blocked by security policy" is passed to Claude.
+
+### 2.5.2 Auto-Linting After File Save (PostToolUse + Write|Edit)
+
+Automatically run a linter after creating or modifying a file.
+
+`settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/auto-lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`.claude/hooks/auto-lint.sh`:
+
+```bash
+#!/bin/bash
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Run the appropriate linter based on file extension
+case "$file_path" in
+  *.ts|*.tsx)
+    npx eslint --fix "$file_path" 2>/dev/null
+    ;;
+  *.py)
+    ruff check --fix "$file_path" 2>/dev/null
+    ;;
+  *.go)
+    gofmt -w "$file_path" 2>/dev/null
+    ;;
+esac
+
+exit 0
+```
+
+**Point**: Since `PostToolUse` is a non-blocking event, returning exit code 2 does not abort the operation. The linter's results are passed to Claude via stdout.
+
+### 2.5.3 Task Completion Validation (Stop + prompt handler)
+
+When Claude is about to finish a response, the `prompt` handler validates whether the task is complete.
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Review the task that was just completed. Comparing it to the user's original request: 1) Were all requirements met? 2) Was this a change requiring tests, but tests were not written? 3) Is anything missing? If anything is lacking, tell me specifically."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Behavior scenario**: When Claude processes a request like "add a function" and is about to finish its response, the `Stop` Hook asks the LLM to review. If the LLM judges that "tests are missing," that feedback is passed to Claude, which then continues with additional work.
+
+### 2.5.4 MCP Tool Monitoring (mcp__*__ matcher)
+
+Monitor and log tool calls of an MCP server.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__memory__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'echo \"[$(date)] MCP memory tool call: $(cat | jq -r .tool_name)\" >> /tmp/mcp-audit.log'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 2.5.5 Asynchronous Test Execution (async: true)
+
+After a file change, run tests asynchronously so they do not block Claude's next task.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'npm test -- --related $(cat | jq -r .tool_input.file_path) &>/tmp/test-results.log'",
+            "async": true,
+            "timeout": 120000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Point**: Setting `async: true` means it does not wait until the Hook finishes executing. This is suitable for time-consuming tasks like tests.
+
+## 2.6 Hooks Best Practices
+
+### 2.6.1 Recommended Use Case Collection
+
+| Use Case | Event | Handler | Description |
+|----------|--------|--------|------|
+| Block dangerous commands | `PreToolUse` (Bash) | `command` | Block `rm -rf /`, `git push --force main`, etc. |
+| Auto lint/format | `PostToolUse` (Write\|Edit) | `command` | Auto-run ESLint, gofmt, ruff on file save |
+| Enforce commit message rules | `PreToolUse` (Bash) | `command` | Block if not in Conventional Commits format |
+| Protect sensitive files | `PreToolUse` (Write\|Edit) | `command` | Block edits to `.env`, `secrets.yaml`, etc. |
+| Auto-run tests | `PostToolUse` (Write\|Edit) | `command` (async) | Run related tests asynchronously without blocking the workflow |
+| Task completion validation | `Stop` | `prompt` | Review requirement fulfillment and missing tests |
+| Code review automation | `Stop` | `agent` | Read modified files and check for style guide violations |
+| API call audit log | `PreToolUse` (mcp__*) | `command` | Log MCP tool call records to a file |
+| Branch protection | `PreToolUse` (Bash) | `command` | Prevent direct commits to main/master branch |
+| Environment initialization | `SessionStart` | `command` | Load `.env` and verify required tools exist at session start |
+
+### 2.6.2 Design Principles
+
+**1. Use the command handler by default**
+
+For tasks with clear rules, such as linting, formatting, and pattern checking, `command` is the most efficient. Use `prompt` or `agent` only when judgment is required, since they incur LLM cost.
+
+**2. Block minimally, give clear feedback**
+
+When blocking with exit code 2, you should specifically explain **why it was blocked** in stderr so that Claude can find an alternative.
+
+```bash
+# ❌ Bad example: blocking without a reason
+echo "Blocked" >&2 && exit 2
+
+# ✅ Good example: provide a specific reason and alternative
+echo "You cannot push directly to the main branch. Create a PR from a feature branch." >&2 && exit 2
+```
+
+**3. Run heavy tasks with async**
+
+For time-consuming tasks like running tests or validating builds, set `"async": true` so they do not block Claude's workflow.
+
+**4. Make Hook scripts exit quickly**
+
+Synchronous Hooks block Claude's response. Do not rely on the default timeout (command: 600 seconds); write the script itself to finish as quickly as possible.
+
+**5. Narrow the event + matcher combination precisely**
+
+If you omit the matcher, the Hook runs for **all** tools of that event. To reduce unnecessary execution, specify the matcher as specifically as possible.
+
+```json
+// ❌ Run lint on all tools (unnecessary)
+{ "matcher": null }
+
+// ✅ Run lint only on file-modifying tools
+{ "matcher": "Write|Edit" }
+```
+
+# 3. Plugin System
+
+## 3.1 What Is a Plugin
+
+A Plugin is a packaging system that bundles Skills, Hooks, Agents, MCP servers, and LSP servers into **a single distribution unit**. Instead of configuring individual extensions directly, packaging them as a Plugin makes installation, updates, and sharing easy.
+
+Key characteristics:
+- **Unified packaging**: Bundles Command, Skill, Agent, Hook, MCP, and LSP into one
+- **Namespacing**: Prevents name collisions with the `/plugin-name:skill-name` format
+- **One-click install**: Install via the `/plugins` command or Marketplace
+- **Auto-update**: Supports version management and auto-update when registered on a Marketplace
+- **Scope selection**: Choose among user global, project shared, or project local
+
+## 3.2 Plugin Structure
+
+### 3.2.1 Directory Layout
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json         # Manifest (required)
+├── commands/               # Slash commands (markdown files)
+│   └── deploy.md
+├── skills/                 # Agent Skills
+│   └── code-review/
+│       └── SKILL.md
+├── agents/                 # Custom subagents
+│   └── reviewer.md
+├── hooks/
+│   └── hooks.json          # Event handlers
+├── .mcp.json               # MCP server config
+└── .lsp.json               # LSP server config
+```
+
+All directories are optional. You only need to include the extensions you need. The only required file is `.claude-plugin/plugin.json`.
+
+### 3.2.2 plugin.json Manifest Schema
+
+```json
+{
+  "name": "my-awesome-plugin",
+  "description": "A Plugin that automates the project development workflow",
+  "version": "1.0.0",
+  "author": {
+    "name": "Developer Name",
+    "url": "https://github.com/username"
+  },
+  "homepage": "https://github.com/username/my-awesome-plugin",
+  "repository": "https://github.com/username/my-awesome-plugin",
+  "license": "MIT"
+}
+```
+
+| Field | Required | Description |
+|------|------|------|
+| `name` | Yes | Plugin identifier (lowercase, numbers, hyphens) |
+| `description` | Yes | Plugin description |
+| `version` | Yes | Semantic Versioning (e.g. `1.0.0`) |
+| `author` | No | Author info (`name`, `url`) |
+| `homepage` | No | Plugin homepage URL |
+| `repository` | No | Source code repository URL |
+| `license` | No | License |
+
+## 3.3 Plugin Development Workflow
+
+### 3.3.1 Local Testing (--plugin-dir)
+
+When developing a Plugin, you can test it locally right away.
+
+```bash
+# Load a single Plugin
+claude --plugin-dir ./my-plugin
+
+# Load multiple Plugins at once
+claude --plugin-dir ./plugin-one --plugin-dir ./plugin-two
+```
+
+A Plugin loaded with `--plugin-dir` behaves the same as a regular installation. Skills can be invoked in the `/plugin-name:skill-name` format, and Hooks also work as configured.
+
+### 3.3.2 Migrating Existing .claude/ Configuration to a Plugin
+
+If you already have extensions configured in the `.claude/` directory, you can convert them to a Plugin with a simple structural transformation.
+
+| Existing location | Plugin location |
+|---|---|
+| `.claude/commands/*.md` | `commands/*.md` |
+| `.claude/skills/<name>/SKILL.md` | `skills/<name>/SKILL.md` |
+| `.claude/agents/*.md` | `agents/*.md` |
+| hooks section in `settings.json` | `hooks/hooks.json` |
+| `.mcp.json` | `.mcp.json` (as is) |
+
+Migration steps:
+
+1. Create the Plugin directory and write `plugin.json`
+2. Copy existing files into the new structure
+3. Separate the hooks from `settings.json` into `hooks/hooks.json`
+4. Test with `--plugin-dir`
+5. Remove the existing `.claude/` configuration (optional)
+
+## 3.4 LSP Server (Code Intelligence)
+
+A Plugin can include an LSP (Language Server Protocol) server to provide **real-time code intelligence**. The LSP server provides Claude with features such as code diagnostics (errors, warnings), autocompletion, and go-to-definition.
+
+### 3.4.1 .lsp.json Configuration
+
+```json
+{
+  "mcpServers": {
+    "typescript-lsp": {
+      "command": "npx",
+      "args": ["typescript-language-server", "--stdio"],
+      "languages": ["typescript", "typescriptreact"]
+    },
+    "python-lsp": {
+      "command": "pylsp",
+      "args": [],
+      "languages": ["python"]
+    }
+  }
+}
+```
+
+When the LSP server is enabled, Claude can reference real-time diagnostic information when modifying code. It detects compile errors or type errors and recognizes problems before making fixes.
+
+### 3.4.2 Official LSP Plugins
+
+The official Anthropic Marketplace provides LSP Plugins for 11 languages.
+
+| Plugin | Language | Required binary |
+|--------|------|---------------|
+| `typescript-lsp` | TypeScript/JavaScript | `typescript-language-server` |
+| `pyright-lsp` | Python | `pyright-langserver` |
+| `gopls-lsp` | Go | `gopls` |
+| `rust-analyzer-lsp` | Rust | `rust-analyzer` |
+| `clangd-lsp` | C/C++ | `clangd` |
+| `jdtls-lsp` | Java | `jdtls` |
+| `kotlin-lsp` | Kotlin | `kotlin-language-server` |
+| `swift-lsp` | Swift | `sourcekit-lsp` |
+| `csharp-lsp` | C# | `csharp-ls` |
+| `php-lsp` | PHP | `intelephense` |
+| `lua-lsp` | Lua | `lua-language-server` |
+
+When an LSP Plugin is enabled, Claude automatically receives diagnostic information (errors, warnings) after modifying a file, allowing it to recognize problems without running the compiler directly.
+
+# 4. Plugin Marketplace
+
+## 4.1 Official Marketplace
+
+Anthropic operates an official Plugin Marketplace (`anthropics/claude-plugins-official`), which provides curated Plugins. It is available automatically when Claude Code starts.
+
+Characteristics of the official Marketplace:
+- Includes only Plugins verified by Anthropic
+- Connected by default when Claude Code is installed
+- Browse and install directly via the `/plugins` command
+
+## 4.2 Installing Plugins
+
+### 4.2.1 /plugins Command
+
+Running the `/plugins` command in Claude Code opens the Plugin management interface. You can search for and install Plugins from the Marketplace.
+
+### 4.2.2 Installation Scope
+
+When installing a Plugin, you choose one of 3 scopes.
+
+| Scope | Description | Storage location |
+|--------|------|-----------|
+| **Install for you** | Use across all projects (user global) | `~/.claude/plugins/` |
+| **Install for this project** | Share with project teammates | `.claude/plugins/` (Git-committable) |
+| **Install locally** | Current repo, current user only | `.claude/plugins.local/` |
+
+### 4.2.3 Installing via CLI
+
+```bash
+# Install from the Marketplace
+claude plugin install <plugin-name>
+
+# Install directly from a GitHub repo
+claude plugin install github:username/repo-name
+
+# Install from a local path
+claude plugin install /path/to/local/plugin
+```
+
+### 4.2.4 Plugin Management CLI Commands
+
+| Command | Description |
+|------|------|
+| `claude plugin install <plugin> [-s scope]` | Install a Plugin |
+| `claude plugin uninstall <plugin> [-s scope]` | Remove a Plugin |
+| `claude plugin enable <plugin> [-s scope]` | Enable a disabled Plugin |
+| `claude plugin disable <plugin> [-s scope]` | Disable without removing |
+| `claude plugin update <plugin> [-s scope]` | Update to the latest version |
+| `claude plugin validate .` | Validate Plugin structure |
+
+## 4.3 Creating & Distributing a Marketplace
+
+### 4.3.1 Using a GitHub Repo as a Marketplace
+
+A community Marketplace can be run on top of a GitHub repo. Just create a `marketplace.json` file at the repo root.
+
+```json
+{
+  "name": "my-marketplace",
+  "owner": {
+    "name": "DevTools Team",
+    "email": "devtools@example.com"
+  },
+  "metadata": {
+    "description": "Team-only Plugin Marketplace",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "my-plugin",
+      "description": "Plugin description",
+      "source": {
+        "source": "github",
+        "repo": "username/my-plugin"
+      },
+      "tags": ["workflow", "automation"]
+    },
+    {
+      "name": "local-plugin",
+      "description": "Local path Plugin",
+      "source": "./plugins/local-plugin"
+    }
+  ]
+}
+```
+
+### 4.3.2 Registering a Marketplace
+
+How users add a community Marketplace:
+
+You can add it from the Marketplace tab via `/plugins` within Claude Code, or add it via the CLI.
+
+```bash
+# Add by GitHub repo
+/plugin marketplace add username/marketplace-repo
+
+# Add by Git URL (GitLab, Bitbucket, etc.)
+/plugin marketplace add https://gitlab.com/org/marketplace-repo.git
+
+# Pin to a specific branch/tag
+/plugin marketplace add https://github.com/org/plugins.git#v1.0.0
+```
+
+In team projects, you can configure the Marketplace in `.claude/settings.json` so that teammates use it automatically.
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "company-tools": {
+      "source": {
+        "source": "github",
+        "repo": "your-org/claude-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "code-formatter@company-tools": true,
+    "deployment-tools@company-tools": true
+  }
+}
+```
+
+### 4.3.3 Distribution Checklist
+
+Things to check when distributing a Plugin:
+
+1. Complete the `.claude-plugin/plugin.json` manifest
+2. Write a `README.md` (installation, usage, configuration options)
+3. Apply Semantic Versioning (match the Git tag with the `version` field)
+4. Check whether sensitive information (API keys, personal paths) is included
+5. Complete local testing with `--plugin-dir`
+6. Push to a public GitHub repo
+
+# 5. Agent Teams (Experimental Feature)
+
+## 5.1 Overview
+
+Agent Teams is an experimental feature that coordinates multiple Claude Code instances as a **team**. One session takes the role of Team Lead, distributing work, and multiple Teammates work independently before sharing their results.
+
+The key difference from Subagent is that **direct communication between Teammates** is possible.
+
+| Criteria | Subagent | Agent Team |
+|------|----------|------------|
+| **Context** | Own context, returns only the result | Fully independent instance |
+| **Communication** | Reports only to the main agent | Teammates communicate directly with each other |
+| **Coordination** | Managed by the main agent | Self-coordinated via a shared task list |
+| **Suitable for** | Focused tasks where only the result matters | Complex tasks requiring discussion and collaboration |
+| **Token cost** | Low (result summary) | High (context per instance) |
+
+```mermaid
+flowchart TD
+    Lead["Team Lead\n(coordination only)"]
+    T1["Teammate 1\nSecurity review"]
+    T2["Teammate 2\nPerformance analysis"]
+    T3["Teammate 3\nTest validation"]
+    TL["Shared task list"]
+
+    Lead --> T1
+    Lead --> T2
+    Lead --> T3
+    T1 <--> T2
+    T2 <--> T3
+    T1 <--> T3
+    T1 --- TL
+    T2 --- TL
+    T3 --- TL
+
+    style Lead fill:#e8f4fd,stroke:#1a73e8
+    style TL fill:#fff3cd,stroke:#ffc107
+```
+
+## 5.2 Enabling & Usage
+
+### 5.2.1 Enabling
+
+Agent Teams is disabled by default. Enable it via an environment variable or settings.json.
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+### 5.2.2 Creating a Team
+
+Request the team composition from Claude in natural language.
+
+```
+Create an agent team to review PR #142.
+- 1 person responsible for reviewing security vulnerabilities
+- 1 person responsible for analyzing performance impact
+- 1 person responsible for verifying test coverage
+Each reviews and shares the results.
+```
+
+### 5.2.3 Delegate Mode
+
+Pressing Shift+Tab switches to Delegate mode. In this mode, the Team Lead does not modify code directly and performs **only coordination work**.
+
+- Creating and managing Teammates
+- Assigning tasks and checking status
+- Relaying messages and synthesizing results
+- Delegating code modification, file creation, etc. to Teammates
+
+### 5.2.4 Display Modes
+
+| Mode | Description | Requirements |
+|------|------|----------|
+| `in-process` | Run all Teammates in the main terminal | None (default) |
+| `tmux` | Each Teammate runs in a separate pane | tmux or iTerm2 |
+| `auto` | Split if in a tmux session, otherwise in-process | Auto-detect |
+
+```json
+{
+  "teammateMode": "in-process"
+}
+```
+
+## 5.3 Suitable Use Cases & Limitations
+
+### 5.3.1 Suitable Cases
+
+- **Research & review**: Investigate from multiple perspectives simultaneously (security, performance, UX)
+- **Cross-layer work**: Assign frontend, backend, and tests to different Teammates
+- **Competing-hypothesis debugging**: Verify multiple hypotheses simultaneously and have them refute each other
+- **New module/feature development**: Develop independent modules in parallel
+
+### 5.3.2 Limitations
+
+- **No session resume**: in-process Teammates cannot be restored with `/resume` or `/rewind`
+- **One team per session**: Only one team can run at a time
+- **No nesting**: Teammates cannot create their own teams
+- **Fixed Lead**: The session that created the team is permanently the Lead role
+- **Watch for file conflicts**: If multiple Teammates modify the same file, overwrites occur
+- **Token cost**: Since each Teammate needs a separate context, the cost increases significantly
+
+# 6. Security & Enterprise Management
+
+## 6.1 Hook Security Considerations
+
+Hooks run with **the user's system privileges**. Therefore, you must be especially careful about security.
+
+- **Input validation**: Always validate the JSON data passed via stdin when parsing it
+- **Path traversal defense**: When handling file paths in a Hook script, prevent path traversal attacks such as `..`
+- **Sensitive file protection**: Block commands that access `.env`, `.git/`, API key files, etc.
+- **Timeout setting**: Set the `timeout` field to prevent infinite loops
+
+## 6.2 Enterprise Management Settings
+
+In an enterprise environment, IT administrators can control extensions centrally.
+
+### 6.2.1 managed-mcp.json
+
+IT administrators centrally deploy MCP servers across the entire organization. The organization's standard tools are provided automatically, without users having to configure them individually.
+
+### 6.2.2 MCP Server Allow/Deny Lists
+
+```json
+{
+  "allowedMcpServers": ["github", "jira", "slack"],
+  "deniedMcpServers": ["*"]
+}
+```
+
+- `allowedMcpServers`: List of allowed MCP servers
+- `deniedMcpServers`: List of blocked MCP servers (block all with `*`, then use only the allow list)
+
+### 6.2.3 allowManagedHooksOnly
+
+```json
+{
+  "allowManagedHooksOnly": true
+}
+```
+
+When this setting is enabled, all user- or project-level Hooks are ignored, and **only Hooks set by the administrator** are run. It is useful in security-critical enterprise environments.
+
+### 6.2.4 strictKnownMarketplaces
+
+```json
+{
+  "strictKnownMarketplaces": true
+}
+```
+
+When this setting is enabled, Plugins can be installed only from Marketplaces approved by the administrator. It prevents installing Plugins from unknown sources.
+
+# 7. Conclusion
+
+Including the Command, Skill, and Subagent covered in the previous article, when we put together Claude Code's 5 extension mechanisms, you can choose among them depending on the situation as follows.
+
+```mermaid
+flowchart TD
+    A["Do you need an extension?"] -- Yes --> B["Which type?"]
+    A -- No --> Z["Use plain Claude Code"]
+
+    B --> C["Automate repetitive tasks"]
+    B --> D["Inject knowledge/rules"]
+    B --> E["Delegate independent work"]
+    B --> F["Event automation"]
+    B --> G["Team sharing/distribution"]
+
+    C --> C1["Command\n(/commit, /deploy)"]
+    D --> D1["Skill\n(coding conventions, project rules)"]
+    E --> E1["Subagent\n(code review, debugging)"]
+    F --> F1["Hooks\n(linting, command blocking)"]
+    G --> G1["Plugin\n(package everything)"]
+
+    style C1 fill:#d4edda,stroke:#28a745
+    style D1 fill:#e8f4fd,stroke:#1a73e8
+    style E1 fill:#fce8e6,stroke:#d93025
+    style F1 fill:#fff3cd,stroke:#ffc107
+    style G1 fill:#e8daef,stroke:#8e44ad
+```
+
+| Extension mechanism | One-line summary | Suitable for |
+|---|---|---|
+| **Command** | "Run this procedure" | Standardized tasks you repeat daily |
+| **Skill** | "Refer to this knowledge" | Coding rules, project guidelines |
+| **Subagent** | "Leave it to this expert" | Independent analysis, need for isolated execution |
+| **Hooks** | "Automatically react to this event" | Linting, security checks, deterministic validation |
+| **Plugin** | "Bundle everything and distribute it" | Team sharing, community distribution, Marketplace |
+
+Summarizing the growth path in practice:
+
+1. **Start with Command**: Automate repetitive tasks as slash commands
+2. **Inject knowledge with Skill**: Teach Claude your project rules
+3. **Delegate with Subagent**: Separate independent work to specialized agents
+4. **Automate with Hooks**: Add event-driven deterministic validation
+5. **Package with Plugin**: Bundle all extensions into one and share with your team
+
+# 8. References
+
+- [Claude Code Hooks Reference](https://code.claude.com/docs/en/hooks)
+- [Claude Code Hooks Guide](https://code.claude.com/docs/en/hooks-guide)
+- [Claude Code Plugins](https://code.claude.com/docs/en/plugins)
+- [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
+- [Discover and Install Plugins](https://code.claude.com/docs/en/discover-plugins)
+- [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Agent Teams](https://code.claude.com/docs/en/agent-teams)
+- [Claude Code Official Plugin Marketplace Guide](https://www.petegypps.uk/blog/claude-code-official-plugin-marketplace-complete-guide-36-plugins-december-2025)
+- [Improving your coding workflow with Claude Code Plugins](https://composio.dev/blog/claude-code-plugin)
+- [Claude Code Agent Teams - Addy Osmani](https://addyosmani.com/blog/claude-code-agent-teams/)
+- [From Tasks to Swarms: Agent Teams](https://alexop.dev/posts/from-tasks-to-swarms-agent-teams-in-claude-code/)
+- [Claude Code 확장 기능 완벽 가이드: Command, Skill, Subagent](/article/claude-code-확장-기능-완벽-가이드-command-skill-subagent)

--- a/contents/ai/claude-code-superpowers-완벽-가이드/index_en.md
+++ b/contents/ai/claude-code-superpowers-완벽-가이드/index_en.md
@@ -1,0 +1,406 @@
+---
+title: "Complete Guide to Claude Code Superpowers: From Brainstorm to PR"
+description: "A comprehensive guide to building a Todo web app through the full cycle—from brainstorm to PR—using the Claude Code superpowers plugin."
+date: 2026-05-01
+update: 2026-05-01
+tags:
+  - Claude Code
+  - Superpowers
+  - AI
+  - Skill
+  - Plugin
+  - Subagent
+  - MCP
+  - Playwright
+  - AI코딩도구
+  - 워크플로우자동화
+  - TDD
+  - 코드리뷰
+  - Anthropic
+series: "Claude Code 완벽 가이드"
+---
+
+# 1. Overview
+
+When you write code with Claude Code, there's one recurring frustration. You start out clean, but at some point the context becomes scattered, you lose track of how far you've gotten, and it becomes ambiguous where the tests should stop and restart. Give the AI autonomy and it gets improvisational; try to control it and a human has to step in at every turn.
+
+**Superpowers is a plugin that structures this flow.** It organizes ideas into a spec with brainstorm, decomposes them into work-unit plans with writing-plans, goes through per-phase implementation + automatic review with subagent-driven-development, runs a final check with requesting-code-review, and handles PR/cleanup with finishing-a-development-branch—these five stages are bundled into one complete workflow.
+
+In this article, I'll lay out the core superpowers skills all at once, then walk step by step through an actual case where I built an Echo + React Todo web app from scratch all the way to PR/merge. At the end, I've added a separate honest-review section based on actually using it, so colleagues considering adoption can weigh cost vs. value.
+
+> This article assumes a reader who is reasonably familiar with Claude Code itself and the Skill/Plugin concepts. If any concept is new to you, it helps to first read [Complete Guide to Claude Code Extensions: Command, Skill, Subagent](/articles/claude-code-확장-기능-완벽-가이드-command-skill-subagent) and [Complete Guide to Claude Code Plugin Hooks](/articles/claude-code-plugin-hooks-완벽-가이드).
+
+# 2. What Is Superpowers
+
+Superpowers is a plugin officially registered in the [Claude Code plugin marketplace run by Anthropic](https://www.anthropic.com/engineering/claude-code-plugins). Unlike an ordinary plugin that provides a single function, its distinguishing feature is that it provides **a bundle of multiple skills + a workflow in which the skills are invoked in a defined order**.
+
+Where the existing [Skill guide](/articles/claude-code-확장-기능-완벽-가이드-command-skill-subagent) explains "what each skill is and when it's invoked," this article steps up one level to cover **in what order multiple skills are woven together to form a single cycle**.
+
+# 3. Core Skill Catalog
+
+There are many skills inside Superpowers, but the core ones that form the full cycle are eight. Let's first skim them all at once, then look at each skill one paragraph at a time.
+
+| Skill | Role | Input → Output | Coverage Depth |
+|---|---|---|---|
+| brainstorming | idea → spec | natural language → spec.md | deep (section 5) |
+| writing-plans | spec → plan | spec.md → plan.md | deep |
+| subagent-driven-development | plan → code (subagent) | plan.md → commit | deep |
+| executing-plans | plan → code (inline) | plan.md → commit | brief (alternative) |
+| requesting-code-review | code → review | branch/commit → review comments | medium |
+| test-driven-development | enforces TDD every phase | explicit Red→Green | brief |
+| using-git-worktrees | isolated worktree | feature-work isolation | brief |
+| finishing-a-development-branch | wrap-up | work complete → PR/cleanup | medium |
+
+## 3.1 brainstorming
+
+A skill invoked with `/superpowers:brainstorming`. It takes an idea expressed in natural language and asks the user one multiple-choice question at a time, organizing it into spec.md. It saves the decisions to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commits them.
+
+The key is "one question at a time." Rather than dumping the stack, feature scope, libraries, and tone all at once, it proceeds like a decision tree. For visual decisions like UI design, it can also bring up a visual companion (browser mockup comparison).
+
+## 3.2 writing-plans
+
+Once the spec is complete, `superpowers:writing-plans` is invoked automatically. It decomposes the spec into per-phase tasks and explicitly writes the following five steps for each task.
+
+1. Write a failing test
+2. Confirm the test fails (Red)
+3. Minimal implementation
+4. Confirm the test passes (Green)
+5. Commit
+
+Each task is one commit unit, usually 2-5 minutes of work. The plan is saved to `docs/superpowers/plans/YYYY-MM-DD-<topic>-plan.md`.
+
+## 3.3 subagent-driven-development
+
+Once the plan is ready, two execution options are presented. **subagent-driven** dispatches a new subagent for each task to isolate context. A single task goes through the following flow.
+
+1. **Implementer subagent** — receives the task instructions, writes code, tests, self-reviews, and commits
+2. **Spec compliance reviewer subagent** — verifies the implementation matches the spec exactly
+3. **Code quality reviewer subagent** — checks code quality, test gaps, and pitfalls
+
+All three stages must pass before moving to the next task. If a review finds an issue, the implementer is called again to fix → re-review. With no context contamination, one subagent is responsible for one task.
+
+## 3.4 executing-plans (alternative)
+
+An alternative that runs the same plan inline within the same session. At each step it directly updates the checkbox in the plan file to `- [x]` as it proceeds. There's no subagent dispatch cost, but also no context isolation, so on large work context contamination can accumulate.
+
+Selection criteria:
+- subagent-driven: large multi-stage work, many tasks, where the value of the review cycle is high
+- executing-plans: short and simple work, where the plan file itself serves as progress tracking
+
+## 3.5 requesting-code-review
+
+Before the entire cycle ends, you get one more comprehensive review. It bundles all commits in the branch and checks spec compliance, regressions, pitfalls, and items needing additional tests. Comments classified as critical/important/minor come back.
+
+## 3.6 test-driven-development
+
+TDD is already built into the task skeleton of writing-plans, so a separate invocation is rare. But it guides the implementer subagent to consciously follow the TDD cycle. The key is confirming, in the Red stage, that the test really fails.
+
+## 3.7 using-git-worktrees
+
+Before starting large work, it creates an isolated worktree so the current working directory isn't affected. It's often omitted for a single learning cycle, but it's recommended in real-world environments where you work on multiple features simultaneously.
+
+## 3.8 finishing-a-development-branch
+
+Invoked at the very end after all tasks are done. It presents the following as structured options.
+- choose among merge / PR / keep a separate branch
+- automatic push policy
+- branch cleanup
+
+In this article's case, I didn't invoke this skill explicitly; following the user's global policy (no arbitrary push) I ran `gh pr create` + `gh pr merge` directly—I'll revisit this in the review section.
+
+# 4. The Full Cycle Flow
+
+It becomes clear when you see, in a diagram, the order in which the core skills are woven together.
+
+```mermaid
+flowchart LR
+    A[brainstorming] --> B[writing-plans]
+    B --> C[subagent-driven-development]
+    C --> D[requesting-code-review]
+    D --> E[finishing-a-development-branch]
+```
+
+Each arrow means an automatic invocation. When brainstorming finishes writing the spec, after user approval it automatically calls writing-plans, and once the plan is written the user chooses the execution mode (subagent-driven or executing-plans). At the end, finishing-a-development-branch presents the PR/merge options.
+
+## 4.1 Points of User Intervention
+
+Across the entire flow, the points where the user must decide are as follows.
+
+| Point | What | Common Question Received |
+|---|---|---|
+| 1. During brainstorm | stack/feature scope/libraries | multiple choice like "which of A/B/C?" |
+| 2. Spec review | whether to approve the spec document | "anything to change?" |
+| 3. Plan review (optional) | approve the plan document | "shall we run it right away?" |
+| 4. Execution mode | subagent-driven vs executing-plans | "which way?" |
+| 5. Applying review comments | handling spec/quality review issues | "OK to proceed with the fixup?" |
+| 6. Wrap-up | PR / push / merge approval | "shall I push now?" |
+
+Outside these six points, it's almost all automatic. Because the points requiring human time are clear, the workflow's predictability is high.
+
+## 4.2 Tracking Method (subagent-driven vs executing-plans)
+
+Progress tracking happens in one of two places.
+
+- **subagent-driven**: an in-memory task list via TaskCreate/TaskUpdate. The `- [ ]` checkboxes in the plan file are not updated.
+- **executing-plans**: marking directly by editing the plan file to `- [x]`. The plan file itself is the progress tracker.
+
+The result is the same, but the artifacts differ. Because this article's case used subagent-driven, the plan file remained `- [ ]` to the end—I'll revisit this in the review section.
+
+## 4.3 Directory Structure
+
+The work output is organized into the following form.
+
+```
+project/
+├── docs/superpowers/
+│   ├── specs/YYYY-MM-DD-<topic>-design.md   # brainstorming output
+│   └── plans/YYYY-MM-DD-<topic>-plan.md     # writing-plans output
+├── (actual code)
+└── (tests)
+```
+
+The specs/plans are included together in the PR and become a permanent reference. Since the intent and steps of the work are recorded next to the code, even when you look back six months later it's easy to trace "why did I do it this way."
+
+# 5. Case Study: A Todo Web App from Scratch to PR (Echo + React)
+
+This section is the core of this guide. It walks step by step through the actual flow of building a learning Todo web app from brainstorm to PR/merge under `ai/superpowers/todo/` in the `tutorials-go` repository. The resulting PR is [#701](https://github.com/kenshin579/tutorials-go/pull/701).
+
+Laying out the whole flow in advance:
+
+```mermaid
+flowchart LR
+    S0["brainstorm start"] --> S1["write spec"]
+    S1 --> S2["decompose plan into 11 phases"]
+    S2 --> S3["implement Phase 0-10"]
+    S3 --> S4["MCP playwright e2e"]
+    S4 --> S5["PR / merge"]
+```
+
+Let's look at what command started each stage and what artifacts it left behind.
+
+## 5.1 Brainstorming — Up to Writing the Spec
+
+It starts with a single line, `/superpowers:brainstorming`. You pass a natural-language idea as the argument.
+
+```
+/superpowers:brainstorming I want to write sample code for a todo web application.
+- stack: react, golang 1.25, inmemory
+- I want to write the sample code here: /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers
+Note: the main purpose is to learn how to use superpowers
+```
+
+The skill immediately checks the context (go.mod, sibling directories, existing conventions), then presents multiple choices one question at a time. An excerpt of the actual questions received:
+
+| # | Question | Options |
+|---|---|---|
+| 1 | Feature scope | A minimal / B basic / C extended |
+| 2 | Backend framework | A net/http / B chi / C gin or echo |
+| 3 | Go module structure | A root module / B sub-module / C downgrade |
+| 4 | Frontend stack | Vite + React + TS or JS |
+| 5 | BE/FE integration | A separate + Vite proxy / B CORS / C static serving |
+| 6 | Test coverage | A BE full + FE smoke / B both full / C BE only |
+| 7 | Filter/sort location | A server-side / B client-side |
+
+Each question shows a recommendation (one of A/B/C) along with an explanation of the trade-offs. After passing the 7 questions, a 9-section spec.md (`2026-04-30-todo-app-design.md`, 600+ lines) is generated automatically, ambiguities are reinforced inline via self-review, and then a user review gate opens.
+
+Once approved, the next skill is invoked automatically.
+
+## 5.2 Writing-plans — Decomposing the Plan into 11 Phases
+
+`superpowers:writing-plans` reads the spec and creates a task-unit plan. In the Todo case, it was decomposed into the following 11 stages.
+
+| Phase | Content | TDD Applied |
+|---|---|---|
+| Pre-flight | feature branch + spec/plan commit | — |
+| 0 | directory/Makefile/.gitignore + backend main.go stub + Vite setup | — |
+| 1 | domain model (Priority/Todo/Validate) | ✅ |
+| 2.1 | Store CRUD + concurrency verification | ✅ |
+| 2.2 | Store List filter/sort | ✅ |
+| 3.1~3.3 | Handler Create/Delete/List/Update + writeError | ✅ |
+| 4 | Echo server integration + httptest | ✅ |
+| 5 | FE infrastructure (types/api/MSW) | — |
+| 6 | useTodos hook | ✅ |
+| 7 | TodoForm/FilterBar/TodoItem/TodoList | smoke |
+| 8 | App integration + e2e | ✅ |
+| 9 | README + manual verification | — |
+| 10 | invoke code-review skill + create PR | — |
+
+Each phase is one commit unit, averaging 5-10 minutes of work. The plan ran about 3500 lines, specifying the code/commands/expected output of every step.
+
+## 5.3 Subagent-driven-development — 25 commits, two-stage review
+
+This is the heart of the cycle. The following flow repeats for every phase.
+
+```mermaid
+flowchart LR
+    P["task start"] --> I["implementer subagent"]
+    I --> S["spec compliance reviewer"]
+    S --> Q["code quality reviewer"]
+    Q --> N["next task"]
+```
+
+All three subagents operate on the same task in independent contexts. In the actual case, there were two instances where this structure caught a critical issue.
+
+**Case ① — Phase 1 Korean length validation (caught by the TDD reviewer)**
+
+In the domain model's `NewTodo.Validate()`, the title length was being checked with `len()`, and the code quality reviewer pointed out the following.
+
+> `todo.go:60` — Title length uses `len()` (bytes), not runes. A 100-character Korean title is 300 bytes, so it gets rejected. In this project where Korean content is a first-class concern, this is a bug.
+
+I called the implementer again to add `utf8.RuneCountInString` + Korean boundary tests (200 chars valid / 201 chars invalid).
+
+**Case ② — Phase 10 DueDate pointer aliasing (caught by the final reviewer)**
+
+In the final review of the entire branch, the following was found.
+
+> `store.go:39, 82` — `Add`/`Update` store the caller's `*time.Time` pointer as-is. The package GoDoc promises "callers cannot mutate stored state through returned references," but this promise is broken.
+
+I added a defensive copy (a `copyTimePointer` helper) and included regression tests (`TestStore_Add_DueDateNotAliased`, `TestStore_Update_DueDateNotAliased`) along with it.
+
+An excerpt of the representative commit flow:
+
+| Phase | Commit | Notes |
+|---|---|---|
+| Pre-flight | `[feat/todo-app] docs: add spec and implementation plan` | feat/todo-app branch start |
+| 0.1 | `chore: project skeleton (README, Makefile)` | — |
+| 1 | `feat: domain model (Priority, Todo, NewTodo, Patch, Validate)` | TDD Red→Green |
+| 1 fixup | `fix: count title length by rune, not byte (Korean support)` | applying reviewer comment |
+| 2.1 | `feat: in-memory Store CRUD (Add/Get/Update/Delete)` | sync.RWMutex |
+| 4 | `feat: Echo server integration (routing/middleware/CORS) + httptest integration tests` | backend complete |
+| 6 | `feat: useTodos hook (useReducer + create/update/remove + auto refetch)` | FE core |
+| 8 | `feat: App assembly + integration scenario tests (MSW full round-trip)` | FE integration |
+| 10 fixup | `fix: Store defensively copies DueDate pointer to block external mutation` | final reviewer comment |
+
+A total of 25 commits piled up on the feat/todo-app branch.
+
+## 5.4 Creating and Merging the PR
+
+Branch push + PR creation + merge are each one line of command.
+
+```bash
+# push
+git push -u origin feat/todo-app
+
+# create PR (HEREDOC per CLAUDE.md policy)
+gh pr create --title "feat: superpowers todo app (learning sample)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Echo + React + in-memory Todo web application (for learning)
+- fully experienced the superpowers plugin skill cycle
+... (omitted)
+EOF
+)" --assignee kenshin579
+
+# merge
+gh pr merge 701 --merge --delete-branch
+```
+
+Result: [PR #701](https://github.com/kenshin579/tutorials-go/pull/701) merged, integrated into master. From the start of work to merge, it finished within a single session.
+
+![Todo app final screen — header count, segmented filter, priority color badge, line-through on completed items, due date subtext](todo-app-final.png)
+
+# 6. Getting Started
+
+The procedure needed to adopt superpowers for the first time is short.
+
+## 6.1 Installing the Plugin
+
+Install it via the marketplace in Claude Code.
+
+```bash
+/plugin install superpowers@anthropic
+```
+
+(Check the exact command on the [Anthropic Plugin Marketplace page](https://www.anthropic.com/engineering/claude-code-plugins). The channel/name may differ depending on the point in time.)
+
+After installation, you're good if you see slash commands starting with `/superpowers:` in a new session.
+
+## 6.2 Starting the First Cycle
+
+```bash
+/superpowers:brainstorming <a line or two of the idea in natural language>
+```
+
+After that, just follow this flow as-is.
+
+1. Answer 7-10 multiple-choice questions
+2. Review the auto-generated spec.md (you can request 1-2 rounds of changes)
+3. Run the automatically invoked writing-plans
+4. Review the generated plan.md
+5. Choose the execution mode (subagent-driven recommended)
+6. Implementation proceeds automatically (occasionally enter additional context when it gets stuck)
+7. Apply the final review comments
+8. Create the PR (after user approval)
+
+## 6.3 Recommended Preparation
+
+- **Spell out the CLAUDE.md policy**: if you write your push/PR automation policy in CLAUDE.md, the skill respects it (e.g., "DO NOT push without explicit consent").
+- **Code convention rules**: if you write code-style/test conventions in `.claude/rules/*.md`, the reviewer subagent checks against them (e.g., `gofmt`, `testify/assert`, `GoDoc`, etc.).
+
+## 6.4 Directory Structure (recap)
+
+```
+project/
+├── docs/superpowers/
+│   ├── specs/   # brainstorming output
+│   └── plans/   # writing-plans output
+├── code/
+└── tests/
+```
+
+Commit the specs/plans together with the PR to leave them as a permanent reference. When you look back six months later, the answer to "why did I structure it this way" is right there.
+
+# 7. What I Felt After Actually Trying It (honest review)
+
+That's it for the guide-style information. This section is "observations from someone who actually ran one cycle." Please bear with a slightly informal tone.
+
+## What I Liked
+
+- **The entire development flow connects naturally**: previously, I had to manually write a PRD → implementation plan → todo.md separately and review markdown at each stage, which took quite a bit of time. Superpowers ties brainstorm → spec → plan → implementation → review into one flow, so each stage's output naturally becomes the input to the next, and the documentation and review cost the worker spends drops significantly
+- **Almost zero context contamination**: when a task ends, the context is cleaned up along with the implementer subagent → the reason I could finish a large PR (25 commits) in one session
+- **The two-stage spec/quality review pulls PR review cost inside the cycle**: critical issues that pass compilation/tests (Korean rune count, DueDate aliasing) and a regression gap (a Vitest e2e config bug) were all discovered and fixed mid-cycle
+
+## Costs and Trade-offs
+
+- **Token usage ramps up fast**: each task accumulates 3 dispatches—implementer + spec/quality reviewer—so consumption is heavy. Even on the Claude Max 100x plan, I experienced hitting a rate limit mid-cycle
+- **Plan file checkboxes are not auto-updated**: subagent-driven tracks via an in-memory task list, and plan.md stays `- [ ]` to the end. If you want to use the plan as a permanent tracker, executing-plans is a better fit
+
+## Recommended Application Scenarios
+
+In short: **most powerful for multi-stage + multi-area work**; for a single-file edit, a regular slash command is faster.
+
+| Fit | Work Type | Reason |
+|---|---|---|
+| ✅ Very good | multi-stage feature implementation, domain + API + UI all at once | phase separation keeps context clean, TDD applies naturally |
+| ✅ Good | redesign/refactoring | the two-stage review quickly catches regression risk |
+| ✅ Good | learning/onboarding material | the cycle itself becomes reproducible learning material |
+| 🟡 Average | small changes to one or two files | dispatch cost is large relative to value—controller-level handling is enough |
+| ❌ Unsuitable | one-line fix, simple typo | only formalism cost arises |
+| ❌ Unsuitable | deep debugging (debugger step-through) | superpowers does combine with debugging skills, but the cycle skeleton itself doesn't suit debugging |
+
+# 8. Conclusion
+
+Run one cycle of Superpowers and one thing becomes clear. **The efficiency of AI coding is influenced more by workflow structure than by the quality of individual prompts.** With the same model and the same code-writing ability, forcing the flow of brainstorm → plan → impl → review → finish substantially raises the consistency and regression stability of the output.
+
+Three lines of key takeaways:
+
+1. **It's powerful for multi-stage work.** The scenario of building Domain + API + UI all at once is the sweet spot. For a one-line fix, it's overkill.
+2. **The two-stage review catches issues that were invisible.** Even when compilation/tests pass, the promise between spec and code can be broken, and the reviewer verifies that.
+3. **It's very good as learning/onboarding material.** The cycle itself remains in spec/plan in a reproducible form.
+
+Things worth trying next:
+
+- isolate multiple work with `using-git-worktrees`
+- inline execution with `executing-plans` (auto-updating plan checkboxes)
+- formally invoke the `finishing-a-development-branch` skill to be presented with PR/cleanup options
+
+These three are the parts missing from this case, so I'll cover them separately in a follow-up article, or I'd love to hear the experiences of those who have tried them directly.
+
+# 9. References
+
+- [Anthropic Claude Code official docs](https://docs.claude.com/en/docs/claude-code)
+- [Claude Code Plugin Marketplace guide](https://www.anthropic.com/engineering/claude-code-plugins)
+- This case's PRs: [tutorials-go #701 (full Todo implementation)](https://github.com/kenshin579/tutorials-go/pull/701), [#702 (FE theme redesign)](https://github.com/kenshin579/tutorials-go/pull/702)
+- [Complete Guide to Claude Code Extensions: Command, Skill, Subagent](/articles/claude-code-확장-기능-완벽-가이드-command-skill-subagent)
+- [Complete Guide to Claude Code Plugin Hooks](/articles/claude-code-plugin-hooks-완벽-가이드)
+- [Claude Code MCP Recommendation Guide](/articles/claude-code-mcp-추천-가이드)

--- a/contents/ai/claude-code-멀티-계정-전환-가이드/index_en.md
+++ b/contents/ai/claude-code-멀티-계정-전환-가이드/index_en.md
@@ -1,0 +1,188 @@
+---
+title: "Claude Code Multi-Account Switching Guide: Keep Working Without Interruption Even When Rate Limited"
+description: "A configuration guide for quickly switching between personal and work accounts in Claude Code using OAuth and API Key authentication to work without interruption from rate limits"
+date: 2026-02-28
+update: 2026-02-28
+tags:
+  - Claude Code
+  - Claude
+  - 멀티 계정
+  - API Key
+  - OAuth
+  - rate limit
+  - 계정 전환
+series: "Claude Code 실전 가이드"
+---
+
+# 1. Overview
+
+Have you ever been working with Claude Code only to suddenly hit a rate limit and have your work grind to a halt? If you have both a personal account and a work account, you can switch to the other account and immediately continue working.
+
+In this article, I'll summarize the differences between Claude Code's two authentication methods (OAuth / API Key) and introduce how to configure account switching for each situation.
+
+# 2. OAuth vs API Key: Different Billing Systems
+
+Before setting up account switching, there's a core concept you absolutely need to understand: **OAuth login and API Key are completely separate billing systems**.
+
+| Category | OAuth (`claude auth login`) | API Key (`ANTHROPIC_API_KEY`) |
+|------|---------------------------|-------------------------------|
+| Billing method | Pro/Team **plan subscription** (monthly fee) | **Prepaid API credits** (deducted by usage) |
+| Where to fund | Plan subscription on claude.ai | [console.anthropic.com](https://console.anthropic.com) → Billing |
+| Characteristics | Usage included in subscription | Error occurs when credits are not funded |
+
+Even if you're subscribed to a Pro plan, if you have no API credits, the API Key method produces the following error.
+
+```
+Credit balance too low · Add funds: https://platform.claude.com/settings/billing
+```
+
+## 2.1 Beware of Auth Conflict
+
+If an OAuth session and an API Key **exist at the same time**, a conflict error occurs.
+
+```
+Auth conflict: Both a token (claude.ai) and an API key (ANTHROPIC_API_KEY) are set.
+This may lead to unexpected behavior.
+```
+
+**Key principle: the two authentication methods must not exist simultaneously.** When switching, you must always disable one of them.
+
+- If you want to use the API Key → `claude auth logout` (remove the OAuth session)
+- If you want to use OAuth → `unset ANTHROPIC_API_KEY` (remove the environment variable)
+
+# 3. Comparison of Account Switching Methods
+
+| Method | Pros | Cons |
+|------|------|------|
+| OAuth switching function | Use the plan subscription as-is, no extra cost | Requires browser login (slow) |
+| API Key environment variable switching | Instant switching, fastest | Requires separately funding API credits |
+| Hybrid (recommended) | OAuth normally + API Key in emergencies | Requires initial setup |
+
+# 4. Recommended Strategies by Situation
+
+## 4.1 Case A: Both Accounts on Pro/Team Plans (My Case)
+
+**Recommended: OAuth switching function**
+
+In my case, both my personal account and work account are subscribed to Pro plans, so I use this method. You can use it within your plan subscription without extra billing, and although switching requires a browser login, you can simplify it with a shell function.
+
+## 4.2 Case B: When Fast Switching Is Important
+
+**Recommended: OAuth normally + API Key in emergencies (hybrid)**
+
+You use your main account with OAuth, fund a small amount ($5–10) of API credits in advance, and temporarily switch to the API Key only when you hit a limit. This is the most practical combination.
+
+# 5. Configuration
+
+## 5.1 Case A: OAuth Switching Function
+
+Add the following function to `~/.zshrc`.
+
+```bash
+cs() {
+  echo "🔄 Switching account..."
+  claude auth logout
+  echo "✅ Logout complete. Run claude, then re-authenticate with /login."
+}
+```
+
+**OAuth re-login flow:**
+
+`claude auth login` prints an authentication link in the terminal, but you can't enter the authentication code that is issued after browser approval back into the terminal. Therefore, you need to run `claude` first and then use the `/login` command inside the REPL.
+
+1. Run `cs` → log out of the existing OAuth session
+2. Run `claude` → enter the Claude Code REPL
+3. Enter `/login` in the REPL
+4. The browser opens automatically → log in with the account you want to switch to
+5. Paste the issued authentication code into the REPL → authentication complete
+
+```bash
+# When you hit a limit
+cs
+# → logout complete
+
+claude
+# → after entering the REPL
+/login
+# → browser opens → select the other account → paste the authentication code into the REPL
+```
+
+## 5.2 Case B: API Key Switching (Hybrid)
+
+### Prerequisite: Issue an API Key
+
+1. Go to [console.anthropic.com](https://console.anthropic.com)
+2. Settings → API Keys → Create Key
+3. Store the key securely (it's only shown once)
+4. **Funding credits in Settings → Billing is required**
+
+### ~/.zshrc configuration
+
+```bash
+# An Auth conflict occurs if OAuth and the API Key exist at the same time
+# When switching, you must always disable one of them
+
+claude-work() {
+  claude auth logout 2>/dev/null
+  export ANTHROPIC_API_KEY="sk-ant-work-key"
+  echo "✅ Switched to work account (API Key)"
+}
+
+claude-personal() {
+  claude auth logout 2>/dev/null
+  export ANTHROPIC_API_KEY="sk-ant-personal-key"
+  echo "✅ Switched to personal account (API Key)"
+}
+
+claude-oauth() {
+  unset ANTHROPIC_API_KEY
+  echo "✅ API Key removed. Run claude, then re-authenticate OAuth with /login."
+}
+```
+
+### Usage
+
+```bash
+source ~/.zshrc
+
+# Normally: use OAuth (Pro/Team plan)
+claude
+
+# When you hit a limit → switch to API Key instantly
+claude-work
+claude
+
+# Return to OAuth (plan) again
+claude-oauth
+claude
+# → /login in the REPL → browser authentication → paste code
+```
+
+# 6. FAQ
+
+**Q: Does this affect Claude Desktop?**
+
+No. Claude Desktop is based on a separate OAuth and is completely independent of Claude Code's `ANTHROPIC_API_KEY` environment variable.
+
+**Q: I'm subscribed to a Pro plan, so why doesn't it work when I switch to an API Key?**
+
+A Pro/Team plan subscription and API credits are separate billing systems. Even if you're subscribed to a plan, to use the API you must separately fund credits at [console.anthropic.com](https://console.anthropic.com).
+
+**Q: What if I set the environment variable while logged in with OAuth?**
+
+An Auth conflict error occurs. If Claude Code detects both authentication methods at the same time, it prioritizes the API Key, which can lead to an insufficient credit error. Be sure to disable one of them. (`claude auth logout` or `unset ANTHROPIC_API_KEY`)
+
+# 7. Conclusion
+
+To summarize:
+
+- Always be aware that **OAuth and API Key are separate billing systems**
+- Pro/Team plan users → recommend the **OAuth switching function (`cs`)**
+- If you need fast switching → combine **funding a small amount of API credits + environment variable switching**
+- The two authentication methods must not exist simultaneously. Always disable one when switching
+- Unrelated to Claude Desktop
+
+# 8. References
+
+- [Anthropic Console - Issue an API Key](https://console.anthropic.com)
+- [Claude Code official documentation](https://docs.anthropic.com/en/docs/claude-code)

--- a/contents/ai/claude-code-확장-기능-완벽-가이드-command-skill-subagent/index_en.md
+++ b/contents/ai/claude-code-확장-기능-완벽-가이드-command-skill-subagent/index_en.md
@@ -1,0 +1,898 @@
+---
+title: "The Complete Guide to Claude Code Extensions: Command, Skill, Subagent"
+description: "Organizes the concepts and differences between Claude Code's core extension mechanisms—Command, Skill, and Subagent—and explores how to use them in practice."
+date: 2026-03-24
+update: 2026-03-24
+tags:
+  - Claude Code
+  - AI
+  - Skill
+  - Subagent
+  - Command
+  - 서브에이전트
+  - 슬래시커맨드
+  - AI코딩도구
+  - 워크플로우자동화
+series: "Claude Code 완벽 가이드"
+---
+
+# 1. Overview
+
+![Claude Code](image-20260206193705314.png)
+
+Claude Code is an AI-powered CLI tool built by Anthropic that reads and modifies code directly in the terminal and performs a wide range of development tasks. It goes beyond simple question-and-answer interactions to autonomously handle file exploration, code modification, Git operations, and test execution—an agentic coding tool.
+
+Using Claude Code with its default configuration is already productive enough, but when repetitive work patterns emerge or you want to apply project-specific rules, you need **extensions**. Claude Code provides three core mechanisms for this.
+
+| Category | Custom Commands | Skills | Subagents |
+|------|----------------|--------|-----------|
+| **Definition** | Reusable prompt shortcuts | Extension system that injects knowledge/guidelines | Specialized agents that work in an isolated context |
+| **Location** | `.claude/commands/` | `.claude/skills/<name>/SKILL.md` | `.claude/agents/<name>.md` |
+| **Invocation** | `/name` (user manual) | `/name` (manual) + automatic invocation possible | Claude delegates automatically or on user request |
+| **Execution context** | Main conversation (inline) | Main conversation (inline), isolated with `context: fork` | Separate context window (isolated) |
+| **Tool restriction** | None | Restricted via `allowed-tools` | Fine-grained control via `tools`/`disallowedTools` |
+| **Parallel execution** | Not possible | Not possible | Possible (multiple subagents run concurrently) |
+
+These three look similar, but **they break problems down in fundamentally different ways**. This article organizes the concept, configuration, and practical examples of each, and discusses when to choose which.
+
+> The example code used in this article is available in the [tutorials-go/.claude](https://github.com/kenshin579/tutorials-go/tree/master/.claude) repository.
+
+# 2. Command (Slash Command)
+
+## 2.1 Concept
+
+A Command is a prompt template that the user runs directly by typing `/`. It acts as a **shortcut** that stores a frequently repeated task as a single command and invokes it when needed.
+
+Key characteristics:
+- **Invoked directly by the user** (`/commit`, `/plan-task`, etc.)
+- **One-time execution**: the prompt is injected at invocation time and Claude executes it immediately
+- **Argument passing supported**: parameters passed in the form `/command arg1 arg2`
+- **Autocomplete support**: typing `/` displays the list of available commands
+- **Inline execution in the main conversation context** (no separate isolation)
+
+### 2.1.1 Storage Location
+
+```
+~/.claude/commands/        # Global (used across all projects)
+.claude/commands/          # Project-specific (used only in that project)
+```
+
+Global commands are used commonly across all projects, while project commands can be stored in the `.claude/commands/` directory and shared with teammates via Git.
+
+Using subdirectories creates namespace separation.
+
+```
+.claude/commands/
+├── commit.md            # /commit
+├── plan-task.md         # /plan-task
+├── start-task.md        # /start-task
+└── work/                # Namespace (group commands via subdirectory)
+    ├── commit-pr.md     # /work:commit-pr
+    └── start-task.md    # /work:start-task
+```
+
+## 2.2 Practical Example: Repetitive Work in a Single Slash
+
+### 2.2.1 Git Commit Automation (`/commit`)
+
+This is the most basic form of a Command—a simple prompt template.
+Instead of repeating `git add`, `git commit`, and `git push` every time you modify code, a single `/commit` automates everything from analyzing changes to generating the commit message to pushing.
+
+`.claude/commands/commit.md`:
+
+```markdown
+## Purpose
+Commit modified files and push to the remote repository
+
+## Execution Steps
+1. Check changes with `git status`
+2. If the current branch is main/master:
+   - Create a new branch in the format `feature/{summary-of-work}`
+3. Stage changed files (`git add`)
+4. Write the commit message (conventional commits format)
+5. Push to the remote repository
+
+## Rules
+- No direct commits to the main/master branch
+- Commit message format: `type: brief description`
+  - type: feat, fix, docs, refactor, test, chore, etc.
+```
+
+**Usage**: After modifying code, type `/commit` and Claude analyzes the changes, automatically generates a conventional commit message, and commits.
+
+### 2.2.2 Generating Implementation Docs from a PRD (`/plan-task`)
+
+This is an example of a Command that takes arguments using `$ARGUMENTS`.
+Instead of manually creating an implementation document and todo checklist every time after writing a PRD (requirements document), you just pass the PRD path and Claude analyzes it and generates them automatically.
+
+`.claude/commands/plan-task.md`:
+
+```markdown
+## Purpose
+Generate an implementation document and todo checklist based on $ARGUMENTS (requirements file)
+
+## Arguments
+- $ARGUMENTS: requirements file path (e.g., docs/start/1_feature_prd.md)
+
+## Execution Steps
+1. Read and analyze the requirements file ($ARGUMENTS)
+2. Generate the implementation document ({order}_{feature-name}_implementation.md)
+   - Include only the core implementation details
+   - Exclude unnecessary content such as future plans and extensibility
+3. Generate the todo checklist ({order}_{feature-name}_todo.md)
+   - Break it into stages
+   - Each item in checkbox format (- [ ])
+
+## File Generation Rules
+- Create in the same directory as the requirements file
+- Filename pattern: `{order}_{feature-name}_{document-type}.md`
+
+## Example
+Input: `/plan-task docs/start/1_github_action_prd.md`
+
+Output:
+- `docs/start/1_github_action_implementation.md`
+- `docs/start/1_github_action_todo.md`
+```
+
+**Usage**: Typing `/plan-task docs/start/3_claude_prd.md` analyzes the PRD and automatically generates the implementation document and todo checklist.
+
+**Key point**: It takes user arguments via `$ARGUMENTS` and operates dynamically. Although it is a multi-stage workflow of read file -> analyze -> generate file, it still runs inline in the main conversation context.
+
+### 2.2.3 Starting a Task (`/start-task`)
+
+This is an example of a composite-workflow Command that combines multiple tools (GitHub MCP, Git).
+When starting development of a new feature, it handles GitHub Issue creation, feature branch creation, and work environment setup with a single command. It demonstrates how Commands can extend beyond simple prompts to integrate external tools.
+
+`.claude/commands/start-task.md`:
+
+```markdown
+## Purpose
+Start work based on $ARGUMENTS (PRD document)
+
+## Arguments
+- $ARGUMENTS: PRD document path (e.g., docs/start/3_claude_prd.md)
+
+## Execution Steps
+1. Create a GitHub Issue (using GitHub MCP)
+   - title: PRD title
+   - body: summary of PRD content
+   - assignee: kenshin579
+2. Pull the latest code from the master branch
+3. Create a new feature branch: `feature/{issue-number}-{feature-name}`
+4. If a todo file exists, proceed with the work in order
+5. On completion of each step:
+   - Commit the changes
+   - Mark the item as done in the todo file (- [x])
+
+## Rules
+- No direct commits to the master branch
+- Follow the step order in the todo file
+- Commit messages in conventional commits format
+
+## Example
+Input: `/start-task docs/start/3_claude_prd.md`
+
+Behavior:
+1. Create GitHub Issue #607: "Claude Code Skills vs Commands vs Subagents blog examples"
+2. Create branch `feature/607-claude-blog-examples`
+3. Start work in the order of the todo file
+```
+
+**Key point**: After generating the implementation document and todo with `/plan-task`, you can kick off the actual work with `/start-task`—**workflow chaining between Commands** is possible. This is a composite Command that combines GitHub MCP + Git commands.
+
+# 3. Skill
+
+## 3.1 Concept
+
+A Skill is a **knowledge package that Claude automatically detects and loads**. While the user can invoke it directly, the core feature is that Claude analyzes the current task context and automatically activates the relevant Skill.
+
+Key characteristics:
+- **Automatically invoked by the model**: Claude judges relevance and loads it without the user explicitly running it
+- **Manual invocation also possible**: with `user-invocable: true`, you can invoke it directly via `/skill-name`
+- **Progressive Disclosure**: it first scans the metadata (about 100 tokens) and loads the full content (under 5,000 tokens) only when relevant
+- **Folder-based structure**: auxiliary files (templates, references, scripts) can be packaged together
+- **Tool restriction possible**: `allowed-tools` restricts the tools the Skill can use
+- **Isolated execution possible**: with `context: fork`, it runs in a separate context (the boundary with Subagents)
+
+### 3.1.1 Storage Location
+
+```
+~/.claude/skills/          # Global (personal)
+.claude/skills/            # Project-specific
+```
+
+Each Skill is organized as an independent folder.
+
+```
+.claude/skills/
+├── go-convention/
+│   └── SKILL.md
+├── go-project-layout/
+│   └── SKILL.md
+├── api-convention/
+│   └── SKILL.md
+└── analyze-codebase/
+    └── SKILL.md
+```
+
+### 3.1.2 SKILL.md Frontmatter Fields
+
+| Field | Required | Description |
+|------|------|------|
+| `name` | O | Unique name of the Skill |
+| `description` | O | Purpose description (**the key to automatic activation**) |
+| `user-invocable` | X | `true` allows manual invocation via `/name`; `false` makes it Subagent-only |
+| `allowed-tools` | X | Restricts usable tools (uses all when omitted) |
+| `context` | X | Setting `fork` runs it isolated in a separate context |
+| `agent` | X | The agent type to use with `context: fork` |
+| `model` | X | The model to use (`sonnet`, `opus`, `haiku`) |
+
+> **Note on the `agent` field**: Built-in types include `Explore` (code exploration, read-only), `Plan` (implementation-plan research), and `general-purpose` (general, default). You can also specify the name of a custom agent defined in `.claude/agents/`.
+
+## 3.2 Practical Example: Project Knowledge Injected Automatically
+
+### 3.2.1 Go Coding Convention (`go-convention`)
+
+This example demonstrates a Skill's core features: "automatic invocation" and "knowledge injection."
+When you request "write some Go code," Claude looks at the `description` and automatically activates the Skill. At that point, the coding rules written in the SKILL.md body are loaded into the main conversation's context as if they were a system prompt—this is "knowledge injection." The injected knowledge persists until the conversation ends, so subsequent code generation or reviews automatically follow the conventions without separate instructions.
+
+`.claude/skills/go-convention/SKILL.md`:
+
+```markdown
+---
+name: go-convention
+description: Apply the project's coding conventions when writing or reviewing Go code.
+  Used automatically when creating, modifying, or reviewing Go files.
+model: haiku
+user-invocable: true
+allowed-tools: Read, Grep, Glob
+---
+
+## This Project's Go Coding Conventions
+
+### Package Structure
+- Test files are placed in the same directory as the source file: `*_test.go`
+- Mock files are created in the `mocks/` subdirectory
+- Each directory is organized as an independent example (may have its own `go.mod`)
+
+### Test Writing Rules
+- Use testify: `github.com/stretchr/testify/assert`
+- Apply the table-driven test pattern
+- Test function name: `Test{FunctionName}_{Scenario}` format
+
+### Error Handling
+- For custom error types, use `errors.New()` or `fmt.Errorf("context: %w", err)`
+- Define sentinel errors as package-level variables: `var ErrNotFound = errors.New("not found")`
+
+### Import Ordering
+- Order: standard library → external packages → internal packages
+- Internal package alias: use an underscore prefix (`_articleHttp`)
+```
+
+**Behavior scenario**:
+1. **Automatic invocation**: When the user requests "create a new Go file," Claude recognizes the "creating, modifying Go files" wording in the `description`, automatically loads this Skill, and applies the conventions
+2. **Manual invocation**: Invoke `/go-convention` directly to check whether existing code follows the conventions
+
+**Key points**:
+- The trigger condition in the `description` is clear, so Claude **automatically invokes** it as appropriate (the key difference from a Command)
+- `user-invocable: true` also enables manual invocation
+- The knowledge is injected into the main conversation and **continues to influence** later work
+
+### 3.2.2 Go Project Layout (`go-project-layout`)
+
+When you use the `` !`shell command` `` syntax in the SKILL.md body, the shell command runs at the moment the Skill is activated and its result is inserted into the body. This is called "dynamic context."
+For example, if you write `` !`tree project-layout/ -L 3` ``, the `tree` command runs each time the Skill loads and injects the actual directory structure into the context. Unlike writing the structure directly as static text, this always reflects the latest state even when the project structure changes.
+
+Any command runnable in a shell can be used, so Python scripts or pipe combinations are also possible.
+
+```bash
+# Run a Python script
+!`python3 scripts/generate_context.py`
+
+# Pipe combination
+!`cat config.json | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2))"`
+```
+
+> However, since it runs every time the Skill is activated, a long-running script can delay Skill loading.
+
+`.claude/skills/go-project-layout/SKILL.md`:
+
+```markdown
+---
+name: go-project-layout
+description: Apply a clean architecture folder structure when creating a new Go project
+  or changing its structure.
+model: haiku
+user-invocable: true
+allowed-tools: Read, Grep, Glob
+---
+
+## Reference Project Structure
+
+Below is the clean architecture layout used in this project.
+Follow this structure when creating a new Go project.
+
+!`tree project-layout/go-clean-arch-v2 -I vendor -L 3`
+
+## Roles by Layer
+
+### `cmd/`
+- Application entry point (`main.go`)
+- DI container setup, server startup
+
+### `domain/`
+- Core business entities (struct)
+- Repository/use case interface definitions
+- Error type definitions (`errors.go`)
+- Mock files located in `domain/mocks/`
+
+### `{domain-name}/` (e.g., `article/`, `author/`)
+- `handler.go`: HTTP handlers (Echo routing)
+- `usecase.go`: business logic implementation
+- `repository.go`: data access implementation
+- `*_test.go`: tests for each file
+
+### `pkg/`
+- `config/`: Viper-based configuration management
+- `database/`: DB connection setup
+- `middleware/`: common middleware such as CORS and authentication
+
+## Dependency Direction
+\```
+cmd/ → {domain}/ → domain/
+         ↓
+        pkg/
+\```
+- The domain package has no external dependencies (pure Go)
+- Domain-specific packages implement the domain interfaces
+- cmd/ is responsible for assembling all packages
+```
+
+**Key points**:
+- With `!` (a dynamic-context command), the **actual project structure is read via tree** at execution time—referencing runtime data rather than static text
+- It can be separated from `go-convention` (coding style) for **separation of concerns**
+- Later combined and used in the `api-developer` Subagent via `skills: [go-project-layout]`
+
+### 3.2.3 Codebase Analysis with `context: fork` (`analyze-codebase`)
+
+This example shows that a Skill can run in an isolated context like a Subagent.
+Because it runs in a separate context via `context: fork`, it can analyze a large number of files without consuming the main conversation's context window and returns only the result.
+
+`.claude/skills/analyze-codebase/SKILL.md`:
+
+```markdown
+---
+name: analyze-codebase
+description: Analyzes and summarizes the structure of a codebase
+model: sonnet
+user-invocable: true
+context: fork
+agent: Explore
+---
+
+Analyze the codebase at the $ARGUMENTS path.
+
+## Analysis Items
+1. **Directory structure**: file and package organization
+2. **Core types/interfaces**: list of key structs and interfaces
+3. **Dependencies**: dependency relationships between external libraries and internal packages
+4. **Test status**: presence of test files, test patterns (testify, testcontainers, etc.)
+5. **Entry point**: main.go or the main executable file
+
+## Output Format
+Summarize in markdown, referencing each file in `filename:line-number` format
+```
+
+**Usage**: Running `/analyze-codebase golang/concurrency` has the Explore agent analyze that directory in a separate context and return only the result to the main conversation.
+
+**Key points**:
+- Using `context: fork` makes the Skill **run isolated in a separate context**
+- `agent: Explore` specifies the agent type to use (optimized for fast exploration)
+- Reading a large number of files does not pollute the main context window
+- The point where the boundaries of Skills and Subagents meet: **Skill format + Subagent execution model**
+
+## 3.3 Skill vs CLAUDE.md
+
+Both provide knowledge to Claude, but there is a fundamental difference.
+
+| Comparison | CLAUDE.md | Skill |
+|----------|-----------|-------|
+| Loading timing | Always loaded at conversation start | Loaded only when relevant work is detected |
+| Token consumption | Always occupies context | Consumed only when needed (progressive loading) |
+| Structure | Single file | Folder (can include auxiliary files) |
+| Purpose | Project-wide rules and conventions | Specialized knowledge for specific tasks |
+
+**Decision criterion**: Putting rules that are always needed in every conversation in `CLAUDE.md`, and separating specialized knowledge needed only in specific situations into `Skill`, is how to use context efficiently.
+
+## 3.4 Improving Automatic Activation
+
+If a Skill does not activate automatically as intended, you can use a Hook to explicitly trigger activation. A Hook registers a regex matcher on the `UserPromptSubmit` event in `.claude/settings.json`, so that when the user input matches the pattern, it instructs Claude to use a specific Skill.
+
+**Example 1**: Force-activate the `subagent-creator` Skill on requests like "create a subagent"
+
+```json
+// .claude/settings.json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "sub-?agent|custom agent|에이전트 만들",
+        "command": "echo 'Use Skill(subagent-creator)'"
+      }
+    ]
+  }
+}
+```
+
+When the user types "create a subagent" or "create a custom agent," Claude automatically loads the `subagent-creator` Skill and guides the agent-creation process.
+
+**Example 2**: Force-activate the `go-convention` Skill on Go test-related requests
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "테스트 작성|test 추가|_test\\.go",
+        "command": "echo 'Use Skill(go-convention)'"
+      }
+    ]
+  }
+}
+```
+
+When you request "write a test for this function," the `go-convention` Skill is force-loaded and conventions such as using testify and the table-driven test pattern are applied. This is useful when automatic activation via the `description` alone does not work well.
+
+# 4. Subagent
+
+## 4.1 Concept
+
+A Subagent is a **specialized agent with its own independent context window**. When the main Claude encounters a complex task, it delegates to an appropriate Subagent, which performs the work in its own context and then returns a summary of the result.
+
+Key characteristics:
+- **Independent context**: does not pollute the main conversation's context
+- **Role separation**: separated by specialized domains such as code review, debugging, and test execution
+- **Tool restriction**: `tools`/`disallowedTools` allow only the tools appropriate for the role
+- **Model selection**: a different model can be used depending on task complexity (cost savings)
+- **Skill combination**: domain knowledge is injected via the `skills` field to strengthen expertise
+- **Automatic delegation**: based on the `description`, Claude automatically delegates work at the appropriate time
+
+### 4.1.1 Storage Location
+
+```
+~/.claude/agents/          # Global (personal)
+.claude/agents/            # Project-specific
+```
+
+Each Subagent is defined as a single `.md` file.
+
+```
+.claude/agents/
+├── code-reviewer.md       # Code review specialist
+├── debugger.md            # Debugging specialist
+├── test-runner.md         # Test execution specialist
+└── api-developer.md       # API development specialist (Skill integration)
+```
+
+### 4.1.2 Frontmatter Fields
+
+| Field | Required | Description |
+|------|------|------|
+| `name` | O | Lowercase, hyphen-separated |
+| `description` | O | Purpose and invocation timing (the key to automatic delegation) |
+| `tools` | X | Comma-separated tool list (inherits all when omitted) |
+| `disallowedTools` | X | List of tools to forbid (control in the opposite direction of `tools`) |
+| `model` | X | `sonnet`, `opus`, `haiku`, `inherit` |
+| `permissionMode` | X | `default`, `acceptEdits`, `bypassPermissions`, `plan` |
+| `skills` | X | Skills to auto-load |
+
+## 4.2 Practical Example: Building Role-Specific Specialist Agents
+
+### 4.2.1 Code Review Specialist (`code-reviewer`)
+
+This example demonstrates independent execution and **read-only** tool restriction.
+It is automatically delegated to right after code is modified to perform a review, but since it has no Write/Edit tools, it cannot change the code directly and returns only feedback.
+
+`.claude/agents/code-reviewer.md`:
+
+```markdown
+---
+name: code-reviewer
+description: A professional code review specialist. Proactively reviews code quality,
+  security, and maintainability. Use right after writing or modifying code.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You are a senior code reviewer who ensures high code quality and security.
+
+When invoked:
+1. Run git diff to check recent changes
+2. Focus on the modified files
+3. Begin the review immediately
+
+Review checklist:
+- Is the code simple and readable
+- Are functions and variables well named
+- Is there duplicated code
+- Is there proper error handling
+- Are there any exposed secrets or API keys
+- Is input validation implemented
+- Is there good test coverage
+- Are performance considerations addressed
+
+Provide feedback organized by priority:
+- Critical issues (must fix)
+- Warnings (should fix)
+- Suggestions (consider improving)
+
+Include concrete code examples of how to resolve issues.
+```
+
+**Behavior scenario**:
+1. The user writes/modifies code
+2. Claude recognizes the "Use right after writing or modifying code" wording in the description
+3. Automatically delegates the work to the code-reviewer subagent
+4. The Subagent analyzes `git diff` in a separate context and returns the review result
+
+**Key point**: `tools: Read, Grep, Glob, Bash` has **no Write/Edit**. Being read-only, there is no risk of accidentally modifying code during analysis.
+
+### 4.2.2 Debugging Specialist (`debugger`)
+
+Unlike code-reviewer, this is a Subagent example that **includes Edit** to perform fixes as well.
+When a test failure or error occurs, it is automatically delegated to, analyzes the cause, and directly modifies the code to resolve the problem.
+
+`.claude/agents/debugger.md`:
+
+```markdown
+---
+name: debugger
+description: A debugging specialist for errors, test failures, and unexpected behavior.
+  Use proactively when a problem occurs.
+tools: Read, Edit, Bash, Grep, Glob
+---
+
+You are an expert debugger specializing in root cause analysis.
+
+When invoked:
+1. Capture the error message and stack trace
+2. Identify reproduction steps
+3. Isolate the failure location
+4. Implement a minimal fix
+5. Verify the fix with `go test`
+
+Debugging process:
+- Analyze error messages and logs
+- Check recent code changes (git diff, git log)
+- Form hypotheses and test them
+- Check related test files (*_test.go)
+
+For each issue, provide:
+- An explanation of the root cause
+- Evidence supporting the diagnosis (filename:line-number)
+- A concrete code fix
+- Test execution results after the fix
+
+Focus on solving the fundamental problem, not the symptoms.
+```
+
+**Key point**: With `tools: Read, Edit, Bash, Grep, Glob`, **Edit is added** compared to code-reviewer, allowing it to modify code directly. It autonomously performs the entire flow of error analysis -> cause identification -> code modification -> go test verification in a separate context.
+
+### 4.2.3 Test Execution Specialist (`test-runner`)
+
+This example demonstrates fine-grained control with `disallowedTools` and `model: haiku`.
+It is responsible only for test execution and result reporting, and is restricted from modifying code. Since it is a lightweight task, the `haiku` model is specified to optimize cost and speed.
+
+`.claude/agents/test-runner.md`:
+
+```markdown
+---
+name: test-runner
+description: A specialist that runs Go tests and analyzes the results. Use for test
+  execution requests or when test verification is needed after code changes.
+tools: Read, Bash, Grep, Glob
+disallowedTools: Write, Edit
+model: haiku
+---
+
+You are a specialist in running tests and analyzing results for Go projects.
+
+When invoked:
+1. Check the test files of the target package (*_test.go)
+2. Run `go test` (verbose + coverage)
+3. Analyze the results and generate a report
+
+Execution commands:
+- Single package: `go test -v -cover ./path/to/package/...`
+- Specific test: `go test -v -run TestFunctionName ./path/to/package`
+- All: `go test -v -cover ./...`
+
+Report format:
+- Total tests / passed / failed / skipped
+- Per failed test: test name, error message, failure location (filename:line-number)
+- Coverage: coverage % per package
+- Execution time
+
+Failure analysis:
+- Compare expected vs actual values of failed tests
+- Reference related source code (filename:line-number)
+- Estimate possible causes (do not modify code)
+
+Do not modify code directly. Provide only the analysis results.
+```
+
+**Key points**:
+- `disallowedTools: Write, Edit` explicitly forbids code modification (analysis only)
+- `model: haiku` uses a **low-cost model** for the simple run+analyze task to save costs
+- The system prompt also states "Do not modify code directly" as a double safeguard
+
+## 4.3 Comparing the Tool Combinations of the 3 Subagents
+
+| Subagent | tools | disallowedTools | model | Role |
+|----------|-------|-----------------|-------|------|
+| code-reviewer | Read, Grep, Glob, Bash | - | inherit | Read and analyze |
+| debugger | Read, Edit, Bash, Grep, Glob | - | (default) | Read, analyze, and fix |
+| test-runner | Read, Bash, Grep, Glob | Write, Edit | haiku | Run and analyze (no fixes) |
+
+They are the same kind of Subagent, but **the scope of what they can do differs completely** depending on the tool combination.
+
+## 4.4 Design Principle: "Subagent Analyzes, Main Claude Executes"
+
+The effective Subagent design pattern is the **separation of analysis and execution**.
+
+```mermaid
+flowchart LR
+    A[User request] --> B[Main Claude]
+    B -- Delegate --> C(Subagent: analyze)
+    C -- Return result --> D(Main Claude: execute)
+
+    style C fill:#e8f4fd,stroke:#1a73e8
+    style D fill:#fce8e6,stroke:#d93025
+```
+
+- **Subagent (analyze)**: uses only Read, Grep, Glob → code exploration, problem analysis, planning
+- **Main Claude (execute)**: uses Write, Edit, Bash → modifies based on the Subagent's analysis results
+
+Granting the Subagent only read-only tools provides:
+- **Safety**: no accidental file modification during the analysis stage
+- **Context preservation**: large-scale file exploration does not pollute the main conversation
+- **Result summarization**: the Subagent's work result comes back summarized, so only the essentials are conveyed
+
+> **The importance of conciseness**: A Subagent's system prompt **performs better the more concise it is**. In one experiment, reducing an 803-line agent prompt to 281 lines (a 65% reduction) raised the evaluation score from 62/100 to 82–85/100 with no loss of functionality.
+
+# 5. Subagent + Skill Integration
+
+## 5.1 API Development Specialist (`api-developer` + `api-convention` + `go-project-layout`)
+
+This example shows a Subagent preloading Skills to operate as a **specialist equipped with domain knowledge**.
+
+First is the Skill that serves as the knowledge. With `user-invocable: false`, direct invocation is blocked, but it can be used from a Subagent.
+
+`.claude/skills/api-convention/SKILL.md`:
+
+```markdown
+---
+name: api-convention
+description: RESTful API design conventions
+user-invocable: false
+---
+
+## API Design Rules
+
+### URL Naming
+- Use plural nouns: `/users`, `/articles`
+- Hierarchical relationships: `/users/{id}/articles`
+- No verbs: `/getUser` → `/users/{id}`
+
+### Response Format
+- Success: `{ "data": ..., "meta": { "page": 1, "total": 100 } }`
+- Error: `{ "error": { "code": "NOT_FOUND", "message": "..." } }`
+
+### HTTP Status Codes
+- 200: success, 201: created, 204: delete success
+- 400: bad request, 401: unauthenticated, 403: forbidden, 404: not found
+- 500: server error
+
+### Echo Framework Patterns
+- Handlers located in the `http/` directory
+- Route groups: `e.Group("/api/v1")`
+- Middleware: CORS and JWT verification applied at the group level
+```
+
+And here is the executor Subagent that leverages this knowledge.
+
+`.claude/agents/api-developer.md`:
+
+```markdown
+---
+name: api-developer
+description: A professional developer who implements API endpoints. Designs and implements
+  RESTful APIs based on the Echo framework.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: sonnet
+skills:
+  - api-convention
+  - go-project-layout
+---
+
+You are an API development specialist based on the Go Echo framework.
+
+When invoked:
+1. Define the domain model (struct) of the requested API
+2. Design the repository interface
+3. Implement the use case (business logic)
+4. Write the HTTP handler
+5. Register the router
+6. Write tests
+
+Project structure (clean architecture):
+- `domain/`: entities and interfaces
+- `repository/`: data access implementation
+- `usecase/`: business logic
+- `http/`: handlers and routers
+
+Be sure to follow the rules of the preloaded api-convention and go-project-layout skills.
+```
+
+**Behavior scenario**:
+1. The user requests "add a user CRUD API"
+2. Claude delegates to the api-developer subagent
+3. When the Subagent starts, it automatically loads the contents of the `api-convention` and `go-project-layout` Skills
+4. Implements the endpoints while adhering to the API conventions and project structure
+
+**Key points**:
+- `skills: [api-convention, go-project-layout]` injects domain knowledge into the Subagent
+- The Skill's `user-invocable: false` blocks direct invocation but allows use from a Subagent
+- The role split of **Skills = knowledge, Subagents = executors** is clear
+
+# 6. When Should You Use Which?
+
+## 6.1 Decision Tree for Choosing
+
+When you are unsure which of the three extensions to use, following the decision tree below will help you find the right choice.
+
+```mermaid
+flowchart TD
+    A["Do you repeat this task frequently?"] -- No --> B["Just ask Claude directly"]
+    A -- Yes --> C["Is it the same procedure every time?"]
+    C -- Yes --> D["Command"]
+    D -.- D1["/commit, /start-task, etc."]
+    C -- No --> E["Do you want Claude to apply it on its own?"]
+    E -- Yes --> F["Skill"]
+    F -.- F1["go-convention, go-project-layout, etc."]
+    E -- No --> G["Do you need independent analysis/processing?"]
+    G -- Yes --> H["Subagent"]
+    H -.- H1["code-reviewer, debugger, etc."]
+    G -- No --> B
+
+    style D fill:#d4edda,stroke:#28a745
+    style D1 fill:#d4edda,stroke:#28a745,stroke-dasharray: 5 5
+    style F fill:#e8f4fd,stroke:#1a73e8
+    style F1 fill:#e8f4fd,stroke:#1a73e8,stroke-dasharray: 5 5
+    style H fill:#fce8e6,stroke:#d93025
+    style H1 fill:#fce8e6,stroke:#d93025,stroke-dasharray: 5 5
+```
+
+## 6.2 Recommendations by Situation
+
+Once the decision tree has given you a rough direction, you can find a recommendation for your specific situation in the table below.
+
+| Situation | Recommendation |
+|------|------|
+| When you need a simple shortcut command | Command (`/commit`) |
+| When you take arguments and run a fixed procedure | Command (`/plan-task docs/...`) |
+| When you automatically apply coding conventions/guidelines | Skill (`go-convention`) |
+| When you need knowledge that references runtime data | Skill with `!` (`go-project-layout`) |
+| When you run independent work in isolation | Subagent (`code-reviewer`) |
+| When you restrict tools to read-only | Subagent (`tools` field) |
+| When you handle simple work with a low-cost model | Subagent (`model: haiku`) |
+| When you run multiple tasks in parallel | Subagent (multiple running concurrently) |
+| When you combine knowledge + execution | Subagent + Skill (`skills` field) |
+| When you need a Skill but with isolated execution | Skill (`context: fork`) |
+
+## 6.3 Comparison Table
+
+This table lets you compare the core differences of the three features at a glance. In particular, advanced features such as tool restriction, model selection, and parallel execution are supported only by Skills and Subagents.
+
+| Criterion | Command | Skill | Subagent |
+|------|---------|-------|----------|
+| **Invocation method** | User direct (`/command`) | Automatic + manual | Claude automatic delegation |
+| **Context** | Injected into main conversation | Loaded into main conversation (`fork` possible) | Separate context |
+| **State persistence** | None (one-time) | Persists within the conversation | Persists within the task |
+| **File structure** | Single `.md` file | Folder (SKILL.md + auxiliary files) | Single `.md` file |
+| **Tool restriction** | Not possible | Possible (`allowed-tools`) | Possible (`tools`/`disallowedTools`) |
+| **Model selection** | Not possible | Possible | Possible |
+| **Argument passing** | Possible (`$ARGUMENTS`) | Possible (`$ARGUMENTS`) | Passed via task description |
+| **Skill combination** | Not possible | Not possible | Possible (`skills` field) |
+| **Parallel execution** | Not possible | Not possible | Possible |
+
+## 6.4 Practical Tips
+
+**Understanding by analogy**:
+- **Commands** = macros (run repetitive work as a shortcut)
+- **Skills** = reference documents (spread out on your desk and referenced while working)
+- **Subagents** = teammates (work independently at a separate desk and hand back only the result)
+
+**Practical growth path**: You do not need to use all three features from the start. Introducing them step by step naturally broadens your range of use.
+
+1. **Start with Commands**: turn daily repetitive tasks (commits, deployments, PR creation) into slash commands
+2. **When patterns emerge, move to Skills**: package knowledge such as per-project coding rules and review checklists as Skills
+3. **As things get complex, move to Subagents**: separate work requiring independent analysis—like code review, debugging, and document exploration—into Subagents
+4. **Combine**: inject Skills into a Subagent to build a specialist agent equipped with domain knowledge
+
+**Watch out for anti-patterns**:
+- **Overusing Subagents**: separating even simple tasks into Subagents only increases overhead. If you do not need an independent context, a Command is enough.
+- **Using a Skill like a macro**: a Skill provides "knowledge," not the execution of a "procedure." If sequential execution is the goal, a Command is more appropriate.
+
+# 7. Summary of Constraints
+
+| Constraint | Commands | Skills | Subagents |
+|------|----------|--------|-----------|
+| Automatic invocation | Not possible | Possible (requires `description`) | Possible (requires `description`) |
+| Context isolation | Not possible | Possible via `context: fork` | Default behavior |
+| Creating another agent | Not possible | Not possible | Not possible (no nesting) |
+| Using MCP tools | Possible | Possible | Not possible during background execution |
+| Parallel execution | Not possible | Not possible | Possible |
+| Auxiliary file support | Not possible (single file) | Possible (directory structure) | Not possible (single file) |
+
+# 8. FAQ
+
+**Q. Can you also specify `model` in a Command?**
+
+A. No. A Command is a pure markdown prompt template without frontmatter, so it does not support metadata settings such as `model`. When a Command runs, the model used in the current conversation is applied as is. To specify a model, you must use a Skill (`model` field) or a Subagent (`model` field).
+
+**Q. Can you call another Subagent from within a Subagent?**
+
+A. No. Subagent nesting is not supported. If you need a complex pipeline, you must design it so that the main Claude calls multiple Subagents sequentially or in parallel.
+
+**Q. Can you use a Skill and a Command at the same time?**
+
+A. Yes. For example, while running the `/commit` Command, the `go-convention` Skill can automatically activate. Since the Skill's knowledge is injected together into the main conversation context where the Command runs, it combines so that the commit message is written by referencing the coding conventions during the commit.
+
+**Q. What is the difference between `context: fork` and a Subagent?**
+
+A. Both run in a separate context, but `context: fork` is an option of a Skill, while a Subagent is an independent agent. A Skill + `context: fork` is suitable for running a single task in isolation, whereas a Subagent is suitable when you need fine-grained control such as tool restriction, model selection, and Skill preloading.
+
+# 9. Conclusion
+
+The reason Command, Skill, and Subagent are confusing is that all three share the commonality of "customizing Claude's behavior." Summarizing the differences in one line each:
+
+- **Command**: "When I tell you to, run this procedure" (e.g., `/commit`, `/plan-task`)
+- **Skill**: "Refer to this field's specialized knowledge when needed" (e.g., `go-convention`, `go-project-layout`)
+- **Subagent**: "Hand this type of work to a separate specialist" (e.g., `code-reviewer`, `debugger`, `test-runner`)
+- **Subagent + Skill**: "Hand it to a specialist equipped with specialized knowledge" (e.g., `api-developer` + `api-convention`)
+
+The full directory structure of this article is as follows.
+
+```
+.claude/
+├── commands/
+│   ├── commit.md              # Example 1: Git Commit automation
+│   ├── plan-task.md           # Example 2: PRD → implementation doc generation
+│   └── start-task.md          # Example 3: Starting a task
+├── skills/
+│   ├── go-convention/
+│   │   └── SKILL.md           # Example 4: Go coding convention (auto-invocation)
+│   ├── go-project-layout/
+│   │   └── SKILL.md           # Example 5: Go project layout (dynamic context)
+│   ├── analyze-codebase/
+│   │   └── SKILL.md           # Example 6: Codebase analysis (context: fork)
+│   └── api-convention/
+│       └── SKILL.md           # Example 7: API convention (Subagent-only)
+└── agents/
+    ├── code-reviewer.md       # Example 8: Code review (read-only)
+    ├── debugger.md            # Example 9: Debugging (can modify)
+    ├── test-runner.md         # Example 10: Test execution (haiku, no modification)
+    └── api-developer.md       # Example 11: API development (Skill combination)
+```
+
+# 10. References
+
+- [Claude Code: Skills, Commands, Subagents, and Plugins](https://www.youngleaders.tech/p/claude-skills-commands-subagents-plugins)
+- [Claude Code Customization Guide](https://alexop.dev/posts/claude-code-customization-guide-claudemd-skills-subagents/)
+- [Claude Code Skills, Commands, Subagents 정리](https://tilnote.io/pages/695a5e15d63c6ab14589c082)
+- [Skills explained: How Skills compares to prompts, Projects, MCP, and subagents](https://rosettalens.com/s/ko/skills-explained)
+- [Skills explained 번역](https://rudaks.tistory.com/entry/Claude-%EB%B2%88%EC%97%AD-Skills-explained-How-Skills-compares-to-prompts-Projects-MCP-and-subagents)
+- [Claude Code Skills vs Plugins](https://goddaehee.tistory.com/440)
+- [tutorials-go/.claude 예제 코드](https://github.com/kenshin579/tutorials-go/tree/master/.claude)


### PR DESCRIPTION
## Summary
- `contents/ai/` 5개 글에 영어 번역본(`index_en.md`) 추가
  - Claude Code MCP 추천 가이드
  - Claude Code Plugin & Hooks 완벽 가이드
  - Claude Code Superpowers 완벽 가이드
  - Claude Code 멀티 계정 전환 가이드
  - Claude Code 확장 기능 완벽 가이드 (Command, Skill, Subagent)
- 번역 규칙 준수: 코드 로직·식별자 보존, 코드 내 한글 주석/문자열만 영어화, frontmatter `tags`/`date`/`series` 원본 유지, 이미지·내부 링크(한글 slug) 그대로 보존, Mermaid 노드 HTML 태그 미추가

## Test plan
- [ ] `npm run generate:manifest` 실행 시 5개 글이 `lang=en`으로 등록되는지 확인 (완료)
- [ ] `npm run build`로 `/en/{slug}/` 렌더 확인
- [ ] 코드 블록 동작·식별자 보존 여부 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)