### PR TITLE
fix: go/golang 중복 태그를 golang으로 통일

### DIFF
--- a/contents/database/m1-맥북에서-memongo-실행하기/index.md
+++ b/contents/database/m1-맥북에서-memongo-실행하기/index.md
@@ -8,7 +8,6 @@ tags:
   - mac
   - mongo
   - mongodb
-  - go
   - golang
   - 몽고
   - 맥북

--- a/contents/database/m1-맥북에서-memongo-실행하기/index_en.md
+++ b/contents/database/m1-맥북에서-memongo-실행하기/index_en.md
@@ -8,7 +8,6 @@ tags:
   - mac
   - mongo
   - mongodb
-  - go
   - golang
   - 몽고
   - 맥북

--- a/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index.md
+++ b/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index.md
@@ -6,7 +6,6 @@ update: 2026-02-20
 tags:
   - MQTT
   - MQTT v5
-  - Go
   - Golang
   - Paho
   - autopaho

--- a/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index_en.md
+++ b/contents/database/mqtt-v5-완벽-가이드-5-go-paho-실전-구현과-운영/index_en.md
@@ -6,7 +6,6 @@ update: 2026-02-20
 tags:
   - MQTT
   - MQTT v5
-  - Go
   - Golang
   - Paho
   - autopaho

--- a/contents/go/go-1-26-변경사항-whats-new-in-go-1-26/index.md
+++ b/contents/go/go-1-26-변경사항-whats-new-in-go-1-26/index.md
@@ -5,7 +5,6 @@ date: 2026-03-13
 update: 2026-03-13
 tags:
   - golang
-  - go
   - go1.26
   - new
   - green-tea-gc

--- a/contents/go/go-1-26-변경사항-whats-new-in-go-1-26/index_en.md
+++ b/contents/go/go-1-26-변경사항-whats-new-in-go-1-26/index_en.md
@@ -5,7 +5,6 @@ date: 2026-03-13
 update: 2026-03-13
 tags:
   - golang
-  - go
   - go1.26
   - new
   - green-tea-gc

--- a/contents/go/go-fx-의존성-주입/index.md
+++ b/contents/go/go-fx-의존성-주입/index.md
@@ -4,7 +4,6 @@ description: "uber/fx를 사용하여 Go 애플리케이션의 의존성을 자�
 date: 2026-05-24
 update: 2026-05-24
 tags:
-  - Go
   - Golang
   - uber/fx
   - Dependency Injection

--- a/contents/go/go-fx-의존성-주입/index_en.md
+++ b/contents/go/go-fx-의존성-주입/index_en.md
@@ -4,7 +4,6 @@ description: "How to use uber/fx to automatically wire dependencies in a Go appl
 date: 2026-05-24
 update: 2026-05-24
 tags:
-  - Go
   - Golang
   - uber/fx
   - Dependency Injection

--- a/contents/go/go-pprof-프로파일링으로-성능-문제-진단하기/index.md
+++ b/contents/go/go-pprof-프로파일링으로-성능-문제-진단하기/index.md
@@ -4,7 +4,6 @@ description: "Go의 내장 프로파일링 도구 pprof를 활용하여 CPU, 메
 date: 2026-04-09
 update: 2026-04-09
 tags:
-  - go
   - golang
   - pprof
   - profiling

--- a/contents/go/go-pprof-프로파일링으로-성능-문제-진단하기/index_en.md
+++ b/contents/go/go-pprof-프로파일링으로-성능-문제-진단하기/index_en.md
@@ -4,7 +4,6 @@ description: "How to use Go's built-in profiling tool pprof to diagnose and opti
 date: 2026-04-09
 update: 2026-04-09
 tags:
-  - go
   - golang
   - pprof
   - profiling

--- a/contents/go/go-recover-함수에서-반환값을-반환하는-예제/index.md
+++ b/contents/go/go-recover-함수에서-반환값을-반환하는-예제/index.md
@@ -5,7 +5,6 @@ date: 2022-08-07
 update: 2022-08-07
 tags:
   - golang
-  - go
   - recover
   - return
   - panic

--- a/contents/go/go-recover-함수에서-반환값을-반환하는-예제/index_en.md
+++ b/contents/go/go-recover-함수에서-반환값을-반환하는-예제/index_en.md
@@ -5,7 +5,6 @@ date: 2022-08-07
 update: 2022-08-07
 tags:
   - golang
