### PR TITLE
feat: ai 카테고리 영어 번역 (4건)

### DIFF
--- a/contents/ai/openclaw-telegram-멀티-에이전트-구성하기/index_en.md
+++ b/contents/ai/openclaw-telegram-멀티-에이전트-구성하기/index_en.md
@@ -1,0 +1,362 @@
+---
+title: "Running Multiple AI Bots from One Gateway with OpenClaw Telegram Multi-Agent"
+description: "A step-by-step guide to running several Telegram bots independently using OpenClaw's multi-agent architecture."
+date: 2026-03-09
+update: 2026-03-09
+tags:
+  - OpenClaw
+  - Telegram
+  - AI에이전트
+  - 멀티에이전트
+  - 셀프호스팅
+  - 챗봇
+series: "OpenClaw 활용 가이드"
+---
+
+# 1. Overview
+
+OpenClaw is a **self-hosted gateway** that connects messaging apps such as WhatsApp, Telegram, and Discord to AI agents. By default a single agent handles all messages, but in real-world operations you often want to separate bots by purpose.
+
+For example:
+
+- **Alert bot**: delivers only server failure or deployment notifications
+- **Monitoring bot**: analyzes system metrics and produces reports
+- **Assistant bot**: handles everyday questions and tasks
+
+OpenClaw's **multi-agent** feature makes this kind of setup possible. Each agent runs as a completely isolated, independent "brain" and can be managed from a single Gateway.
+
+This article walks through how to configure multiple Telegram bots as OpenClaw multi-agents, step by step. The whole process proceeds in the following four steps.
+
+1. **Create Telegram bots** - Create as many bots as agents in BotFather
+2. **Add agents** - Register agents with the OpenClaw CLI
+3. **Pass bot tokens** - Hand the tokens to OpenClaw to auto-configure the bindings
+4. **Verify and run** - Check the agent list and channel status
+
+> For OpenClaw's basic concepts and installation, refer to the [Complete OpenClaw Guide](/article/openclaw-완벽-가이드) article.
+
+# 2. Multi-Agent Architecture
+
+## 2.1 Overall Structure
+
+The core of a multi-agent system is that **a single Gateway manages multiple agents and routes messages according to binding rules**.
+
+```mermaid
+flowchart LR
+    subgraph Telegram
+        B1["🤖 alerts_bot"]
+        B2["🤖 monitoring_bot"]
+        B3["🤖 assistant_bot"]
+    end
+
+    subgraph Gateway
+        R["Routing Engine\n(Bindings)"]
+    end
+
+    subgraph Agents
+        A1["Agent: alerts\n(Claude Opus)"]
+        A2["Agent: monitoring\n(Claude Sonnet)"]
+        A3["Agent: assistant\n(Claude Haiku)"]
+    end
+
+    B1 --> R
+    B2 --> R
+    B3 --> R
+    R --> A1
+    R --> A2
+    R --> A3
+```
+
+Each Telegram bot has an independent account (accountId) and is connected to a specific agent through binding rules.
+
+## 2.2 Components of an Agent
+
+Each agent has completely isolated components.
+
+| Component | Path | Role |
+|----------|------|------|
+| **Workspace** | `~/.openclaw/workspace-<agentId>/` | AGENTS.md, SOUL.md, USER.md, local files |
+| **State directory (agentDir)** | `~/.openclaw/agents/<agentId>/agent/` | Auth profiles, model registry, agent settings |
+| **Session store** | `~/.openclaw/agents/<agentId>/sessions/` | Conversation history |
+
+> **Caution**: never share the `agentDir` between agents. Sharing it causes authentication conflicts.
+
+## 2.3 Directory Structure
+
+The actual multi-agent structure on the filesystem looks like this.
+
+```mermaid
+graph TD
+    ROOT["~/.openclaw/"] --> CONFIG["openclaw.json"]
+    ROOT --> WS1["workspace-alerts/"]
+    ROOT --> WS2["workspace-monitoring/"]
+    ROOT --> AGENTS["agents/"]
+
+    WS1 --> WS1_A["AGENTS.md"]
+    WS1 --> WS1_S["SOUL.md"]
+    WS1 --> WS1_U["USER.md"]
+
+    WS2 --> WS2_A["AGENTS.md"]
+    WS2 --> WS2_S["SOUL.md"]
+    WS2 --> WS2_U["USER.md"]
+
+    AGENTS --> AG1["alerts/"]
+    AGENTS --> AG2["monitoring/"]
+
+    AG1 --> AG1_D["agent/"]
+    AG1 --> AG1_S["sessions/"]
+    AG1_D --> AG1_AUTH["auth-profiles.json"]
+
+    AG2 --> AG2_D["agent/"]
+    AG2 --> AG2_S["sessions/"]
+    AG2_D --> AG2_AUTH["auth-profiles.json"]
+```
+
+Each agent's Workspace contains files that define the agent's character and role.
+
+- **AGENTS.md**: the agent's instructions and tool settings
+- **SOUL.md**: the agent's persona and personality
+- **USER.md**: user information and preferences
+
+# 3. Multi-Agent Configuration
+
+## 3.1 Step 1 - Create Telegram Bots (BotFather)
+
+In Telegram, chat with [@BotFather](https://t.me/BotFather) and create as many bots as you have agents.
+
+1. Send the `/newbot` command to BotFather
+2. Enter the bot name (e.g., `My Alert Bot`)
+3. Enter the bot username (e.g., `my_alert_bot`)
+4. Store the issued **bot token** securely
+
+Repeat this process for the number of bots you need. For example, if you plan to run three agents, create three bots.
+
+```
+# Example tokens received from BotFather
+alerts_bot:     123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+monitoring_bot: 987654:XYZ-UVW9876tgHjk-abc34V3w9z456ty22
+assistant_bot:  111222:GHI-JKL5678mnOpq-rst12X4y6z789ab33
+```
+
+## 3.2 Step 2 - Add Agents
+
+Add each agent with the OpenClaw CLI.
+
+```bash
+openclaw agents add alerts
+openclaw agents add monitoring
+openclaw agents add assistant
+```
+
+Each command automatically creates the following.
+- Workspace directory (`~/.openclaw/workspace-<agentId>/`)
+- State directory (`~/.openclaw/agents/<agentId>/agent/`)
+- Session store (`~/.openclaw/agents/<agentId>/sessions/`)
+
+When you actually run `openclaw agents add`, an interactive wizard runs.
+
+```
+$ openclaw agents add proj-photo
+
+🦞 OpenClaw 2026.2.17 (4134875) — The UNIX philosophy meets your DMs.
+
+┌  Add OpenClaw agent
+│
+◇  Workspace directory
+│  /Users/user/.openclaw/workspace-proj-photo
+│
+◇  Copy auth profiles from "main"?
+│  Yes
+│
+◇  Auth profiles ─────────────────────╮
+│                                     │
+│  Copied auth profiles from "main".  │
+│                                     │
+├─────────────────────────────────────╯
+│
+◇  Configure model/auth for this agent now?
+│  Yes
+│
+◇  Model/auth provider
+│  Anthropic
+│
+◇  Anthropic auth method
+│  Anthropic token (paste setup-token)
+│
+◇  Paste Anthropic setup-token
+│  sk-ant-oat01-****
+│
+◇  Token name (blank = default)
+│  proj-photo
+│
+◇  Configure chat channels now?
+│  Yes
+│
+◇  Select a channel
+│  Finished
+│
+└  Agent "proj-photo" ready.
+```
+
+Workspace, auth profiles, and model settings are all completed in one go.
+
+## 3.3 Step 3 - Pass the Bot Tokens to OpenClaw
+
+You don't need to edit `openclaw.json` directly. In the OpenClaw chat window (Dashboard or Telegram), tell it that you added a new bot and hand over the token; OpenClaw will add the configuration on its own and restart the Gateway.
+
+```
+User: "I added a new Telegram bot. Its name is alerts_bot and the token is 123456:ABC-DEF1234..."
+OpenClaw: Configuration added → Gateway automatically restarted
+```
+
+**Actual workflow:**
+
+1. Create a bot in BotFather → copy the token
+2. Pass the token in the OpenClaw chat window
+3. OpenClaw handles it automatically:
+   - Adds the agent and Telegram account to `openclaw.json`
+   - Creates binding rules
+   - Restarts the Gateway
+
+Below is what passing a bot token actually looks like in the OpenClaw Telegram chat window. Once you hand over the token, OpenClaw automatically adds the configuration and shows the bot status.
+
+![OpenClaw에게 Telegram 봇 토큰을 전달하는 화면](./openclaw-token-transfer.jpg)
+
+## 3.4 Understanding the openclaw.json Structure
+
+OpenClaw generates the configuration automatically, but understanding the internal structure helps with customization and troubleshooting. `openclaw.json` consists of three main sections.
+
+### agents Section
+
+Defines each agent (AI brain). You can assign an independent workspace and model to each agent.
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "alerts",
+        name: "Alert Agent",
+        workspace: "~/.openclaw/workspace-alerts",
+        agentDir: "~/.openclaw/agents/alerts/agent",
+        model: "anthropic/claude-opus-4-6",
+      },
+      {
+        id: "monitoring",
+        name: "Monitoring Agent",
+        workspace: "~/.openclaw/workspace-monitoring",
+        agentDir: "~/.openclaw/agents/monitoring/agent",
+        model: "anthropic/claude-sonnet-4-5",
+      },
+      {
+        id: "assistant",
+        name: "Assistant Agent",
+        workspace: "~/.openclaw/workspace-assistant",
+        agentDir: "~/.openclaw/agents/assistant/agent",
+        model: "anthropic/claude-haiku-4-5",
+      },
+    ],
+  },
+}
+```
+
+Since each agent can use a different model, you can tune performance and cost to fit each purpose.
+
+### channels Section
+
+Configures Telegram bot tokens and access policies.
+
+```json5
+{
+  channels: {
+    telegram: {
+      accounts: {
+        alerts_bot: {
+          botToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+          dmPolicy: "pairing",
+        },
+        monitoring_bot: {
+          botToken: "987654:XYZ-UVW9876tgHjk-abc34V3w9z456ty22",
+          dmPolicy: "allowlist",
+          allowFrom: ["tg:123456789"],
+        },
+        assistant_bot: {
+          botToken: "111222:GHI-JKL5678mnOpq-rst12X4y6z789ab33",
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    },
+  },
+}
+```
+
+`dmPolicy` controls who can send DMs to a bot.
+
+| dmPolicy | Description |
+|----------|------|
+| `pairing` | Only users who enter the pairing code can chat (default) |
+| `allowlist` | Only users registered in `allowFrom` can chat |
+| `open` | Anyone can chat (`allowFrom: ["*"]` required) |
+| `disabled` | DM disabled |
+
+### bindings Section
+
+Defines the routing rules for which bot's messages go to which agent.
+
+```json5
+{
+  bindings: [
+    {
+      agentId: "alerts",
+      match: { channel: "telegram", accountId: "alerts_bot" },
+    },
+    {
+      agentId: "monitoring",
+      match: { channel: "telegram", accountId: "monitoring_bot" },
+    },
+    {
+      agentId: "assistant",
+      match: { channel: "telegram", accountId: "assistant_bot" },
+    },
+  ],
+}
+```
+
+> When you need advanced settings such as changing dmPolicy, swapping models, or refining bindings, you can edit this file directly.
+
+## 3.5 Step 4 - Verify and Run
+
+Once the configuration is complete, verify it with the following commands.
+
+```bash
+# Check the agent list and bindings
+openclaw agents list --bindings
+
+# Check channel status (verify bot token validity)
+openclaw channels status --probe
+
+# Restart the Gateway (when changing settings manually)
+openclaw gateway restart
+```
+
+If everything is set up correctly, sending a message to each Telegram bot will get a response from the corresponding agent. Below is what an actual conversation with a newly added bot looks like.
+
+![새로 추가한 Telegram 봇과의 대화 화면](./openclaw-bot-conversation.png)
+
+# 4. Conclusion
+
+With OpenClaw's multi-agent feature, you can run multiple Telegram bots independently from a single Gateway. To summarize the key points:
+
+- Each agent is an independent AI brain with completely isolated **Workspace, agentDir, and sessions**
+- Create bots in BotFather and **just hand the tokens to OpenClaw** for automatic configuration
+- **Binding rules** route messages to agents, allowing branching per bot, per user, or per group
+- Use a **different AI model** per agent to optimize performance and cost
+
+Multi-agent isn't just about creating several bots; it's about giving each bot a **specialized role and context**. A well-designed agent separation raises both response quality and operational efficiency at the same time.
+
+# 5. References
+
+- [OpenClaw Official Documentation](https://docs.openclaw.ai)
+- [Multi-Agent Concept](https://docs.openclaw.ai/concepts/multi-agent)
+- [Telegram Channel Setup](https://docs.openclaw.ai/channels/telegram)
+- [Getting Started Guide](https://docs.openclaw.ai/start/getting-started)

--- a/contents/ai/openclaw에서-gog로-google-workspace-연동하기/index_en.md
+++ b/contents/ai/openclaw에서-gog로-google-workspace-연동하기/index_en.md
@@ -1,0 +1,391 @@
+---
+title: "Connecting Google Workspace to OpenClaw with gog"
+description: "How to set up gog (Google Workspace CLI) in OpenClaw to control Gmail, Calendar, and Drive from Telegram"
+date: 2026-03-08
+update: 2026-03-08
+tags:
+  - openclaw
+  - gog
+  - google-workspace
+  - gmail
+  - google-calendar
+  - google-drive
+  - telegram
+  - oauth
+  - ai-agent
+  - 오픈클로
+  - 구글워크스페이스
+  - 텔레그램
+  - AI에이전트
+  - 자동화
+series: "OpenClaw 활용 가이드"
+---
+# 1. Overview
+
+Connecting Google Workspace to OpenClaw lets you control Gmail, Calendar, and Drive entirely through Telegram chat. This article walks through setting up [gog (Google Workspace CLI)](https://clawhub.ai/steipete/gog) in OpenClaw.
+
+> **After downloading the OAuth JSON file from the Google Cloud Console, every step was carried out solely through Telegram chat.** I never typed a command directly in a terminal.
+
+- OAuth setup in the Google Cloud Console (web browser)
+- After sending the JSON credential file to Telegram, everything was done through Telegram, without typing any CLI command directly
+
+> For the basic OpenClaw installation and Telegram bot integration, see the [Complete OpenClaw Guide](/article/openclaw-완벽-가이드).
+
+# 2. What is gog?
+
+gog is a CLI tool for controlling Google Workspace from the terminal.
+
+Supported services:
+
+- **Gmail** - search, read, send mail, and manage labels
+- **Calendar** - view, create, and edit events
+- **Drive** - search, upload, and download files
+- **Contacts** - manage contacts
+- **Docs / Sheets / Slides** - manage documents
+- **Tasks** - manage to-dos
+- **Chat** - Google Chat messages
+- **Forms** - query survey data
+- **Apps Script** - manage scripts
+
+By integrating with OpenClaw, you can handle all of this through natural-language conversation.
+
+```mermaid
+flowchart LR
+    A[User] -->|Telegram message| B[OpenClaw Bot]
+    B -->|Run gog CLI| C[gog]
+    C -->|OAuth 2.0| D[Google Workspace API]
+    D --> E[Gmail]
+    D --> F[Calendar]
+    D --> G[Drive]
+    D --> H[Docs / Sheets / ...]
+```
+
+# 3. Prerequisites
+
+- OpenClaw installed and Telegram bot integration complete
+- macOS environment (brew available)
+- A Google account
+
+# 4. Full Setup Flow
+
+The overall flow can be summarized as follows.
+
+1. **Google Cloud Console** - create an OAuth project & a Client ID → download JSON
+2. **Telegram** - send the JSON file to the OpenClaw bot
+3. **Telegram** - provide your Gmail address → OpenClaw generates an authentication URL
+4. **Browser** - sign in to Google & approve permissions → copy the callback URL
+5. **Telegram** - paste the callback URL → OpenClaw exchanges the token & finishes the setup
+6. **Google Cloud Console** - enable the Gmail, Calendar, and Drive APIs
+7. **Telegram** - "Tell me tomorrow's schedule" → start using Google Workspace
+
+# 5. Installing gog
+
+I asked the OpenClaw bot in Telegram how to set up gog.
+
+> **Me**: I want to set up gog google workspace. https://clawhub.ai/steipete/gog
+>
+> **OpenClaw**: I already installed `gogcli` earlier. Now we need to **set up Google authentication**. Let's go step by step:
+>
+> Step 1: Create a Google Cloud OAuth client
+>
+> 1. Open the **Google Cloud Console** — https://console.cloud.google.com/
+> 2. Create a **new project** (name: `gog-cli`)
+> 3. Configure **APIs & Services → OAuth consent screen**
+> 4. **APIs & Services → Credentials → Create Credentials → OAuth client ID**
+>    - Application type: **Desktop app**
+>    - Download `client_secret_xxxx.json`
+
+![Requesting gog setup from OpenClaw in Telegram](telegram-gog-setup.png)
+
+OpenClaw immediately guides you through the entire setup. If gog is not yet installed, just say "install gog" and OpenClaw runs `brew install gogcli` in the background.
+
+# 6. Google Cloud Console OAuth Setup
+
+This is the only stage that **the user must perform directly in a web browser**.
+
+## 6.1 Create a Project
+
+Go to the [Google Cloud Console](https://console.cloud.google.com/) and create a new project.
+
+- Project name: `gog-cli` (any name you like)
+
+![Create a new project](gcloud-create-project.png)
+
+![Google Cloud Console main screen](gcloud-console-main.png)
+
+## 6.2 Configure the OAuth Consent Screen
+
+Click APIs & Services → OAuth consent screen to go to the OAuth overview page, then click the Get Started button.
+
+Enter the **app information**:
+
+- App name: `gog-cli`
+- User support email: your own email
+
+![App information input form](oauth-consent-app-info.png)
+
+Select the **audience**:
+
+- Select **External**
+
+![Audience selection - External](oauth-consent-external.png)
+
+Enter the contact information and finish.
+
+![Final confirmation](oauth-consent-confirm.png)## 6.3 Create an OAuth Client ID
+
+Go to APIs & Services → Credentials → **Create Credentials** → **OAuth client ID**.
+
+![Creating an OAuth client ID from the Credentials menu](credentials-menu.png)
+
+- Application type: **Desktop app**
+- Name: `gog-cli`
+- Click **Create**
+
+![Create OAuth client ID - select Desktop app](oauth-client-create.png)
+
+Once it is created, click the **Download JSON** button to download the `client_secret_xxxx...xxxx.json` file.
+
+![OAuth client creation complete - download JSON](oauth-client-complete.jpg)
+
+> **This is the last step you do in a web browser.** From here on, you return to Telegram chat.
+
+# 7. gog Authentication Setup (done via Telegram chat)
+
+> From this section on, **you do not operate the terminal directly.** OpenClaw runs every CLI command on your behalf.
+
+## 7.1 Send the JSON Credential File
+
+Send the downloaded JSON file to the Telegram chat as a file attachment.
+
+> **Me**: *(attaching the client_secret_xxxx...xxxx.json file)*
+>
+> **OpenClaw**: Got the file! I'll proceed with the setup.
+>
+> **OpenClaw**: Credential registration complete! Now we need to authenticate the Google account.
+> Tell me your Gmail address — I'll run it in `--manual` mode and send you the authentication URL!
+
+**OpenClaw background tasks:**
+
+```bash
+# 1. Save the JSON file received from Telegram to the Mac Mini
+mv /tmp/telegram_download/client_secret_xxxx.json ~/Downloads/
+
+# 2. Register the OAuth credentials with gog
+gog auth credentials ~/Downloads/client_secret_xxxx...xxxx.json
+```
+
+## 7.2 Provide the Gmail Address → Receive the Authentication URL
+
+Type your Gmail address into the chat, and OpenClaw sends you the authentication URL.
+
+> **Me**: your-email...@gmail.com
+>
+> **OpenClaw**: Standing by! Now follow the steps below:
+>
+> **1.** Open this link in your browser:
+> `https://accounts.google.com/o/oauth2/auth?access_type=offline&client_id=xxxx...xxxx&...`
+>
+> **2.** Sign in to Google and approve the permissions
+>
+> **3.** It's normal for the page not to open! Copy the **full URL from the browser's address bar** and send it to me
+> It's a URL that looks like `http://127.0.0.1:.../oauth2/callback?state=...&code=...`!
+
+**OpenClaw background tasks:**
+
+```bash
+# Start authentication in --manual mode (print the URL directly instead of opening a browser)
+gog auth add your-email...@gmail.com --manual
+
+# Send the printed OAuth authentication URL as a Telegram message
+# Wait for the local callback server (127.0.0.1:50554) in the background
+```
+
+### 7.3 Troubleshooting: 403 access_denied
+
+When you first open the authentication URL, you may get a 403 error.
+
+![403 access_denied error screen](403-access-denied.png)
+
+> **Me**: *(sending the 403 access_denied screenshot)*
+>
+> **OpenClaw**: `403 access_denied` — it's because the OAuth app is still in **test mode**. You need to add a test user.
+>
+> In the Google Cloud Console:
+>
+> 1. Go to **APIs & Services → OAuth consent screen**
+> 2. In the **Test users** section, click **Add users**
+> 3. Add your own email
+>
+> **Me**: I don't want to add a test user; I just want it to actually work. Can I just click Publish app?
+>
+> **OpenClaw**: Yes, you can **Publish** the app! If only you use it, there's no problem.
+>
+> **Me**: Done publishing.
+
+The cause is that OAuth apps are created in **test mode** by default. There are two ways to fix it:
+
+1. **Publish the app**: OAuth consent screen → Audience → click **Publish app** (recommended if only you use it)
+2. **Add a test user**: Audience → add your own email to the test users
+
+![App publishing page](oauth-publish-page.png)
+
+![Publish confirmation dialog](oauth-publish-confirm.png)
+
+### 7.4 Sign in to Google → Provide the callback URL
+
+After publishing the app, open the authentication URL again and the Google sign-in proceeds normally.
+
+**1. Select an account**
+
+![Google account selection](google-account-select.png)
+
+**2. "Google hasn't verified this app" warning**
+
+A warning appears because the app hasn't gone through Google's official verification. Since you created the app yourself, click **Advanced → Continue**.
+
+![Google hasn't verified this app warning](google-unverified-app.png)
+
+**3. Approve the permission request**
+
+The list of Google services that gog-cli will access is displayed. Click **Continue** to approve all permissions.
+
+![Permission request screen 1](google-permission-1.png)
+
+![Permission request screen 2](google-permission-2.png)
+
+**4. Copy the callback URL**
+
+After approval, you are redirected to a `http://127.0.0.1:50554/oauth2/callback?...` address, and it is **normal** for the page not to open. **Copy the full URL** from the browser's address bar and paste it into Telegram.
+
+> **Me**: `http://127.0.0.1:50554/oauth2/callback?state=xxxx...xxxx&code=4/0Axxxx...xxxx&scope=email%20profile%20...`
+>
+> **OpenClaw**: Authentication complete!
+>
+> ```
+> email     your-email...@gmail.com
+> services  appscript, calendar, chat, classroom, contacts,
+>           docs, drive, forms, gmail, people, sheets, slides, tasks
+> ```
+
+**OpenClaw background tasks:**
+
+```bash
+# 1. Extract the authorization code from the callback URL the user sent
+#    http://127.0.0.1:50554/oauth2/callback?code=4/0Axxxx...xxxx&...
+#    → code = "4/0Axxxx...xxxx"
+
+# 2. Exchange the authorization code for Google OAuth tokens
+#    (internally gog exchanges code → access_token + refresh_token)
+
+# 3. Store the tokens securely in the macOS Keychain
+
+# 4. Verify the authentication result
+gog auth list
+# → email: your-email...@gmail.com, confirm 13 services connected
+```
+
+### 7.5 Troubleshooting: macOS Keychain Access
+
+gog stores authentication tokens in the macOS Keychain. On the first run, a Keychain access prompt may appear.
+
+> **OpenClaw**: `gog auth list` keeps hanging — it might be a macOS Keychain access issue. Test it directly in the terminal on the Mac Mini — a Keychain access prompt may appear.
+>
+> **Me**: A lot of Keychain access prompt windows popped up; I entered my login password and finished.
+>
+> **OpenClaw**: Great! Now that you've allowed Keychain access, it should work. Let me test again!
+
+The Keychain prompt must be handled directly on the Mac Mini screen. Once allowed, it is accessed automatically thereafter.
+
+## 7.6 Set the Environment Variable
+
+You need to set the `GOG_ACCOUNT` environment variable so you don't have to add the `--account` option every time.
+
+> **Me**: Is the GOG_ACCOUNT environment variable set as well?
+>
+> **OpenClaw**: It's not! I'll set it up.
+>
+> **OpenClaw**: Done adding it!
+>
+> - Added `export GOG_ACCOUNT=your-email...@gmail.com` to `~/.zshrc`
+> - Applied automatically from new terminal sessions
+>
+> **Me**: Run source ~/.zshrc.
+>
+> **OpenClaw**: Done! `GOG_ACCOUNT=your-email...@gmail.com` is now applied.
+
+**OpenClaw background tasks:**
+
+```bash
+# 1. Add the environment variable to ~/.zshrc
+echo 'export GOG_ACCOUNT=your-email...@gmail.com' >> ~/.zshrc
+
+# 2. Apply it to the current session
+source ~/.zshrc
+```
+
+# 8. Enabling Google APIs
+
+Authentication is complete, but you must **enable** the APIs you actually use in the Google Cloud project for them to work. As OpenClaw tries testing, it tells you the list of required APIs and their links.
+
+> **OpenClaw**: We're making progress! Keychain is resolved, and now we need to **enable the APIs in Google Cloud**.
+>
+> 1. **Gmail API**: `https://console.developers.google.com/apis/api/gmail.googleapis.com/...`
+> 2. **Calendar API**: `https://console.developers.google.com/apis/api/calendar-json.googleapis.com/...`
+> 3. **Drive API**: `https://console.developers.google.com/apis/api/drive.googleapis.com/...`
+
+In the Google Cloud Console, search for each API and click the **Enable** button.
+
+![Gmail API enable example](gmail-api-enable.png)
+
+![Gmail API enable complete](gmail-api-complete.png)
+
+Once you let OpenClaw know in Telegram that it's enabled, OpenClaw tests it right away.
+
+![API test result - all working](telegram-api-test-result.png)
+
+**OpenClaw background tasks:**
+
+```bash
+# Run the test as soon as the user says "I enabled it"
+gog gmail search 'newer_than:1d'     # → confirm Gmail API works
+gog calendar calendars                # → confirm Calendar API works
+gog drive files list                  # → confirm Drive API works
+
+# Summarize the results and respond via Telegram
+```
+
+> You can enable additional APIs such as Contacts, Tasks, and Sheets as needed.
+
+# 9. Real-World Usage
+
+Once the setup is complete, you can use Google Workspace right away with natural language.
+
+## 9.1 Querying Calendar Events
+
+![Querying calendar events in Telegram](telegram-calendar-query.jpg)
+
+## 9.2 Natural Language → gog Command Conversion
+
+When the user makes a request in natural language, OpenClaw converts it into the appropriate gog command and runs it. The user doesn't need to know the gog command syntax at all.
+
+
+| User (natural language)            | Command OpenClaw runs                                                 |
+| ----------------------------- | --------------------------------------------------------------------- |
+| "Tell me tomorrow's schedule"            | `gog calendar events --from 2026-02-20 --to 2026-02-21`               |
+| "Also tell me my March weekend schedule"      | `gog calendar events --from 2026-03-01 --to 2026-03-31` + weekend filtering |
+| "Check the mail that came in today"       | `gog gmail search 'newer_than:1d'`                                    |
+| "Find the XX file in Drive" | `gog drive files list --query 'name contains "XX"'`                   |
+
+# 10. Wrapping Up
+
+The entire setup takes about 10 minutes, and the only parts the user does directly are the Google Cloud Console and the browser authentication.
+
+After setup, you just make requests in natural language from Telegram. Say things like "Check my mail today" or "Tell me this week's schedule," and OpenClaw picks the right gog command on its own and answers with the results organized in a human-readable form.
+
+# 11. References
+
+- [gog official docs (ClaWHub)](https://clawhub.ai/steipete/gog)
+- [Google Cloud Console](https://console.cloud.google.com/)
+- [Complete OpenClaw Guide](/article/openclaw-완벽-가이드)
+- [Setting Up OpenClaw Telegram Multi-Agent](/article/openclaw-telegram-멀티-에이전트-구성하기)

--- a/contents/ai/tmux-입문-터미널-세션-관리부터-claude-code-활용까지/index_en.md
+++ b/contents/ai/tmux-입문-터미널-세션-관리부터-claude-code-활용까지/index_en.md
@@ -1,0 +1,252 @@
+---
+title: "Getting Started with tmux: From Terminal Session Management to Using It with Claude Code"
+description: "A beginner-friendly guide to the terminal multiplexer tmux, covering its core concepts, how to use Sessions, Windows, and Panes, a minimal config, and how to use it alongside Claude Code sessions."
+date: 2026-05-26
+update: 2026-05-26
+tags:
+  - tmux
+  - terminal
+  - 터미널
+  - 세션
+  - claude-code
+  - 생산성
+---
+
+# 1. Introduction
+
+Back when I worked with Linux servers a lot, I couldn't imagine getting things done without `tmux`. Then I moved to mostly local development and forgot about it for a while, but lately, using terminal-based AI coding tools like Claude Code, I've started reaching for it again. So I figured I'd take this chance to lay out tmux from scratch, from a beginner's perspective.
+
+If any of these sound familiar, tmux might be the answer.
+
+- You have 10 terminal tabs open and have no idea what's where
+- Your SSH connection dropped while working on a remote server, and the build or script that was running got wiped out entirely
+- You want to see code editing and logs on one screen, but you keep switching back and forth between windows
+
+This guide covers installation on macOS, walks through the concepts, basic usage, and a minimal config in order, and finishes by introducing how to use it alongside a Claude Code Session. You can just follow along from top to bottom.
+
+# 2. What is tmux?
+
+tmux is short for **t**erminal **mux**(multiplexer), i.e. "terminal multiplexer." It's a tool that lets you handle multiple workspaces within a single terminal window and keep those workspaces running in the background.
+
+There are two core values a beginner should remember.
+
+**① Session persistence** — A tmux Session stays alive in the background even if you close the terminal window or your SSH connection drops. Later, all you have to do is attach again, and your work picks up as if it was never interrupted. The "SSH dropped and my build got wiped out" problem I mentioned earlier disappears right here.
+
+**② Screen splitting** — You can divide a single screen into multiple Windows and Panes to view several tasks at once. You can keep an editor, logs, and a dev server all in view while you work.
+
+To sum it up in one line, tmux is **a workspace that doesn't disappear when you close it and that you can freely divide with partitions**.
+
+# 3. Installation (macOS)
+
+On macOS, it's a one-liner with Homebrew.
+
+```bash
+brew install tmux
+```
+
+Once installation finishes, check the version.
+
+```bash
+tmux -V
+# tmux 3.5a  (example)
+```
+
+If a version string is printed, you're ready to go. Now, type `tmux` in your terminal and your first Session begins.
+
+# 4. Core Concepts: Session, Window, Pane
+
+To use tmux, you need to know three units. They form a containment hierarchy in the order **Session > Window > Pane**.
+
+- **Session**: The top-level workspace unit in tmux. Typically you use one Session per project or task. The detach/attach mentioned earlier targets exactly this Session
+- **Window**: Think of it as a "tab" inside a Session. It takes up the whole screen, and you switch between multiple Windows
+- **Pane**: A split screen within a Window. Multiple Panes are visible at once inside a single Window
+
+To put it together, a single Session contains several Windows, and a single Window contains several Panes. By analogy with a browser, a Window is like a "tab," and a Pane is like a "split screen" that divides one tab left/right or top/bottom.
+
+In practice, if you split one Window into three Panes, it looks like the image below. One Pane on top and two Panes on the bottom are all visible on one screen at once, and the bottom line is the status bar that shows the Window list and status.
+
+![A screen with one tmux Window split into three Panes](tmux-panes.png)
+
+# 5. Basic Usage
+
+Almost every tmux shortcut works by **pressing `Ctrl+b` first** and then pressing the next key. This `Ctrl+b` is called the **prefix key**. For example, `Ctrl+b c` means "press `Ctrl+b`, release it, then press `c`." Just remember that you press them in sequence, not at the same time. (This prefix key can be changed to another key, which is covered in Section 6.)
+
+## 5.1 Session
+
+A Session is the unit that holds the entire workspace. Typically you create one Session per project, detach when you're done to step out, and attach again later to continue. The three you'll use most often are these.
+
+- Start a new Session (with a name): `tmux new -s my-project`
+- Step out of a Session (detach): `Ctrl+b d` (the Session stays alive)
+- Attach to a Session again: `tmux attach -t my-project`
+
+Even after you detach, the work inside the Session keeps running in the background. This detach/attach is the heart of tmux. The rest of the Session-related commands are as follows.
+
+| Action | Command / Shortcut |
+|------|---------------|
+| Start a new Session | `tmux new -s name` |
+| detach (step out) | `Ctrl+b d` |
+| attach (re-attach) | `tmux attach -t name` |
+| Attach to the most recent Session | `tmux a` |
+| View the Session list | `tmux ls` |
+| Pick and switch from the Session list | `Ctrl+b s` |
+| Rename a Session | `Ctrl+b $` |
+| Kill a Session | `tmux kill-session -t name` |
+
+## 5.2 Window
+
+A Window is a "tab" inside a Session. If you split Windows by the nature of the task (e.g. one for editing, one for the server), it's convenient to switch between them. The ones you'll use most are creating a new Window and moving between them.
+
+- New Window: `Ctrl+b c`
+- Next / previous Window: `Ctrl+b n` / `Ctrl+b p`
+- Jump by number: `Ctrl+b 0` ~ `Ctrl+b 9`
+
+The rest of the Window-related shortcuts are as follows.
+
+| Action | Shortcut |
+|------|--------|
+| New Window | `Ctrl+b c` |
+| Next / previous Window | `Ctrl+b n` / `Ctrl+b p` |
+| Jump by number | `Ctrl+b 0` ~ `Ctrl+b 9` |
+| Toggle to the last viewed Window | `Ctrl+b l` |
+| Pick and move from the Window list | `Ctrl+b w` |
+| Rename a Window | `Ctrl+b ,` |
+| Close the current Window | `Ctrl+b &` (confirm with y) |
+
+## 5.3 Pane
+
+A Pane is a split screen that divides a Window left/right or top/bottom. You use it when you want to see code, logs, and server output at the same time on one screen. The ones you'll use most are splitting and moving.
+
+- Split left/right: `Ctrl+b %`
+- Split top/bottom: `Ctrl+b "`
+- Move between Panes: `Ctrl+b arrow key`
+
+The rest of the Pane-related shortcuts are as follows.
+
+| Action | Shortcut |
+|------|--------|
+| Split left/right | `Ctrl+b %` |
+| Split top/bottom | `Ctrl+b "` |
+| Move between Panes | `Ctrl+b arrow key` |
+| Cycle to the next Pane | `Ctrl+b o` |
+| Resize a Pane | `Ctrl+b Ctrl+arrow key` |
+| Toggle fullscreen for the current Pane (zoom) | `Ctrl+b z` |
+| Show Pane numbers, then select | `Ctrl+b q` |
+| Break the current Pane into a new Window | `Ctrl+b !` |
+| Close the current Pane | `Ctrl+b x` (confirm with y) |
+
+# 6. Minimal .tmux.conf Config
+
+There's no need to deck it out lavishly from the start. Let's put just four things that make a big difference for beginners into `~/.tmux.conf`.
+
+```bash
+# 1) Change prefix to Ctrl+a (if Ctrl+b doesn't feel right)
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# 2) Enable mouse for Pane selection/resizing/scrolling
+set -g mouse on
+
+# 3) Make split shortcuts intuitive ( | left/right, - top/bottom )
+bind | split-window -h
+bind - split-window -v
+
+# 4) Config reload shortcut (prefix r)
+bind r source-file ~/.tmux.conf \; display "Reloaded!"
+```
+
+After saving, to apply it, press `Ctrl+b r` inside tmux. There's also the option of restarting with `tmux kill-server`, but be careful—this **terminates every running Session**. Usually the `Ctrl+b r` reload is enough.
+
+For reference, changing the prefix to `Ctrl+a` in setting #1 is purely a matter of taste, an **optional** choice. Changing it makes it differ from the default prefix, which can be confusing. Just remember that all the shortcuts used in the rest of this article are based on the **default prefix `Ctrl+b`**.
+
+# 7. Using It with Claude Code
+
+That covers the tmux fundamentals. Now let's come back to what I mentioned at the start—the reason I started using tmux often again. Claude Code and tmux pair quite well. There are two reasons.
+
+- **Long autonomous work survives via detach.** If you hand Claude Code a long task and step out with `Ctrl+b d`, the work keeps running even after you close the terminal
+- **You can work in parallel on one screen.** Splitting Claude Code, the dev server, and logs into Panes and viewing them at once keeps your workflow from breaking
+
+## Creating and Naming a Session per Folder
+
+When you move between several projects using Claude Code, it's convenient to keep one tmux Session running per project (folder). On top of that, if you use multiple machines (laptop, desktop, mini PC, etc.), Session names can collide, so naming them with the **`<machine>-<folder>` rule** keeps things from getting confusing no matter where you attach. For example, if you open the `blog` folder on your desktop (`m4`), the Session name becomes `m4-blog`.
+
+Going one step further, it's nice to pass the same name along when you launch Claude Code in each Session. `-n <name>` gives the Claude session a name and shows it in the prompt, the resume picker, and the terminal title, while `--remote-control <name>` turns on remote control under that name. Even if you attach from your phone or another PC, "which task this is right now" is clear from the name alone.
+
+Below is a simplified version of the script I use. You just need to change `WORKSPACES` (the folder list) and `VALID_MACHINES` (machine names) to match your own environment.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ===== Config (edit to match your own environment) =====
+WORKSPACES=(blog inspireme markora)   # Folder names under ~/src
+VALID_MACHINES=(m1 m4 mini)           # Machine names (laptop/desktop, etc.)
+SRC_DIR="${SRC_DIR:-$HOME/src}"
+CLAUDE_CMD="${CLAUDE_CMD:-claude}"
+
+# Session name rule: <machine>-<folder>  (replace . : in the folder with -)
+session_name() { echo "$1-${2//[.:]/-}"; }
+
+# Command to run in the Session: give Claude a name (-n) and a remote-control name (--remote-control)
+launch_cmd() { echo "$CLAUDE_CMD -n $1 --remote-control $1"; }
+
+create_one() { # <machine> <directory> <folder>
+  local session; session="$(session_name "$1" "$3")"
+  if tmux has-session -t "$session" 2>/dev/null; then
+    echo "Already exists, skipping -> $session"
+    return 0
+  fi
+  tmux new-session -d -s "$session" -c "$2" "$(launch_cmd "$session")"
+  echo "Created -> $session ($2)"
+}
+
+# Usage: claude_tmux_sessions.sh <machine> [<folder>]
+#   If the folder is omitted, all of WORKSPACES; if specified, just that one folder
+machine="${1:?A machine name is required (e.g. m4)}"
+folder="${2:-}"
+
+if [[ -n "$folder" ]]; then
+  create_one "$machine" "$SRC_DIR/$folder" "$folder"
+else
+  for f in "${WORKSPACES[@]}"; do
+    [[ -d "$SRC_DIR/$f" ]] && create_one "$machine" "$SRC_DIR/$f" "$f"
+  done
+fi
+
+echo "----- Current tmux sessions -----"
+tmux ls
+echo "Connect: tmux attach -t <session-name>"
+```
+
+Using it is simple.
+
+- Launch all defined folders at once: `claude_tmux_sessions.sh m4`
+- Launch just one specific folder: `claude_tmux_sessions.sh m4 blog`
+
+Then Sessions like `m4-blog` and `m4-inspireme` are created per folder, and Claude Code is running under the same name inside each Session. From anywhere, you can attach with `tmux attach -t m4-blog` and continue working. If you leave it detached, the work keeps running even if you close your laptop or your SSH drops, so you can leave it running on a remote server and continue the same task while moving between home, the office, and your phone. (The actual script also includes a feature to clean up the Sessions you created all at once with `--kill`.)
+
+> Note: Appending `--dangerously-skip-permissions` to `CLAUDE_CMD` lets you skip the permission prompt every time, but since the tool then runs commands without confirmation, use it only in a trusted environment. Also, options like `-n` and `--remote-control` may differ depending on your Claude Code version, so check with `claude --help`.
+
+> Caution: If you open the same repo in multiple Sessions at once and Claude edits the same file simultaneously, conflicts can occur. For parallel work, it's safer to split by folder or separate them with `git worktree`.
+
+# 8. Wrapping Up
+
+The real value of tmux can be summed up in one line: **a workspace that doesn't disappear when you close it.** Screen splitting is handy too, but in the end the biggest change is escaping the state of "not being able to close the terminal for fear of losing my work."
+
+You don't need to memorize every shortcut from the start. You can start by getting these five into your hands.
+
+- New Session: `tmux new -s name`
+- Step out: `Ctrl+b d`
+- Re-attach: `tmux attach -t name`
+- New Window: `Ctrl+b c`
+- Split left/right: `Ctrl+b %`
+
+In particular, I recommend getting comfortable with `Ctrl+b d` (detach) and `tmux attach` (re-attach) first. Once just these two are in your hands, the way you approach the terminal changes. After that, layer it on top of long-running work like Claude Code, and you'll quickly feel why you find yourself reaching for tmux again.
+
+# 9. References
+
+- [tmux + Claude Code: The Perfect Terminal Workflow](https://willness.dev/blog/tmux-claude-code-workflow)
+- [Using tmux with Claude Code](https://hboon.com/using-tmux-with-claude-code/)
+- [How to Run Claude Code with tmux on a VPS](https://codeongrass.com/blog/how-to-run-claude-code-with-tmux/)
+- [Seamless Claude Code Handoff: SSH From Your Phone With tmux](https://elliotbonneville.com/phone-to-mac-persistent-terminal/)
+- [Claude Code Multi-Agent tmux Setup](https://www.dariuszparys.com/claude-code-multi-agent-tmux-setup/)

--- a/contents/ai/맥에서-직접-ai-모델-돌려보자-ollama로-llm-서버-구축하기/index_en.md
+++ b/contents/ai/맥에서-직접-ai-모델-돌려보자-ollama로-llm-서버-구축하기/index_en.md
@@ -1,0 +1,176 @@
+---
+title: "Run AI Models Directly on Your Mac! Building an LLM Server with Ollama"
+description: "A hands-on guide to installing and running LLMs locally on macOS with Ollama and Open WebUI."
+date: 2025-02-01
+update: 2025-02-01
+tags:
+  - AI
+  - ollama
+  - LLM
+  - ChatGPT
+  - llama
+---
+
+# 1. Overview
+
+As AI-related services have become more widely used recently, the associated costs often become a burden. To address this, I'd like to introduce a way to build and use an `LLM` directly in a local environment. In this article, we cover how to install and use an `LLM` on macOS.
+
+# 2. Installing an `LLM`
+
+## 2.1 Installing and Verifying `Ollama`
+
+First, install `Ollama`. `Ollama` is a tool that makes it easy to run an `LLM` locally.
+
+### **Installation**
+
+Go to the website, download the build for your OS, and proceed with the installation.
+
+![Ollama 다운로드](image-20250323141909438.png)
+
+![첫 실행](image-20250323141925478.png)
+
+If you'd like to install it from the terminal using a command, you can install it with `brew`.
+
+```bash
+> brew install --cask ollama
+```
+
+Once the installation is complete, verify that it was installed correctly.
+
+```bash
+> ollama -v
+ollama version is 0.6.2
+Warning: client version is 0.4.7
+```
+
+### Running Ollama
+
+After installation, you can now download and run a model.
+
+```bash
+> ollama run llama3.2
+pulling manifest
+pulling dde5aa3fc5ff... 100% ▕█████████████████████████████████████████▏ 2.0 GB
+pulling 966de95ca8a6... 100% ▕█████████████████████████████████████████▏ 1.4 KB
+pulling fcc5a6bec9da... 100% ▕█████████████████████████████████████████▏ 7.7 KB
+pulling a70ff7e570d9... 100% ▕█████████████████████████████████████████▏ 6.0 KB
+pulling 56bb8bd477a5... 100% ▕█████████████████████████████████████████▏   96 B
+pulling 34bb5ab01051... 100% ▕█████████████████████████████████████████▏  561 B
+verifying sha256 digest
+writing manifest
+success
+>>> Send a message (/? for help)
+```
+
+When you type what you want at the `>>>` `LLM` prompt, you can see that it gives you an answer.
+
+```bash
+>>> hi
+How can I help you today?
+```
+
+# 3. Using the `LLM`
+
+## 3.1 Open WebUI
+
+Using only the CLI environment can be inconvenient, so you can also use Open WebUI. Open WebUI is a web-based UI that makes it easy to use `Ollama`.
+
+### **Installation**
+
+There are several methods, but here we'll simply run it with Docker.
+
+```bash
+# Create a volume folder to be used by Docker
+> docker run -d -p 3000:8080 --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
+```
+
+Now, if you access [http://localhost:3000](http://localhost:3000) in your web browser, you can use `Ollama` through the web UI.
+
+![Open WebUI](image-20250323141942551.png)
+
+You can see that it looks similar to the ChatGPT web interface and works well.
+
+![Open WebUI - Prompt](image-20250323142000013.png)
+
+## 3.2 Calling via the API
+
+Ollama provides an API, so you can also call it directly using curl.
+
+```bash
+> curl -X POST "http://localhost:11434/api/generate" \
+     -H "Content-Type: application/json" \
+     -d '{"model": "llama3.2", "prompt": "Hello, what is AI?"}'
+```
+
+## 3.3 Calling from Python
+
+For Python, a langchain library is provided, so you can use it to work with an `LLM`.
+
+```python
+from unittest import TestCase
+
+from langchain.llms import Ollama
+from langchain.chains import LLMChain
+from langchain.prompts import PromptTemplate
+from langchain.callbacks.manager import CallbackManager
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+
+class Test(TestCase):
+    def test_ollam_example(self):
+        # Initialize the Ollama model (the default model is llama3.2, but other models can also be specified)
+        llm = Ollama(
+            model="llama3.2",  # Specify the model to use (e.g., llama3.2, mistral, gemma, etc.)
+            callback_manager=CallbackManager([StreamingStdOutCallbackHandler()]),
+        )
+
+        # Call the model with a simple prompt
+        response = llm("What is Python?")
+        print(f"\\nCompleted response: {response}")
+```
+
+
+
+# 4. Collection of Ollama Commands
+
+The `ollama` command provides various subcommands, and the most frequently used ones are as follows.
+
+- Check the list of models
+
+  ```bash
+  > ollama list
+  NAME               ID              SIZE      MODIFIED
+  llama3.2:latest    a80c4f17acd5    2.0 GB    6 hours ago
+  mistral:latest     f974a74358d6    4.1 GB    3 months ago
+  ```
+
+- Add a new model
+
+  - You can find downloadable models on the [library](https://ollama.com/library) site.
+
+  ```bash
+  > ollama pull gemma
+  ```
+
+- Remove a model
+
+  ```bash
+  > ollama rm mistral
+  ```
+
+- Run a model directly in your local environment
+
+  ```bash
+  > ollama run mistral
+  ```
+
+# 5. Conclusion
+
+You've now learned how to build and use an `LLM` on macOS. With `Ollama` and Open WebUI, you can run AI models efficiently in a local environment, so I recommend trying it out for yourself.
+
+# 6. References
+
+- [LLM을 local에서 돌려보자](https://devocean.sk.com/blog/techBoardDetail.do?ID=165686&boardType=techBlog)
+- [Ollama 를 활용해서 개인형 LLM 서버 구성하기](https://devocean.sk.com/blog/techBoardDetail.do?ID=165685&boardType=techBlog)
+- [오픈소스 LLM 활용](https://wikidocs.net/232980)
+- https://github.com/open-webui/open-webui
+- https://github.com/ollama/ollama


### PR DESCRIPTION
## Summary
`translate-article-en` 스킬로 ai 카테고리의 미번역 글 4건을 영어로 번역해 `index_en.md`를 추가한다. 이로써 ai 카테고리 영어화 완료(9건 전부).

번역한 글:
- tmux 입문: 터미널 세션 관리부터 Claude Code 활용까지
- OpenClaw + Telegram 멀티 에이전트 구성하기
- OpenClaw에서 gog로 Google Workspace 연동하기
- 맥에서 직접 AI 모델 돌려보자 (Ollama LLM 서버 구축)

## 번역 규칙 준수
- 본문·title·description·heading·Mermaid 노드·코드 내 한글 주석/문자열 → 영어
- 보존: 코드 로직·식별자, tags·date·update·series, 이미지/링크/URL, 문단·들여쓰기
- 코드 내 기능적 값(세션명 패턴, 계정ID, config 키 등) 보존

## Test plan
- [x] `npm run generate:manifest` — 영어 글 11건(ai 9건)
- [x] `npm run check` (tsc) 통과, `npm run build` 성공
- [ ] `/en/` 목록·각 글 `/en/{slug}/` 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)