### PR TITLE
fix: 슬라이드 임베드 위치 조정 및 저자명 단축

### DIFF
--- a/components/article/hero-card.tsx
+++ b/components/article/hero-card.tsx
@@ -23,7 +23,7 @@ export function HeroCard({
   seriesOrder,
   totalEpisodes,
   tags,
-  author = 'Frank Advenoh',
+  author = 'Frank',
 }: Props) {
   return (
     <section className="mx-auto max-w-canvas px-6 pt-2 md:px-10">

--- a/contents/cloud/grafana-완벽-가이드-1-prometheus와-grafana-기초/index.md
+++ b/contents/cloud/grafana-완벽-가이드-1-prometheus와-grafana-기초/index.md
@@ -53,6 +53,8 @@ series: "Grafana 완벽 가이드"
 
 > 이 글에서 사용한 전체 코드는 [GitHub](https://github.com/kenshin579/tutorials-go/tree/master/monitoring/grafana-metrics)에서 확인할 수 있다.
 
+<!-- slides -->
+
 # 2. Prometheus 핵심 개념
 
 ## 2.1 아키텍처 — Pull 기반 메트릭 수집
@@ -933,8 +935,6 @@ rate(node_network_transmit_bytes_total{device!="lo"}[5m])
 다음 편에서는 node-exporter가 주는 시스템 메트릭에서 한 걸음 더 들어가, Go 애플리케이션에 직접 메트릭을 심는다. HTTP 요청 수와 응답 시간은 물론 주문 건수 같은 비즈니스 지표까지 계측해서 Grafana에 올려본다.
 
 > 이 글에서 사용한 전체 코드는 [GitHub](https://github.com/kenshin579/tutorials-go/tree/master/monitoring/grafana-metrics)에서 확인할 수 있다.
-
-<!-- slides -->
 
 # 7. 참고
 


### PR DESCRIPTION
## Summary

- **슬라이드 임베드를 마무리 섹션 → 들어가며 섹션으로 이동.** 마무리는 글을 끝까지 읽어야 도달해서 노출이 적다. `# 1. 들어가며` 끝(`# 2. Prometheus 핵심 개념` 직전)으로 옮겨, 본문을 읽기 전에 전체 흐름을 훑을 수 있게 했다.
- **hero-card 저자명 `Frank Advenoh` → `Frank`.** 아바타 이니셜은 `author.charAt(0)`이라 `F` 그대로다.

저자명은 `components/article/hero-card.tsx`의 기본 prop이고 `author=`를 넘기는 호출부가 없어서, **모든 글에 일괄 적용**된다.

## Test plan

- [x] `npm run check` 통과
- [x] `npm run build` 성공 — 정적 페이지 2287개
- [x] 임베드가 `1. 들어가며`와 `2. Prometheus 핵심 개념` 사이에 위치 (직전 `<blockquote>`, 직후 `<h1>`)
- [x] 마커는 문서 내 1개만 존재, `<p>` 중첩 없음
- [x] 저자명 `Frank` 렌더 확인, `out/` 전체에 `Frank Advenoh` 잔존 0건
- [x] 다른 글도 `Frank`로 표시되는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)