-  - go
   - recover
   - return
   - panic

--- a/contents/go/go-ternary-operator-삼항연산자/index.md
+++ b/contents/go/go-ternary-operator-삼항연산자/index.md
@@ -4,7 +4,6 @@ description: "Go Ternary Operator (삼항연산자)"
 date: 2021-05-18
 update: 2021-05-18
 tags:
-  - go
   - golang
   - ternary
   - operator

--- a/contents/go/go-ternary-operator-삼항연산자/index_en.md
+++ b/contents/go/go-ternary-operator-삼항연산자/index_en.md
@@ -4,7 +4,6 @@ description: "Why Go has no ternary operator, and how to mimic one with a functi
 date: 2021-05-18
 update: 2021-05-18
 tags:
-  - go
   - golang
   - ternary
   - operator

--- a/contents/go/go-wails-desktop-app/index.md
+++ b/contents/go/go-wails-desktop-app/index.md
@@ -5,7 +5,6 @@ date: 2026-03-08
 update: 2026-03-08
 tags:
   - golang
-  - go
   - wails
   - desktop
   - react

--- a/contents/go/go-wails-desktop-app/index_en.md
+++ b/contents/go/go-wails-desktop-app/index_en.md
@@ -5,7 +5,6 @@ date: 2026-03-08
 update: 2026-03-08
 tags:
   - golang
-  - go
   - wails
   - desktop
   - react

--- a/contents/go/golang-concurrency-1-goroutine-기초/index.md
+++ b/contents/go/golang-concurrency-1-goroutine-기초/index.md
@@ -5,7 +5,6 @@ date: 2026-03-07
 update: 2026-03-07
 tags:
   - golang
-  - go
   - concurrency
   - goroutine
   - parallelism

--- a/contents/go/golang-concurrency-1-goroutine-기초/index_en.md
+++ b/contents/go/golang-concurrency-1-goroutine-기초/index_en.md
@@ -5,7 +5,6 @@ date: 2026-03-07
 update: 2026-03-07
 tags:
   - golang
-  - go
   - concurrency
   - goroutine
   - parallelism

--- a/contents/go/golang-concurrency-2-channel-완전-정복/index.md
+++ b/contents/go/golang-concurrency-2-channel-완전-정복/index.md
@@ -5,7 +5,6 @@ date: 2026-03-19
 update: 2026-03-19
 tags:
   - golang
-  - go
   - concurrency
   - channel
   - buffered

--- a/contents/go/golang-concurrency-2-channel-완전-정복/index_en.md
+++ b/contents/go/golang-concurrency-2-channel-완전-정복/index_en.md
@@ -5,7 +5,6 @@ date: 2026-03-19
 update: 2026-03-19
 tags:
   - golang
-  - go
   - concurrency
   - channel
   - buffered

--- a/contents/go/golang-concurrency-3-select와-channel-심화/index.md
+++ b/contents/go/golang-concurrency-3-select와-channel-심화/index.md
@@ -5,7 +5,6 @@ date: 2026-04-08
 update: 2026-04-08
 tags:
   - golang
-  - go
   - concurrency
   - select
   - timeout

--- a/contents/go/golang-concurrency-3-select와-channel-심화/index_en.md
+++ b/contents/go/golang-concurrency-3-select와-channel-심화/index_en.md
@@ -5,7 +5,6 @@ date: 2026-04-08
 update: 2026-04-08
 tags:
   - golang
-  - go
   - concurrency
   - select
   - timeout

--- a/contents/go/golang-concurrency-4-sync-패키지/index.md
+++ b/contents/go/golang-concurrency-4-sync-패키지/index.md
@@ -5,7 +5,6 @@ date: 2026-04-15
 update: 2026-04-15
 tags:
   - golang
-  - go
   - concurrency
   - sync
   - mutex

--- a/contents/go/golang-concurrency-4-sync-패키지/index_en.md
+++ b/contents/go/golang-concurrency-4-sync-패키지/index_en.md
@@ -5,7 +5,6 @@ date: 2026-04-15
 update: 2026-04-15
 tags:
   - golang
-  - go
   - concurrency
   - sync
   - mutex

--- a/contents/go/golang-concurrency-5-context-완벽-가이드/index.md
+++ b/contents/go/golang-concurrency-5-context-완벽-가이드/index.md
@@ -2,7 +2,7 @@
 title: "Golang Concurrency 5편 - Context 완벽 가이드"
 description: "Go context 패키지의 WithCancel, WithTimeout, WithDeadline, WithValue 사용법과 context 전파 패턴을 다룹니다"
 date: 2026-04-18
