### PR TITLE
feat: 영어 홈 페이지 완성 + 푸터 현지화

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -1,37 +1,207 @@
-import { getAllArticles, getArticleTitleFromSlug } from '@/lib/articles';
-import Link from 'next/link';
+import { getAllArticles, getAllSeries, getArticlesBySeries, getArticleTitleFromSlug } from '@/lib/articles';
+import { formatDate } from '@/lib/utils';
+import { seriesSlug } from '@/lib/url';
+import { Headline } from '@/components/home/headline';
+import { FeaturedCard } from '@/components/home/featured-card';
+import { SeriesSpotlightCard } from '@/components/home/series-spotlight-card';
+import { LatestCard } from '@/components/home/latest-card';
+import { CategoriesCard } from '@/components/home/categories-card';
+import { RecentCard } from '@/components/home/recent-card';
+import { StatsCard } from '@/components/home/stats-card';
+import { ActivityHeatmap } from '@/components/home/activity-heatmap';
+import { WideLatestList } from '@/components/home/wide-latest-list';
 
 export const metadata = {
   title: "Frank's IT Blog",
   description: 'IT tech blog — development, cloud, database',
 };
 
-function formatDate(date: string): string {
-  const d = new Date(date);
-  if (isNaN(d.getTime())) return '';
-  return d.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+const RECENT_TONES = ['sage', 'butter', 'rose', 'cream'] as const;
+
+const HEATMAP_WEEKS = 16;
+
+type DayCount = { date: string; count: number };
+
+function buildHeatmap(articles: { date: string }[]): {
+  days: DayCount[];
+  streakWeeks: number;
+  peakPerWeek: number;
+} {
+  const totalDays = HEATMAP_WEEKS * 7;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const days: DayCount[] = [];
+  for (let i = totalDays - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    days.push({
+      date: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`,
+      count: 0,
+    });
+  }
+  const indexByDate = new Map<string, number>();
+  days.forEach((d, i) => indexByDate.set(d.date, i));
+
+  for (const a of articles) {
+    const d = new Date(a.date);
+    if (isNaN(d.getTime())) continue;
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const idx = indexByDate.get(key);
+    if (idx !== undefined) days[idx].count += 1;
+  }
+
+  let streakWeeks = 0;
+  for (let w = HEATMAP_WEEKS - 1; w >= 0; w--) {
+    const weekDays = days.slice(w * 7, w * 7 + 7);
+    const hasPost = weekDays.some((d) => d.count > 0);
+    if (hasPost) streakWeeks += 1;
+    else break;
+  }
+
+  let peakPerWeek = 0;
+  for (let w = 0; w < HEATMAP_WEEKS; w++) {
+    const weekTotal = days.slice(w * 7, w * 7 + 7).reduce((acc, d) => acc + d.count, 0);
+    if (weekTotal > peakPerWeek) peakPerWeek = weekTotal;
+  }
+
+  return { days, streakWeeks, peakPerWeek };
 }
 
-export default async function EnHome() {
+export default async function EnHomePage() {
   const articles = await getAllArticles('en');
+  const seriesNames = await getAllSeries('en');
+
+  const totalCount = articles.length;
+  const seriesCount = seriesNames.length;
+
+  const firstYear = articles
+    .map((a) => new Date(a.date).getFullYear())
+    .filter((y) => !isNaN(y))
+    .reduce((acc, y) => Math.min(acc, y), new Date().getFullYear());
+  const yearsWriting = Math.max(1, new Date().getFullYear() - firstYear);
+
+  const featured = articles[0];
+  const latest = articles.slice(1, 5);
+  const recent = articles.slice(5, 9);
+  const wideLatest = articles.slice(9, 14);
+
+  const featuredSeriesArticle = articles.find((a) => a.series);
+  let spotlightEpisodes: Array<{ num: number; title: string; slug: string }> = [];
+  let spotlightName = '';
+  if (featuredSeriesArticle?.series) {
+    spotlightName = featuredSeriesArticle.series;
+    const eps = await getArticlesBySeries(spotlightName, 'en');
+    spotlightEpisodes = eps.map((a, i) => ({
+      num: a.seriesOrder ?? i + 1,
+      title: a.title,
+      slug: getArticleTitleFromSlug(a.slug),
+    }));
+  }
+
+  const categoryCounts = new Map<string, number>();
+  for (const a of articles) {
+    categoryCounts.set(a.category, (categoryCounts.get(a.category) ?? 0) + 1);
+  }
+  const categories = Array.from(categoryCounts.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const { days, streakWeeks, peakPerWeek } = buildHeatmap(articles);
+
   return (
-    <main className="mx-auto max-w-3xl px-4 py-10">
-      <h1 className="text-2xl font-bold mb-6">Frank&apos;s IT Blog</h1>
-      <ul className="space-y-4">
-        {articles.map((a) => (
-          <li key={a.slug}>
-            <Link href={`/en/${getArticleTitleFromSlug(a.slug)}/`} className="font-medium hover:underline">
-              {a.title}
-            </Link>
-            <div className="text-sm text-muted-foreground">{formatDate(a.date)}</div>
-          </li>
+    <main className="min-h-screen bg-bento-bg pb-20 pt-2">
+      <Headline totalCount={totalCount} firstYear={firstYear} />
+
+      <section className="mx-auto grid max-w-canvas grid-cols-12 gap-3 px-6 md:gap-4 md:px-10">
+        {featured && (
+          <FeaturedCard
+            href={`/en/${encodeURIComponent(getArticleTitleFromSlug(featured.slug))}`}
+            title={featured.title}
+            category={featured.category}
+            date={formatDate(featured.date)}
+            excerpt={featured.excerpt}
+            readTime={featured.readTime}
+            tags={featured.tags}
+          />
+        )}
+
+        <StatsCard
+          stats={[
+            { value: String(totalCount), label: 'POSTS' },
+            { value: String(seriesCount), label: 'SERIES' },
+            { value: `${yearsWriting}y`, label: 'WRITING' },
+          ]}
+        />
+
+        {categories.length > 0 && (
+          <CategoriesCard
+            categories={categories}
+            totalCount={totalCount}
+            basePath="/en"
+            caption={
+              <>
+                {totalCount} posts<br />
+                across {categories.length} categories
+              </>
+            }
+          />
+        )}
+
+        {spotlightName && (
+          <SeriesSpotlightCard
+            seriesName={spotlightName}
+            seriesHref={`/en/series/${encodeURIComponent(seriesSlug(spotlightName))}`}
+            episodes={spotlightEpisodes}
+          />
+        )}
+
+        {latest.length > 0 && (
+          <LatestCard
+            basePath="/en"
+            subtitle="One post biweekly"
+            items={latest.map((a) => ({
+              slug: getArticleTitleFromSlug(a.slug),
+              title: a.title,
+              date: formatDate(a.date),
+            }))}
+          />
+        )}
+
+        <ActivityHeatmap
+          days={days}
+          weeks={HEATMAP_WEEKS}
+          streakWeeks={streakWeeks}
+          peakPerWeek={peakPerWeek}
+        />
+
+        {recent.map((a, i) => (
+          <RecentCard
+            key={a.slug}
+            href={`/en/${encodeURIComponent(getArticleTitleFromSlug(a.slug))}`}
+            title={a.title}
+            category={a.category}
+            date={formatDate(a.date)}
+            readTime={a.readTime}
+            tone={RECENT_TONES[i % RECENT_TONES.length]}
+          />
         ))}
-      </ul>
-      <p className="mt-8 text-sm"><Link href="/en/posts/" className="underline">All posts →</Link></p>
+
+        {wideLatest.length > 0 && (
+          <WideLatestList
+            basePath="/en"
+            heading="This month"
+            items={wideLatest.map((a) => ({
+              slug: getArticleTitleFromSlug(a.slug),
+              title: a.title,
+              category: a.category,
+              date: a.date,
+              readTime: a.readTime,
+            }))}
+            totalCount={totalCount}
+          />
+        )}
+      </section>
     </main>
   );
 }

--- a/components/home/categories-card.tsx
+++ b/components/home/categories-card.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { categorySlug } from '@/lib/url';
 
@@ -9,24 +10,35 @@ type CategoryEntry = {
 type Props = {
   categories: CategoryEntry[];
   totalCount: number;
+  basePath?: string;
+  caption?: ReactNode;
 };
 
 const FOCUS_RING =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-sage';
 
-export function CategoriesCard({ categories, totalCount }: Props) {
+export function CategoriesCard({
+  categories,
+  totalCount,
+  basePath = '',
+  caption = (
+    <>
+      {totalCount}편을<br />
+      {categories.length}개의 결로
+    </>
+  ),
+}: Props) {
   return (
     <div className="col-span-12 flex flex-col rounded-card-xl bg-bento-sage p-6 md:col-span-4 md:p-7">
       <div className="text-[10px] uppercase tracking-[0.1em] text-bento-ink/60">Topics</div>
       <h3 className="mt-2 text-2xl font-bold leading-tight tracking-tighter text-bento-ink md:text-3xl">
-        {totalCount}편을<br />
-        {categories.length}개의 결로
+        {caption}
       </h3>
       <div className="mt-auto flex flex-wrap gap-2 pt-6">
         {categories.map((c) => (
           <Link
             key={c.name}
-            href={`/category/${encodeURIComponent(categorySlug(c.name))}`}
+            href={`${basePath}/category/${encodeURIComponent(categorySlug(c.name))}`}
             className={[
               'inline-flex items-center gap-2 rounded-full bg-bento-ink/[0.08] px-3 py-1.5 text-[12px] text-bento-ink no-underline transition hover:bg-bento-ink/[0.12]',
               FOCUS_RING,

--- a/components/home/latest-card.tsx
+++ b/components/home/latest-card.tsx
@@ -8,20 +8,22 @@ type Item = {
 
 type Props = {
   items: Item[];
+  basePath?: string;
+  subtitle?: string;
 };
 
-export function LatestCard({ items }: Props) {
+export function LatestCard({ items, basePath = '', subtitle = '격주에 한 편씩' }: Props) {
   return (
     <div className="col-span-12 flex flex-col rounded-card-xl bg-bento-accent p-6 text-white md:col-span-4 md:p-7">
       <div className="text-[11px] uppercase tracking-[0.1em] text-white/70">Biweekly</div>
-      <h3 className="mt-2 text-xl font-bold tracking-tighter md:text-2xl">격주에 한 편씩</h3>
+      <h3 className="mt-2 text-xl font-bold tracking-tighter md:text-2xl">{subtitle}</h3>
       <ul className="mt-auto flex flex-col gap-2 pt-6">
         {items.map((it, i) => {
           const active = i < 2;
           return (
             <li key={it.slug}>
               <Link
-                href={`/${encodeURIComponent(it.slug)}`}
+                href={`${basePath}/${encodeURIComponent(it.slug)}`}
                 className="flex items-center gap-3 text-white no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bento-accent"
               >
                 <span

--- a/components/home/wide-latest-list.tsx
+++ b/components/home/wide-latest-list.tsx
@@ -11,6 +11,8 @@ type Item = {
 type Props = {
   items: Item[];
   totalCount: number;
+  basePath?: string;
+  heading?: string;
 };
 
 const FOCUS_RING =
@@ -22,7 +24,7 @@ function shortDate(iso: string): string {
   return `${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
 }
 
-export function WideLatestList({ items, totalCount }: Props) {
+export function WideLatestList({ items, totalCount, basePath = '', heading = '이번 달 글' }: Props) {
   if (items.length === 0) return null;
   return (
     <div className="col-span-12 flex flex-col rounded-card-xl bg-bento-card p-6 md:col-span-8 md:p-7">
@@ -30,11 +32,11 @@ export function WideLatestList({ items, totalCount }: Props) {
         <div>
           <div className="text-[10px] uppercase tracking-[0.1em] text-bento-dim">Latest</div>
           <h3 className="mt-1 text-xl font-bold tracking-tighter text-bento-ink md:text-2xl">
-            이번 달 글
+            {heading}
           </h3>
         </div>
         <Link
-          href="/posts"
+          href={`${basePath}/posts`}
           className={[
             'text-[13px] text-bento-dim no-underline transition hover:text-bento-ink',
             FOCUS_RING,
@@ -47,7 +49,7 @@ export function WideLatestList({ items, totalCount }: Props) {
         {items.map((a, i) => (
           <li key={a.slug}>
             <Link
-              href={`/${encodeURIComponent(a.slug)}`}
+              href={`${basePath}/${encodeURIComponent(a.slug)}`}
               className={[
                 'grid grid-cols-[52px_1fr] items-baseline gap-3 py-3 no-underline text-bento-ink transition hover:bg-bento-ink/[0.02] dark:hover:bg-white/[0.02] md:grid-cols-[60px_1fr_80px_50px]',
                 i > 0 ? 'border-t border-bento-ink/[0.06]' : '',

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { socialLinks } from '@/config/social';
+import { getLangFromPathname, localizeHref, type Lang } from '@/lib/i18n/lang';
+import { getDictionary } from '@/lib/i18n/dictionaries';
 
 interface Manifest {
   categories: string[];
@@ -10,6 +13,10 @@ interface Manifest {
 
 export function SiteFooter() {
   const [categories, setCategories] = useState<string[]>([]);
+  const pathname = usePathname();
+  const lang: Lang = getLangFromPathname(pathname);
+  const t = getDictionary(lang);
+  const rssHref = lang === 'en' ? '/en/rss.xml' : '/rss.xml';
 
   useEffect(() => {
     fetch('/content-manifest.json')
@@ -30,8 +37,7 @@ export function SiteFooter() {
           <div className="space-y-4">
             <h3 className="text-sm font-semibold">Frank's IT Blog</h3>
             <p className="text-sm text-bento-dim leading-relaxed">
-              기술 블로그, 프로그래밍, 개발 관련<br />
-              지식과 경험을 공유하는 개인 블로그입니다.
+              {t.footer.tagline}
             </p>
             {/* 소셜 링크 */}
             <div className="flex gap-4">
@@ -52,13 +58,13 @@ export function SiteFooter() {
 
           {/* 중앙: 카테고리 */}
           <div className="space-y-4">
-            <h3 className="text-sm font-semibold">카테고리</h3>
+            <h3 className="text-sm font-semibold">{t.footer.categories}</h3>
             <div className="grid grid-cols-3 gap-x-4 gap-y-2">
               {categories.length > 0 ? (
                 categories.map(tag => (
                   <Link
                     key={tag}
-                    href={`/?category=${tag}`}
+                    href={localizeHref(`/?category=${tag}`, lang)}
                     className="text-sm text-bento-dim hover:text-bento-ink hover:underline transition-colors"
                   >
                     {tag}
@@ -72,25 +78,25 @@ export function SiteFooter() {
 
           {/* 오른쪽: 정보 */}
           <div className="space-y-4">
-            <h3 className="text-sm font-semibold">정보</h3>
+            <h3 className="text-sm font-semibold">{t.footer.info}</h3>
             <div className="space-y-2">
               <a
-                href="/rss.xml"
+                href={rssHref}
                 className="block text-sm text-bento-dim hover:text-bento-ink hover:underline transition-colors"
               >
-                RSS
+                {t.footer.rss}
               </a>
               <a
                 href="/sitemap.xml"
                 className="block text-sm text-bento-dim hover:text-bento-ink hover:underline transition-colors"
               >
-                사이트맵
+                {t.footer.sitemap}
               </a>
               <Link
-                href="/series"
+                href={localizeHref('/series', lang)}
                 className="block text-sm text-bento-dim hover:text-bento-ink hover:underline transition-colors"
               >
-                시리즈
+                {t.footer.series}
               </Link>
             </div>
           </div>

--- a/docs/superpowers/plans/2026-06-03-blog-en-home.md
+++ b/docs/superpowers/plans/2026-06-03-blog-en-home.md
@@ -1,0 +1,100 @@
+# 영어 홈 페이지 (Plan 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or executing-plans. Steps use checkbox (`- [ ]`).
+
+**Goal:** `/en/` 홈을 한국어 홈(`app/page.tsx`)과 동일한 bento 레이아웃으로 완성한다 — 영어 데이터, 현지화 라벨, `/en` 링크. (현재 영어 글 135건으로 위젯이 충분히 채워짐)
+
+**Architecture:** `app/en/page.tsx`를 `app/page.tsx` 기반으로 미러링하되 모든 데이터 조회에 `'en'`을 쓰고, href는 `/en` prefix. 홈 위젯 대부분은 `href`를 prop으로 받으므로 페이지에서 `/en` 링크를 넘기면 된다. 링크/라벨을 하드코딩한 3개 위젯(`wide-latest-list`, `categories-card`, `latest-card`)에만 선택적 `basePath`(기본 `''`)와 라벨 prop(기본 한국어)을 추가한다. QOTD(QuoteSection)는 한국어 명언 기반이라 영어 홈에서 제외.
+
+**Tech Stack:** Next.js App Router(static export), TS. 검증: `npm run check`, `npm run build`, `npm run dev`.
+
+---
+
+## File Structure
+
+- `components/home/wide-latest-list.tsx` — 수정: `basePath?=''` + `heading?` 라벨 prop("이번 달 글")
+- `components/home/categories-card.tsx` — 수정: `basePath?=''` + 문구 prop(또는 영어 분기)
+- `components/home/latest-card.tsx` — 수정: `basePath?=''` + `subtitle?` 라벨 prop("격주에 한 편씩")
+- `app/en/page.tsx` — 교체: 최소 홈 → 한국어 홈 전체 미러(영어판)
+
+---
+
+## Task 1: 링크/라벨 하드코딩 위젯 3종에 prop 추가
+
+**Files:** `components/home/wide-latest-list.tsx`, `components/home/categories-card.tsx`, `components/home/latest-card.tsx`
+
+각 위젯에 선택적 prop을 추가하되 **기본값은 현재 한국어 동작과 동일**(한국어 홈 무변경).
+
+- [ ] **Step 1: wide-latest-list.tsx**
+  - Props에 `basePath?: string` (기본 `''`), `heading?: string` (기본 `'이번 달 글'`) 추가.
+  - 33행 텍스트 `이번 달 글` → `{heading}`.
+  - 37행 `href="/posts"` → `` href={`${basePath}/posts`} ``; 50행 `` href={`/${encodeURIComponent(a.slug)}`} `` → `` href={`${basePath}/${encodeURIComponent(a.slug)}`} ``.
+
+- [ ] **Step 2: latest-card.tsx**
+  - Props에 `basePath?: string` (기본 `''`), `subtitle?: string` (기본 `'격주에 한 편씩'`) 추가.
+  - 17행 `격주에 한 편씩` → `{subtitle}`; 24행 slug href에 `${basePath}` prefix.
+
+- [ ] **Step 3: categories-card.tsx**
+  - Props에 `basePath?: string` (기본 `''`) 추가; 29행 `` href={`/category/${encodeURIComponent(categorySlug(c.name))}`} `` → `${basePath}` prefix.
+  - 22-23행 한글 문구(`{totalCount}편을 {categories.length}개의 결로`)는 선택적 prop `caption?: React.ReactNode`로 빼서 기본값을 현재 한글 JSX로 두고, 영어 페이지에서 영어 문구를 넘길 수 있게 한다. (기본값 유지로 한국어 홈 무변경)
+
+- [ ] **Step 4: 타입 체크**
+
+Run: `npm run check`
+Expected: 통과 (기본값으로 한국어 홈 무영향).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add components/home/wide-latest-list.tsx components/home/latest-card.tsx components/home/categories-card.tsx
+git commit -m "feat: 홈 위젯 3종에 basePath/라벨 prop 추가 (기본 한국어 유지)"
+```
+
+---
+
+## Task 2: 영어 홈 전체 미러 (app/en/page.tsx)
+
+**Files:** `app/en/page.tsx` (기존 최소 홈을 교체), Read first: `app/page.tsx`
+
+- [ ] **Step 1: 한국어 홈 전체 읽기**
+
+Run: `cat app/page.tsx`
+목적: `buildHeatmap` 헬퍼, 데이터 조회, 위젯 배치, props 파악.
+
+- [ ] **Step 2: 영어 홈 작성**
+
+`app/page.tsx`를 기반으로 `app/en/page.tsx`를 작성:
+- 모든 데이터: `getAllArticles('en')`, `getAllSeries('en')`, `getArticlesBySeries(name, 'en')`.
+- `buildHeatmap` 헬퍼는 동일 로직 재사용(영어 글 날짜 기반).
+- href를 prop으로 받는 위젯(FeaturedCard, RecentCard, SeriesSpotlightCard, QuoteCard 등)에는 `/en/...` 링크를 넘긴다.
+- `WideLatestList`, `LatestCard`, `CategoriesCard`에는 `basePath="/en"`과 영어 라벨 전달:
+  - WideLatestList `heading="This month"`
+  - LatestCard `subtitle="One post biweekly"`
+  - CategoriesCard `caption={<>{totalCount} posts<br />across {categories.length} categories</>}`
+- `<Headline>`는 이미 영어(언어 중립) — 그대로 사용.
+- **QuoteSection 제외** (한국어 명언 기반). 그 자리는 비우거나 레이아웃이 깨지지 않게 조정.
+- `metadata`는 영어 title/description.
+
+- [ ] **Step 3: 타입 체크 + 빌드**
+
+Run: `npm run generate:manifest && npm run check && npm run build`
+검증: `npm run build` 성공, `out/en/index.html` 생성. `grep -c "/en/" out/en/index.html` > 0 (영어 홈 내부 링크가 /en).
+
+- [ ] **Step 4: dev 확인**
+
+`http://localhost:3000/en/` — 한국어 홈과 동일 레이아웃, 영어 글/시리즈/카테고리로 채워지고 모든 링크가 `/en/...`. 헤더 토글로 `/`↔`/en/` 정상.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/en/page.tsx
+git commit -m "feat: 영어 홈을 한국어 홈 레이아웃으로 완성 (/en 전체 위젯)"
+```
+
+---
+
+## Self-Review
+
+- **Coverage:** 영어 홈 완전 현지화(레이아웃·데이터·링크·라벨) Task 1~2로 커버. QOTD는 의도적 제외(한국어 명언).
+- **Type consistency:** `basePath?: string = ''` + 라벨 prop 기본값으로 한국어 홈 무변경 보장.
+- **Scope:** 종료 시 `/en/`이 한국어 홈과 동등한 경험 제공.

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -5,6 +5,7 @@ type Dict = {
   article: { related: string; prev: string; next: string; toc: string };
   posts: { all: string; categories: string };
   language: { ko: string; en: string };
+  footer: { tagline: string; categories: string; info: string; rss: string; sitemap: string; series: string };
 };
 
 const ko: Dict = {
@@ -12,6 +13,14 @@ const ko: Dict = {
   article: { related: '관련 글', prev: '이전 글', next: '다음 글', toc: '목차' },
   posts: { all: '전체 글', categories: '카테고리' },
   language: { ko: '한국어', en: 'English' },
+  footer: {
+    tagline: '기술 블로그, 프로그래밍, 개발 관련 지식과 경험을 공유하는 개인 블로그입니다.',
+    categories: '카테고리',
+    info: '정보',
+    rss: 'RSS',
+    sitemap: '사이트맵',
+    series: '시리즈',
+  },
 };
 
 const en: Dict = {
@@ -19,6 +28,14 @@ const en: Dict = {
   article: { related: 'Related posts', prev: 'Previous', next: 'Next', toc: 'Contents' },
   posts: { all: 'All posts', categories: 'Categories' },
   language: { ko: '한국어', en: 'English' },
+  footer: {
+    tagline: 'A personal blog sharing knowledge and experience on tech, programming, and development.',
+    categories: 'Categories',
+    info: 'Info',
+    rss: 'RSS',
+    sitemap: 'Sitemap',
+    series: 'Series',
+  },
 };
 
 const dictionaries: Record<Lang, Dict> = { ko, en };


### PR DESCRIPTION
## Summary
영어 글이 135건으로 충분해져, 그동안 최소 구성이던 `/en/` 홈을 한국어 홈과 동일한 bento 레이아웃으로 완성한다. 더불어 누락됐던 푸터 현지화도 포함.

- 홈 위젯 3종(`wide-latest-list`, `latest-card`, `categories-card`)에 선택적 `basePath`(기본 `''`)·라벨 prop 추가 → 한국어 홈 무변경
- `app/en/page.tsx`를 한국어 홈 전체 미러로 교체 (영어 데이터 `getAll*('en')`, `/en` 링크, 영어 라벨)
  - QOTD(QuoteSection)는 한국어 명언 기반이라 영어 홈에서 제외
- `SiteFooter` 언어 현지화 (헤더와 동일한 pathname 기반): 라벨 영어화 + `/en` 링크 + `/en/rss.xml`
- i18n 사전에 `footer` 섹션 추가(ko/en)

## 설계 문서
- plan: `docs/superpowers/plans/2026-06-03-blog-en-home.md`

## Test plan
- [x] `npm run check` (tsc) 통과, `npm run build` 성공
- [x] `/en/` 홈에 영어 글/시리즈/카테고리·히트맵 렌더, 내부 링크 38개 모두 `/en/`
- [x] 영어 홈 한국어 루트 링크 누수 0건 (푸터 포함)
- [x] 한국어 홈/푸터 무변경 (위젯 기본값 유지)
- [ ] dev에서 헤더 토글 `/`↔`/en/` 및 푸터 링크 동작 최종 확인

## 후속 (범위 밖)
- 영어 QOTD 소스 도입 시 영어 홈에 명언 섹션 재추가 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)