### PR TITLE
fix: 영어 번역본 series frontmatter 한글→영어 번역

### DIFF
--- a/.claude/skills/translate-article-en/SKILL.md
+++ b/.claude/skills/translate-article-en/SKILL.md
@@ -37,7 +37,8 @@ description: Use when translating a Korean blog article (contents/{category}/{sl
 | 본문 산문 | 영어로 번역 (자연스러운 기술문서 톤) |
 | frontmatter `title` / `description` | 영어로 번역 |
 | frontmatter `tags` | **그대로 유지** (번역/추가/삭제 안 함 — 검색 일관성) |
-| frontmatter `date` / `update` / `series` / `seriesOrder` | **원본 값 유지** |
+| frontmatter `series` | **영어로 번역** (영어 series 페이지에 그대로 노출됨 — 같은 series는 항상 동일한 영어 이름으로 통일) |
+| frontmatter `date` / `update` / `seriesOrder` | **원본 값 유지** |
 | 섹션 heading | 영어로 번역 (`# 참고` → `# References`, `# 들어가며` → `# Introduction` 등) |
 | 코드 블록의 코드/식별자/문법 | **보존** (변수명·함수명·키워드 변경 금지) |
 | 코드 블록 안의 한글 (주석·한글 문자열·한글 샘플데이터) | **영어로 번역** |
@@ -85,6 +86,7 @@ tags:
 
 - ❌ 코드 식별자/로직을 영어로 바꿔 예제가 깨짐 → ✅ 코드는 보존, 한글 주석만 번역
 - ❌ tags를 영어로 번역 → ✅ 그대로 유지
+- ❌ series를 한국어 원본 그대로 둠 → ✅ 영어로 번역 (같은 series에 속한 글은 모두 동일한 영어 이름으로 통일 — 안 그러면 영어 series 페이지에서 갈라짐)
 - ❌ `index.en.md`로 저장 → ✅ **`index_en.md`** (언더스코어)
 - ❌ 이미지 파일명을 영어로 바꿈 → ✅ 원본 경로 그대로 (이미지 공유)
 - ❌ Mermaid 노드에 `<br/>` 추가 → ✅ 줄바꿈 필요 시 노드 분리/단순화

--- a/contents/ai/claude-code-plugin-hooks-완벽-가이드/index_en.md
+++ b/contents/ai/claude-code-plugin-hooks-완벽-가이드/index_en.md
@@ -12,7 +12,7 @@ tags:
   - AI코딩도구
   - 워크플로우자동화
   - Anthropic
-series: "Claude Code 완벽 가이드"
+series: "Claude Code Complete Guide"
 ---
 
 # 1. Overview

--- a/contents/ai/claude-code-superpowers-완벽-가이드/index_en.md
+++ b/contents/ai/claude-code-superpowers-완벽-가이드/index_en.md
@@ -17,7 +17,7 @@ tags:
   - TDD
   - 코드리뷰
   - Anthropic
-series: "Claude Code 완벽 가이드"
+series: "Claude Code Complete Guide"
 ---
 
 # 1. Overview

--- a/contents/ai/claude-code-멀티-계정-전환-가이드/index_en.md
+++ b/contents/ai/claude-code-멀티-계정-전환-가이드/index_en.md
@@ -11,7 +11,7 @@ tags:
   - OAuth
   - rate limit
   - 계정 전환
-series: "Claude Code 실전 가이드"
+series: "Claude Code Practical Guide"
 ---
 
 # 1. Overview

--- a/contents/ai/claude-code-확장-기능-완벽-가이드-command-skill-subagent/index_en.md
+++ b/contents/ai/claude-code-확장-기능-완벽-가이드-command-skill-subagent/index_en.md
@@ -13,7 +13,7 @@ tags:
   - 슬래시커맨드
   - AI코딩도구
   - 워크플로우자동화
-series: "Claude Code 완벽 가이드"
+series: "Claude Code Complete Guide"
 ---
 
 # 1. Overview

--- a/contents/ai/openclaw-telegram-멀티-에이전트-구성하기/index_en.md
+++ b/contents/ai/openclaw-telegram-멀티-에이전트-구성하기/index_en.md
@@ -10,7 +10,7 @@ tags:
   - 멀티에이전트
   - 셀프호스팅
   - 챗봇
-series: "OpenClaw 활용 가이드"
+series: "OpenClaw Guide"
 ---
 
 # 1. Overview

--- a/contents/ai/openclaw에서-gog로-google-workspace-연동하기/index_en.md
+++ b/contents/ai/openclaw에서-gog로-google-workspace-연동하기/index_en.md
@@ -18,7 +18,7 @@ tags:
   - 텔레그램
   - AI에이전트
   - 자동화
-series: "OpenClaw 활용 가이드"
+series: "OpenClaw Guide"
 ---
 # 1. Overview
 

--- a/contents/database/mqtt-v5-완벽-가이드-1-입문과-기본-아키텍처/index_en.md
+++ b/contents/database/mqtt-v5-완벽-가이드-1-입문과-기본-아키텍처/index_en.md
@@ -17,7 +17,7 @@ tags:
   - 브로커
   - 메시징
   - 로봇
-series: "MQTT v5 완벽 가이드"
+series: "MQTT v5 Complete Guide"
 ---
 
 > As I started using MQTT at work, I put together these study notes to get familiar with the protocol.

--- a/contents/database/mqtt-v5-완벽-가이드-2-topic-설계와-메시지-모델/index_en.md
+++ b/contents/database/mqtt-v5-완벽-가이드-2-topic-설계와-메시지-모델/index_en.md
@@ -15,7 +15,7 @@ tags:
   - 토픽 설계
   - 메시지 브로커
   - 발행구독 패턴
-series: "MQTT v5 완벽 가이드"
+series: "MQTT v5 Complete Guide"
 ---
 
 # 1. Topic Design

--- a/contents/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략/index_en.md
+++ b/contents/database/mqtt-v5-완벽-가이드-3-qos-session-재연결-전략/index_en.md
@@ -17,7 +17,7 @@ tags:
   - 메시지 전달 보장
   - 세션 관리
   - 네트워크 복원
-series: "MQTT v5 완벽 가이드"
+series: "MQTT v5 Complete Guide"
 ---
 
 # 1. Mastering QoS

--- a/contents/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안/index_en.md
+++ b/contents/database/mqtt-v5-완벽-가이드-4-고급-기능과-보안/index_en.md
@@ -17,7 +17,7 @@ tags:
   - 메시지 큐
   - IoT
   - 로드 밸런싱
-series: "MQTT v5 완벽 가이드"
+series: "MQTT v5 Complete Guide"
 ---
 
 # 1. MQTT v5 Advanced Features

--- a/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index_en.md
+++ b/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index_en.md
@@ -17,7 +17,7 @@ tags:
   - 실전 구현
   - IoT
   - 메시지 브로커
-series: "MQTT v5 완벽 가이드"
+series: "MQTT v5 Complete Guide"
 ---
 
 # 1. Using Go + Paho (v5)

--- a/contents/go/go에서-strategy-패턴-제대로-활용하기/index_en.md
+++ b/contents/go/go에서-strategy-패턴-제대로-활용하기/index_en.md
@@ -15,7 +15,7 @@ tags:
   - 고언어
   - interface
   - 인터페이스
-series: "Go 디자인 패턴"
+series: "Go Design Patterns"
 ---
 
 # 1. Overview

--- a/contents/go/grafana-pyroscope로-go-애플리케이션-continuous-profiling-시작하기/index_en.md
+++ b/contents/go/grafana-pyroscope로-go-애플리케이션-continuous-profiling-시작하기/index_en.md
@@ -15,7 +15,7 @@ tags:
   - pprof
   - 고랭
   - 프로파일링
-series: "Grafana 완벽 가이드"
+series: "Grafana Complete Guide"
 ---
 
 # 1. Introduction

--- a/contents/java/자바8-optional이란/index_en.md
+++ b/contents/java/자바8-optional이란/index_en.md
@@ -11,7 +11,7 @@ tags:
   - openjdk
   - 자바
   - 자바8
-series: "자바8"
+series: "Java 8"
 ---
 
 # 1. What Is Optional


### PR DESCRIPTION
## Summary
- 영어 series 페이지(`/en/series/`)에 한국어 series 이름이 그대로 노출되던 문제 수정
- **원인**: `translate-article-en` 스킬이 `series` 필드를 "원본 값 유지"하도록 지시 → 원본이 한국어인 series가 영어 페이지에 한글로 표시됨 (번역 누락이 아닌 스킬 규칙 문제)
- 한국어로 남아 있던 14개 `index_en.md`의 `series` 필드를 영어로 통일
- `translate-article-en` 스킬 규칙도 수정하여 향후 재발 방지

## series 매핑
| 한국어 (기존) | 영어 (변경) | 글 수 |
|---|---|---|
| 자바8 | Java 8 | 1 |
| Go 디자인 패턴 | Go Design Patterns | 1 |
| MQTT v5 완벽 가이드 | MQTT v5 Complete Guide | 5 |
| Claude Code 완벽 가이드 | Claude Code Complete Guide | 3 |
| Claude Code 실전 가이드 | Claude Code Practical Guide | 1 |
| OpenClaw 활용 가이드 | OpenClaw Guide | 2 |
| Grafana 완벽 가이드 | Grafana Complete Guide | 1 |

## Test plan
- [x] `npm run generate:manifest` 후 en series에 한국어 0개 확인 (총 22 series)
- [ ] `/en/series/` 페이지에서 모든 series 이름 영어 표시 확인
- [ ] 같은 series 글들이 한 묶음으로 그룹핑되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)