### PR TITLE
fix: QOTD 언어 파라미터 수정 + 영어 홈 명언 추가

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -10,6 +10,8 @@ import { RecentCard } from '@/components/home/recent-card';
 import { StatsCard } from '@/components/home/stats-card';
 import { ActivityHeatmap } from '@/components/home/activity-heatmap';
 import { WideLatestList } from '@/components/home/wide-latest-list';
+import { QuoteSection } from '@/components/home/quote-section';
+import type { QuoteViewData } from '@/hooks/use-quote-of-the-day';
 
 export const metadata = {
   title: "Frank's IT Blog",
@@ -17,6 +19,11 @@ export const metadata = {
 };
 
 const RECENT_TONES = ['sage', 'butter', 'rose', 'cream'] as const;
+
+const QOTD_FALLBACK_EN: QuoteViewData = {
+  content: 'A well-kept note is the best gift to your future self.',
+  attribution: '— writing principle',
+};
 
 const HEATMAP_WEEKS = 16;
 
@@ -201,6 +208,8 @@ export default async function EnHomePage() {
             totalCount={totalCount}
           />
         )}
+
+        <QuoteSection fallback={QOTD_FALLBACK_EN} language="en" />
       </section>
     </main>
   );

--- a/components/home/quote-section.tsx
+++ b/components/home/quote-section.tsx
@@ -9,10 +9,12 @@ import {
 type Props = {
   /** 빌드 시 정적 HTML에 박히는 명언. fetch 실패/지연 시에도 이 값이 표시된다. */
   fallback: QuoteViewData;
+  /** 명언 언어 (기본 ko). en이면 영어 오늘의 명언을 받아온다. */
+  language?: 'ko' | 'en';
 };
 
-export function QuoteSection({ fallback }: Props) {
-  const data = useQuoteOfTheDay(fallback);
+export function QuoteSection({ fallback, language = 'ko' }: Props) {
+  const data = useQuoteOfTheDay(fallback, language);
   return (
     <QuoteCard
       content={data.content}

--- a/hooks/use-quote-of-the-day.ts
+++ b/hooks/use-quote-of-the-day.ts
@@ -21,13 +21,16 @@ export type QuoteViewData = {
  * - 실패하면 fallback을 그대로 유지하고 콘솔에 warn만 남긴다.
  *   (명언은 데코레이션 요소라 사용자에게 에러를 노출하지 않는다.)
  */
-export function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData {
+export function useQuoteOfTheDay(
+  fallback: QuoteViewData,
+  language: 'ko' | 'en' = 'ko',
+): QuoteViewData {
   const [data, setData] = useState<QuoteViewData>(fallback);
 
   useEffect(() => {
     let cancelled = false;
 
-    fetchQuoteOfTheDay('ko')
+    fetchQuoteOfTheDay(language)
       .then((q) => {
         if (cancelled || !q) return;
         // 방어적 처리: 응답은 검증 없이 캐스팅된 JSON이라 타입상 string이어도
@@ -53,7 +56,7 @@ export function useQuoteOfTheDay(fallback: QuoteViewData): QuoteViewData {
     // fallback.attribution만 의존성에 포함. effect 내부에서 fallback.attribution만 참조하기 때문이다.
     // fallback.content는 useState 초기값으로만 쓰이고 effect 본문에서 참조되지 않으므로 의도적으로 제외.
     // (fallback 객체 전체를 dep에 넣으면 호출자가 fallback을 메모이즈하지 않을 경우 무한 재호출 위험.)
-  }, [fallback.attribution]);
+  }, [fallback.attribution, language]);
 
   return data;
 }

--- a/lib/inspireme.ts
+++ b/lib/inspireme.ts
@@ -31,7 +31,7 @@ export function quoteDetailUrl(id: string): string {
 export async function fetchQuoteOfTheDay(
   language: string = 'ko',
 ): Promise<InspireMeWidgetQuote | null> {
-  const url = `${INSPIRE_ME_BASE_URL}/api/widget/quote-of-the-day?language=${encodeURIComponent(language)}`;
+  const url = `${INSPIRE_ME_BASE_URL}/api/widget/quote-of-the-day?lang=${encodeURIComponent(language)}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`QOTD widget API returned ${res.status}`);


### PR DESCRIPTION
## Summary
영어 홈에 오늘의 명언이 빠져 있던 문제를 해결한다. 확인 결과 inspireme에 영어 명언이 존재하지만(`?lang=en`), 블로그가 잘못된 파라미터(`?language=`)로 호출해 항상 한국어가 반환되고 있었다.

- **버그 수정** `lib/inspireme.ts`: QOTD 위젯 쿼리 파라미터 `language` → `lang`
  - inspireme 위젯 핸들러는 `c.QueryParam("lang")`(ko|en)을 읽음. 기존 `language=`는 무시되어 항상 기본값 ko 반환 (한국어는 우연히 동작, 영어는 불가)
- `useQuoteOfTheDay(fallback, language='ko')` / `QuoteSection`에 `language` 인자 추가
- 영어 홈(`app/en/page.tsx`)에 `QuoteSection(language="en")` + 영어 fallback 재추가

## 동작
- 영어 홈: 마운트 후 inspireme `?lang=en` 영어 오늘의 명언 표시 (예: "Heaven helps those who help themselves." — Samuel Smiles)
- 한국어 홈: 변경 없음(여전히 한국어 QOTD), 파라미터 이름이 정확해져 더 견고

## Test plan
- [x] `npm run check` (tsc) 통과, `npm run build` 성공
- [x] 영어 홈 영어 fallback 렌더 / 한국어 홈 한국어 fallback 유지
- [x] `curl '.../quote-of-the-day?lang=en'` → 영어 명언 확인
- [ ] 배포 후 영어 홈에서 실제 영어 QOTD 교체 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)