### PR TITLE
fix(home): 시리즈 스포트라이트 episode 최대 4개로 제한

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -99,7 +99,7 @@ export default async function EnHomePage() {
   if (featuredSeriesArticle?.series) {
     spotlightName = featuredSeriesArticle.series;
     const eps = await getArticlesBySeries(spotlightName, 'en');
-    spotlightEpisodes = eps.map((a, i) => ({
+    spotlightEpisodes = eps.slice(0, 4).map((a, i) => ({
       num: a.seriesOrder ?? i + 1,
       title: a.title,
       slug: getArticleTitleFromSlug(a.slug),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,7 +99,7 @@ export default async function HomePage() {
   if (featuredSeriesArticle?.series) {
     spotlightName = featuredSeriesArticle.series;
     const eps = await getArticlesBySeries(spotlightName);
-    spotlightEpisodes = eps.map((a, i) => ({
+    spotlightEpisodes = eps.slice(0, 4).map((a, i) => ({
       num: a.seriesOrder ?? i + 1,
       title: a.title,
       slug: getArticleTitleFromSlug(a.slug),


### PR DESCRIPTION
## Summary
홈 시리즈 스포트라이트 카드가 시리즈 전체 episode를 제한 없이 노출해, 격주 뉴스처럼 긴 시리즈가 스포트라이트되면 1~9가 모두 표시되던 문제를 수정한다.

- `spotlightEpisodes`를 `.slice(0, 4)`로 제한 (최대 4개)
- 한국어 홈(`app/page.tsx`)과 영어 홈(`app/en/page.tsx`)에 동일 적용

## Test plan
- [x] `npm run check` (tsc) 통과, `npm run build` 성공
- [ ] dev에서 `/`·`/en/` 시리즈 카드가 최대 4개만 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)