### PR TITLE
fix: 영어 홈 활동 히트맵 제목 영어화

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -180,6 +180,7 @@ export default async function EnHomePage() {
           weeks={HEATMAP_WEEKS}
           streakWeeks={streakWeeks}
           peakPerWeek={peakPerWeek}
+          language="en"
         />
 
         {recent.map((a, i) => (

--- a/components/home/activity-heatmap.tsx
+++ b/components/home/activity-heatmap.tsx
@@ -13,6 +13,8 @@ type Props = {
   streakWeeks: number;
   /** 메타: 한 주 최대 발행 수 */
   peakPerWeek: number;
+  /** 표시 언어 (기본 ko) */
+  language?: 'ko' | 'en';
 };
 
 function opacityFor(count: number): number {
@@ -22,12 +24,13 @@ function opacityFor(count: number): number {
   return 1.0;
 }
 
-export function ActivityHeatmap({ days, weeks, streakWeeks, peakPerWeek }: Props) {
+export function ActivityHeatmap({ days, weeks, streakWeeks, peakPerWeek, language = 'ko' }: Props) {
+  const heading = language === 'en' ? 'A Record of Consistency' : '꾸준함의 기록';
   return (
     <div className="col-span-12 flex flex-col rounded-card-xl bg-bento-card p-6 md:col-span-4 md:p-7">
       <div className="text-[10px] uppercase tracking-[0.1em] text-bento-dim">Last {weeks} weeks</div>
       <h3 className="mt-2 text-xl font-bold tracking-tighter text-bento-ink md:text-2xl">
-        꾸준함의 기록
+        {heading}
       </h3>
       <div
         className="mt-6 flex-1 grid gap-1"
@@ -43,7 +46,7 @@ export function ActivityHeatmap({ days, weeks, streakWeeks, peakPerWeek }: Props
             key={d.date}
             className="rounded-[3px] bg-bento-accent"
             style={{ opacity: opacityFor(d.count), minHeight: '8px' }}
-            title={`${d.date}: ${d.count}편`}
+            title={language === 'en' ? `${d.date}: ${d.count}` : `${d.date}: ${d.count}편`}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- 영어 홈(`/en/`)에서 활동 히트맵 위젯 제목이 한글("꾸준함의 기록")로 노출되던 문제 수정
- `ActivityHeatmap`에 `language?: 'ko' | 'en'` prop 추가 (기존 `quote-section.tsx` 패턴 준용)
  - 영어: **A Record of Consistency** / 한글: 꾸준함의 기록
  - 셀 툴팁 `편` 표기도 영어에서는 제거
- `app/en/page.tsx`에서 `language="en"` 전달, 한글 홈은 기본값 유지

## Test plan
- [ ] `/en/` 진입 시 히트맵 제목이 "A Record of Consistency"로 표시되는지 확인
- [ ] `/` (한글 홈) 제목은 "꾸준함의 기록" 그대로인지 확인