-tags: ["go", "golang", "concurrency", "context", "timeout", "cancel"]
+tags: ["golang", "concurrency", "context", "timeout", "cancel"]
 series: "Golang Concurrency"
 draft: false
 ---

--- a/contents/go/golang-concurrency-5-context-완벽-가이드/index_en.md
+++ b/contents/go/golang-concurrency-5-context-완벽-가이드/index_en.md
@@ -2,7 +2,7 @@
 title: "Golang Concurrency Part 5 - The Complete Context Guide"
 description: "Covers how to use the Go context package's WithCancel, WithTimeout, WithDeadline, and WithValue, and context propagation patterns"
 date: 2026-04-18
-tags: ["go", "golang", "concurrency", "context", "timeout", "cancel"]
+tags: ["golang", "concurrency", "context", "timeout", "cancel"]
 series: "Golang Concurrency"
 draft: false
 ---

--- a/contents/go/golang-generics-1-개요와-기본-문법/index.md
+++ b/contents/go/golang-generics-1-개요와-기본-문법/index.md
@@ -5,7 +5,6 @@ date: 2026-03-01
 update: 2026-03-01
 tags:
   - golang
-  - go
   - generics
   - 제네릭
   - type-parameter

--- a/contents/go/golang-generics-1-개요와-기본-문법/index_en.md
+++ b/contents/go/golang-generics-1-개요와-기본-문법/index_en.md
@@ -5,7 +5,6 @@ date: 2026-03-01
 update: 2026-03-01
 tags:
   - golang
-  - go
   - generics
   - 제네릭
   - type-parameter

--- a/contents/go/golang-generics-2-type-constraint-완벽-이해/index.md
+++ b/contents/go/golang-generics-2-type-constraint-완벽-이해/index.md
@@ -5,7 +5,6 @@ date: 2026-03-02
 update: 2026-03-02
 tags:
   - golang
-  - go
   - generics
   - 제네릭
   - constraint

--- a/contents/go/golang-generics-2-type-constraint-완벽-이해/index_en.md
+++ b/contents/go/golang-generics-2-type-constraint-완벽-이해/index_en.md
@@ -5,7 +5,6 @@ date: 2026-03-02
 update: 2026-03-02
 tags:
   - golang
-  - go
   - generics
   - 제네릭
   - constraint

--- a/contents/go/golang-generics-3-실전-예제-모음/index.md
+++ b/contents/go/golang-generics-3-실전-예제-모음/index.md
@@ -5,7 +5,6 @@ date: 2026-03-03
 update: 2026-03-03
 tags:
   - golang
-  - go
   - generics
   - 제네릭
   - stack

--- a/contents/go/golang-generics-3-실전-예제-모음/index_en.md
+++ b/contents/go/golang-generics-3-실전-예제-모음/index_en.md
@@ -5,7 +5,6 @@ date: 2026-03-03
 update: 2026-03-03
 tags:
   - golang
-  - go
   - generics
   - 제네릭
   - stack

--- a/contents/go/golang-기반의-분산-스케줄러-asynq에-대해서-알아보자/index.md
+++ b/contents/go/golang-기반의-분산-스케줄러-asynq에-대해서-알아보자/index.md
@@ -5,7 +5,6 @@ date: 2024-06-24
 update: 2024-06-24
 tags:
   - golang
-  - go
   - async
   - scheduler
   - job scheduler

--- a/contents/go/golang-기반의-분산-스케줄러-asynq에-대해서-알아보자/index_en.md
+++ b/contents/go/golang-기반의-분산-스케줄러-asynq에-대해서-알아보자/index_en.md
@@ -5,7 +5,6 @@ date: 2024-06-24
 update: 2024-06-24
 tags:
   - golang
-  - go
   - async
   - scheduler
   - job scheduler

--- a/contents/go/go에서-strategy-패턴-제대로-활용하기/index.md
+++ b/contents/go/go에서-strategy-패턴-제대로-활용하기/index.md
@@ -4,7 +4,6 @@ description: "Go 인터페이스를 활용한 Strategy 패턴 구현 방법과 �
 date: 2026-03-01
 update: 2026-03-01
 tags:
