### PR TITLE
fix: algorithm 글 버그 4건 수정

### DIFF
--- a/contents/algorithm/algorithm-2개의-array에서-common-value-찾기/index.md
+++ b/contents/algorithm/algorithm-2개의-array에서-common-value-찾기/index.md
@@ -1,11 +1,11 @@
 ---
 title: "Algorithm 2개의 array에서 common value 찾기"
-description: "Algorithm 2개의 array에서 common value 찾기"
+description: "2개의 정수 배열에서 중복 없이 공통으로 등장하는 값을 HashTable로 O(n)에 찾는 방법을 정리한다."
 date: 2018-07-29
 update: 2018-07-29
 tags:
   - array
-  - common,
+  - common
   - 알고리즘
   - 인터뷰
   - 면접
@@ -37,7 +37,7 @@ unit test를 미리 작성해서 쉽게 실행하면서 로직을 짜는게 좋�
 
 ```java
 @Test
-public void test_find_common_values() 
+public void test_find_common_values() {
     int[] A = {1, 1, 1, 1, 2, 2};
     int[] B = {3, 3, 4, 1, 2};
 

--- a/contents/algorithm/algorithm-괄호-기호가-Valid한지-체크하기/index.md
+++ b/contents/algorithm/algorithm-괄호-기호가-Valid한지-체크하기/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Algorithm 괄호 기호가 Valid한지 체크하기"
-description: "Algorithm 괄호 기호가 Valid한지 체크하기"
+description: "괄호 문자열이 올바르게 여닫혔는지 스택 자료구조로 O(n)에 검증하는 방법을 정리한다."
 date: 2018-07-29
 update: 2018-07-29
 tags:
@@ -35,8 +35,8 @@ public boolean solution(String str) {
 기본 아이디어는 다음과 같다.
 
 1. String의 한 char씩 스킨한다
-1. OPEN\_괄호 ‘(‘ 을 만나면 스택에 push하고
-1. CLOSE\_괄호 ‘)’를 만나면 스택에서 pop을 한다.
+1. OPEN_괄호 ‘(‘ 을 만나면 스택에 push하고
+1. CLOSE_괄호 ‘)’를 만나면 스택에서 pop을 한다.
 1. 스택에 아무것도 남아 있지 않으면, valid한 괄호인것으로 판단할 수 있다
 
 ```java

--- a/contents/algorithm/algorithm-정수값에서-1이-설정된-bit를-카운트하기/index.md
+++ b/contents/algorithm/algorithm-정수값에서-1이-설정된-bit를-카운트하기/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Algorithm 정수값에서 1이 설정된 bit를 카운트하기"
-description: "Algorithm 정수값에서 1이 설정된 bit를 카운트하기"
+description: "정수에서 1로 설정된 비트 개수를, 단순 반복부터 브라이언 커니핸 알고리즘(O(log n))까지 정리한다."
 date: 2018-10-28
 update: 2018-10-28
 tags:


### PR DESCRIPTION
## 배경

`contents/algorithm` 글 3편을 humanizer 기준으로 검토했다. AI 글쓰기 흔적은 사실상 없는 사람다운 글이라 본문은 그대로 두고, 검토 중 발견한 **실제 버그 4건**만 수정한다.

## 변경 사항

- **코드 버그** — `common value 찾기` 글의 JUnit 테스트 메서드 선언(`test_find_common_values()`)에 여는 중괄호 `{`가 빠져 있어, 복붙 시 컴파일되지 않던 코드를 수정
- **`description` == `title`** — 3개 글 모두 description이 제목과 완전히 동일하던 것을 설명형 문구로 분리 (SEO/미리보기 개선)
- **태그 오타** — `common value` 글 태그 `common,` → `common` (쉼표 제거)
- **이스케이프 잔재** — `괄호 Valid` 글의 `OPEN\_괄호`, `CLOSE\_괄호` → `OPEN_괄호`, `CLOSE_괄호`

## 테스트 계획

- [x] 수정된 Java 코드 블록 문법 정상 확인
- [x] 3개 글 description이 title과 다름 확인
- [x] 태그 오타/이스케이프 잔재 0건 확인
- [x] 3개 파일 UTF-8 인코딩 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)