### PR TITLE
fix(home): Biweekly 카드가 실제 Biweekly News만 표시하도록 수정

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -1,4 +1,4 @@
-import { getAllArticles, getAllSeries, getArticlesBySeries, getArticleTitleFromSlug } from '@/lib/articles';
+import { getAllArticles, getAllSeries, getArticlesBySeries, getArticleTitleFromSlug, isBiweeklySeries } from '@/lib/articles';
 import { formatDate } from '@/lib/utils';
 import { seriesSlug } from '@/lib/url';
 import { Headline } from '@/components/home/headline';
@@ -89,11 +89,12 @@ export default async function EnHomePage() {
   const yearsWriting = Math.max(1, new Date().getFullYear() - firstYear);
 
   const featured = articles[0];
-  const latest = articles.slice(1, 5);
   const recent = articles.slice(5, 9);
   const wideLatest = articles.slice(9, 14);
 
-  const featuredSeriesArticle = articles.find((a) => a.series);
+  const biweeklyItems = articles.filter((a) => isBiweeklySeries(a.series)).slice(0, 4);
+
+  const featuredSeriesArticle = articles.find((a) => a.series && !isBiweeklySeries(a.series));
   let spotlightEpisodes: Array<{ num: number; title: string; slug: string }> = [];
   let spotlightName = '';
   if (featuredSeriesArticle?.series) {
@@ -163,11 +164,11 @@ export default async function EnHomePage() {
           />
         )}
 
-        {latest.length > 0 && (
+        {biweeklyItems.length > 0 && (
           <LatestCard
             basePath="/en"
             subtitle="One post biweekly"
-            items={latest.map((a) => ({
+            items={biweeklyItems.map((a) => ({
               slug: getArticleTitleFromSlug(a.slug),
               title: a.title,
               date: formatDate(a.date),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { getAllArticles, getAllSeries, getArticlesBySeries, getArticleTitleFromSlug } from '@/lib/articles';
+import { getAllArticles, getAllSeries, getArticlesBySeries, getArticleTitleFromSlug, isBiweeklySeries } from '@/lib/articles';
 import { formatDate } from '@/lib/utils';
 import { seriesSlug } from '@/lib/url';
 import { Headline } from '@/components/home/headline';
@@ -89,11 +89,12 @@ export default async function HomePage() {
   const yearsWriting = Math.max(1, new Date().getFullYear() - firstYear);
 
   const featured = articles[0];
-  const latest = articles.slice(1, 5);
   const recent = articles.slice(5, 9);
   const wideLatest = articles.slice(9, 14);
 
-  const featuredSeriesArticle = articles.find((a) => a.series);
+  const biweeklyItems = articles.filter((a) => isBiweeklySeries(a.series)).slice(0, 4);
+
+  const featuredSeriesArticle = articles.find((a) => a.series && !isBiweeklySeries(a.series));
   let spotlightEpisodes: Array<{ num: number; title: string; slug: string }> = [];
   let spotlightName = '';
   if (featuredSeriesArticle?.series) {
@@ -153,9 +154,9 @@ export default async function HomePage() {
           />
         )}
 
-        {latest.length > 0 && (
+        {biweeklyItems.length > 0 && (
           <LatestCard
-            items={latest.map((a) => ({
+            items={biweeklyItems.map((a) => ({
               slug: getArticleTitleFromSlug(a.slug),
               title: a.title,
               date: formatDate(a.date),

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -27,6 +27,12 @@ interface Manifest {
 let manifestCache: Manifest | null = null;
 const articleCache = new Map<string, Article>();
 
+const BIWEEKLY_SERIES_PREFIX = "Frank's IT News";
+
+export function isBiweeklySeries(series?: string | null): boolean {
+  return !!series && series.startsWith(BIWEEKLY_SERIES_PREFIX);
+}
+
 /**
  * Manifest 로드 (캐싱)
  */


### PR DESCRIPTION
## Summary
- 홈(KO/EN)의 "Biweekly / 격주에 한 편씩" 카드(`LatestCard`)가 라벨과 무관하게 `articles.slice(1, 5)` (단순 최신 글)을 받아 비-biweekly 글이 노출되던 버그 수정
- `lib/articles.ts`에 `isBiweeklySeries()` 헬퍼 추가 (시리즈명이 `Frank's IT News`로 시작하는지로 판정 → `2026 상반기`, 향후 `하반기` 등 자동 포함)
- KO/EN 홈에서 LatestCard에 실제 biweekly 글만 전달, 비어 있으면 카드 자동 숨김 (EN은 biweekly 글이 없어 자연스럽게 숨겨짐)
- `SeriesSpotlightCard`가 biweekly 시리즈를 건너뛰도록 변경 (옆 Biweekly 카드와 내용 중복 방지)

## 변경 후 동작
- KO SERIES 카드: `Claude Code 완벽 가이드`
- KO BIWEEKLY 카드: 실제 Biweekly News 4건 (5/15, 5/1, 4/15, 3/18 ~ 4/1)
- EN SERIES 카드: `Claude Code 완벽 가이드` (변동 없음)
- EN BIWEEKLY 카드: 숨김

## 알려진 부수 효과
- KO 메인의 `articles[1]~[4]` (tmux, uber/fx, Biweekly 5/15, Claude Code Superpowers)가 이전엔 LatestCard 자리에 노출됐는데 이제 그 슬롯이 Biweekly 전용
- `RecentCard`는 `slice(5, 9)`, `WideLatestList`는 `slice(9, 14)` 기준 유지 → 메인 bento 그리드에서 일부 글이 카드 자리로는 노출되지 않음 (검색·카테고리·시리즈 페이지에서는 접근 가능)
- 추가 보강이 필요하면 후속 PR에서 `recent`/`wideLatest` 시작 인덱스 조정 가능

## Test plan
- [ ] `npm run check` 통과 확인
- [ ] 로컬 dev 서버에서 KO 메인 (`/`) — SERIES 카드가 "Claude Code 완벽 가이드", BIWEEKLY 카드가 실제 Biweekly News 4건 표시되는지 확인
- [ ] 로컬 dev 서버에서 EN 메인 (`/en`) — SERIES 카드가 "Claude Code 완벽 가이드", BIWEEKLY 카드가 숨겨지는지 확인
- [ ] 배포 후 운영 환경에서 동일 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)