-  - go
   - golang
   - design pattern
   - strategy

--- a/contents/go/go에서-strategy-패턴-제대로-활용하기/index_en.md
+++ b/contents/go/go에서-strategy-패턴-제대로-활용하기/index_en.md
@@ -4,7 +4,6 @@ description: "How to implement the Strategy pattern using Go interfaces, with pr
 date: 2026-03-01
 update: 2026-03-01
 tags:
-  - go
   - golang
   - design pattern
   - strategy

--- a/contents/go/go에서-삼-도트-dot-사용방법-three-dots-usage/index.md
+++ b/contents/go/go에서-삼-도트-dot-사용방법-three-dots-usage/index.md
@@ -4,7 +4,6 @@ description: "Go에서 삼 도트 (dot) 사용방법 (Three Dots Usage)"
 date: 2021-05-08
 update: 2021-05-08
 tags:
-  - go
   - golang
   - dot
   - three

--- a/contents/go/go에서-삼-도트-dot-사용방법-three-dots-usage/index_en.md
+++ b/contents/go/go에서-삼-도트-dot-사용방법-three-dots-usage/index_en.md
@@ -4,7 +4,6 @@ description: "The four ways the ... (three dots) notation is used in Go: variadi
 date: 2021-05-08
 update: 2021-05-08
 tags:
-  - go
   - golang
   - dot
   - three

--- a/contents/go/go에서-컬렉션-정렬하는-방법-go-sort/index.md
+++ b/contents/go/go에서-컬렉션-정렬하는-방법-go-sort/index.md
@@ -4,7 +4,6 @@ description: "Go에서 컬렉션 정렬하는 방법 (Go Sort)"
 date: 2021-05-09
 update: 2021-05-09
 tags:
-  - go
   - golang
   - comparator
   - sort

--- a/contents/go/go에서-컬렉션-정렬하는-방법-go-sort/index_en.md
+++ b/contents/go/go에서-컬렉션-정렬하는-방법-go-sort/index_en.md
@@ -4,7 +4,6 @@ description: "Four ways to sort collections in Go: primitive types, a custom com
 date: 2021-05-09
 update: 2021-05-09
 tags:
-  - go
   - golang
   - comparator
   - sort

--- a/contents/go/go에서의-게터-세터-메서드-getter-setter-in-go/index.md
+++ b/contents/go/go에서의-게터-세터-메서드-getter-setter-in-go/index.md
@@ -4,7 +4,6 @@ description: "Go에서의 게터, 세터 메서드 (Getter, Setter in Go)"
 date: 2021-01-14
 update: 2021-01-14
 tags:
-  - go
   - golang
   - setter
   - getter

--- a/contents/go/go에서의-게터-세터-메서드-getter-setter-in-go/index_en.md
+++ b/contents/go/go에서의-게터-세터-메서드-getter-setter-in-go/index_en.md
@@ -4,7 +4,6 @@ description: "How to write getter and setter methods in Go for encapsulation, in
 date: 2021-01-14
 update: 2021-01-14
 tags:
-  - go
   - golang
   - setter
   - getter

--- a/contents/go/go에서의-다형성-polymorphism/index.md
+++ b/contents/go/go에서의-다형성-polymorphism/index.md
@@ -4,7 +4,6 @@ description: "Go에서의 다형성 (Polymorphism)"
 date: 2021-06-06
 update: 2021-06-06
 tags:
-  - go
   - golang
   - duck
   - typing

--- a/contents/go/go에서의-다형성-polymorphism/index_en.md
+++ b/contents/go/go에서의-다형성-polymorphism/index_en.md
@@ -4,7 +4,6 @@ description: "How to implement polymorphism in Go using interfaces and duck typi
 date: 2021-06-06
 update: 2021-06-06
 tags:
-  - go
   - golang
   - duck
   - typing

--- a/contents/go/go에서의-로그깅-logging-in-go/index.md
+++ b/contents/go/go에서의-로그깅-logging-in-go/index.md
@@ -4,7 +4,6 @@ description: "Go에서의 로그깅 (Logging in Go)"
 date: 2021-01-02
 update: 2021-01-02
 tags:
-  - go
   - golang
   - log
   - logging

--- a/contents/go/go에서의-로그깅-logging-in-go/index_en.md
+++ b/contents/go/go에서의-로그깅-logging-in-go/index_en.md
@@ -4,7 +4,6 @@ description: "How to use Go's standard log package: the basic logger, writing to
 date: 2021-01-02
 update: 2021-01-02
 tags:
-  - go
   - golang
   - log
   - logging

--- a/contents/go/go에서의-열거형-상수-enums-in-go/index.md
+++ b/contents/go/go에서의-열거형-상수-enums-in-go/index.md
@@ -4,7 +4,6 @@ description: "Go에서의 열거형 상수 (Enums in Go)"
 date: 2020-12-20
 update: 2020-12-20
 tags:
-  - go
   - golang
   - enums
   - iota

--- a/contents/go/go에서의-열거형-상수-enums-in-go/index_en.md
+++ b/contents/go/go에서의-열거형-상수-enums-in-go/index_en.md
@@ -4,7 +4,6 @@ description: "How to declare enum-like constants in Go using the iota keyword, w
 date: 2020-12-20
 update: 2020-12-20
 tags:
-  - go
   - golang
   - enums
   - iota

--- a/contents/go/타입-단언-type-assertion/index.md
+++ b/contents/go/타입-단언-type-assertion/index.md
@@ -4,7 +4,6 @@ description: "타입 단언 (Type Assertion)"
 date: 2021-01-16
 update: 2021-01-16
 tags:
-  - go
   - golang
   - type
   - assertion

--- a/contents/go/타입-단언-type-assertion/index_en.md
+++ b/contents/go/타입-단언-type-assertion/index_en.md
@@ -4,7 +4,6 @@ description: "How type assertion works in Go to check whether an interface holds
 date: 2021-01-16
 update: 2021-01-16
 tags:
-  - go
   - golang
   - type
   - assertion

--- a/contents/go/타입-스위치-type-switch/index.md
+++ b/contents/go/타입-스위치-type-switch/index.md
@@ -4,7 +4,6 @@ description: "타입 스위치 (Type switch)"
 date: 2021-01-16
 update: 2021-01-16
 tags:
-  - go
   - golang
   - type
   - switch

--- a/contents/go/타입-스위치-type-switch/index_en.md
+++ b/contents/go/타입-스위치-type-switch/index_en.md
@@ -4,7 +4,6 @@ description: "How a type switch works in Go: running a type assertion and execut
 date: 2021-01-16
 update: 2021-01-16
 tags:
-  - go
   - golang
   - type
   - switch

--- a/contents/linux/raspberry-pi에서-최신-go-버전-설치하기-apt-대신-직접-설치/index.md
+++ b/contents/linux/raspberry-pi에서-최신-go-버전-설치하기-apt-대신-직접-설치/index.md
@@ -12,7 +12,6 @@ tags:
   - raspbian
   - raspberry pi
   - 라즈베리파이
-  - go
   - golang
   - apt
 ---

--- a/contents/linux/raspberry-pi에서-최신-go-버전-설치하기-apt-대신-직접-설치/index_en.md
+++ b/contents/linux/raspberry-pi에서-최신-go-버전-설치하기-apt-대신-직접-설치/index_en.md
@@ -12,7 +12,6 @@ tags:
   - raspbian
   - raspberry pi
   - 라즈베리파이
-  - go
   - golang
   - apt
 ---


### PR DESCRIPTION
## Summary
- 태그 페이지(`/tags/`, `/en/tags/`)에 `#go`와 `#golang`이 동시에 노출되던 중복 문제 해결
- `go` 태그가 붙은 글은 **예외 없이 `golang` 태그도 함께** 가지고 있어 두 태그가 사실상 중복 상태였음
- `golang`으로 통일하고 `go` 태그를 제거

## 변경 내용
- **27개 글** × (한글 원본 `index.md` + 영어 번역본 `index_en.md`) = **총 54개 파일** 수정
- 각 파일 frontmatter `tags`에서 `go` 항목만 제거, `golang`은 유지
- 리스트형(`- go`)·배열형(`tags: ["go", ...]`) 두 형식 모두 처리

## 결과
| 태그 | 변경 전 | 변경 후 |
|------|--------|--------|
| `go` | 27개 글 | 0개 |
| `golang` | 33개 글 | 33개 (유지) |

## Test plan
- [x] frontmatter 파싱 검증: `go=0`, `golang=33` (index.md / index_en.md 동일)
- [x] diff 검증: 태그 라인 외 본문 변경 없음 (2 insertions, 54 deletions)
- [x] UTF-8 인코딩 유지 확인