### PR TITLE
docs: uber/fx 의존성 주입 발표 슬라이드 추가

### DIFF
--- a/contents/go/go-fx-의존성-주입/index.md
+++ b/contents/go/go-fx-의존성-주입/index.md
@@ -29,6 +29,8 @@ Go 애플리케이션이 커지면 의존성 조립이 복잡해진다. `main()`
 - Module 캡슐화: `fx.Private`
 - 테스트 전략: `fxtest.New`, `fx.Replace`, `fx.Populate`
 
+<!-- slides -->
+
 # 2. fx 기초
 
 ## 2.1 Go에서 DI가 필요한 이유

--- a/contents/go/go-fx-의존성-주입/slides.html
+++ b/contents/go/go-fx-의존성-주입/slides.html
@@ -1,0 +1,2078 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>uber/fx로 시작하는 Go 의존성 주입</title>
+<style>
+/* ─────────────────────────────────────────────────────────────
+   계기판(instrument panel) — 차가운 슬레이트 바탕 위 따뜻한 표시등
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0A6E8A;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(10, 110, 138, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+
+  --f-display: "Avenir Next", "Apple SD Gothic Neo", "Helvetica Neue", system-ui, sans-serif;
+  --f-body:    "Apple SD Gothic Neo", -apple-system, "Helvetica Neue", "Noto Sans KR", sans-serif;
+  --f-mono:    "MesloLGS NF", "SF Mono", ui-monospace, Menlo, "D2Coding", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0E1117;
+    --surface:   #161B23;
+    --surface-2: #1B212A;
+    --ink:       #E6E9EE;
+    --ink-dim:   #98A2B0;
+    --ink-faint: #6B7688;
+    --line:      #272F3A;
+    --line-soft: #1E252E;
+    --grid:      rgba(255, 255, 255, .038);
+    --accent:    #3FC7EF;
+    --accent-ink:#031A20;
+    --accent-soft: rgba(63, 199, 239, .14);
+    --teal:      #46C7B0;
+    --teal-soft: rgba(70, 199, 176, .13);
+    --amber:     #E8B84B;
+    --red:       #F0625E;
+    --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg:        #0E1117;
+  --surface:   #161B23;
+  --surface-2: #1B212A;
+  --ink:       #E6E9EE;
+  --ink-dim:   #98A2B0;
+  --ink-faint: #6B7688;
+  --line:      #272F3A;
+  --line-soft: #1E252E;
+  --grid:      rgba(255, 255, 255, .038);
+  --accent:    #3FC7EF;
+  --accent-ink:#031A20;
+  --accent-soft: rgba(63, 199, 239, .14);
+  --teal:      #46C7B0;
+  --teal-soft: rgba(70, 199, 176, .13);
+  --amber:     #E8B84B;
+  --red:       #F0625E;
+  --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+}
+
+:root[data-theme="light"] {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0A6E8A;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(10, 110, 138, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ── 무대: 1280×720 고정, 뷰포트에 맞춰 축소 ───────────────── */
+.stage-wrap {
+  position: fixed;
+  inset: 0 0 52px 0;
+  display: grid;
+  /* 가운데 정렬은 fit() 이 translate 로 직접 한다. grid 중앙 정렬에 맡기면
+     무대가 뷰포트보다 클 때 safe alignment 로 좌상단에 고정되어 계산이 어긋난다. */
+  place-items: start;
+  overflow: hidden;
+}
+.stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  transform-origin: 0 0;
+  flex: none;
+}
+.holder {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .22s ease;
+}
+.holder.is-active { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .holder { transition: none; } }
+
+.slide {
+  width: 1280px;
+  height: 720px;
+  padding: 52px 68px 56px;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 40px,
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px) 0 0 / 40px 100%,
+    var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.slide::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0 34%, var(--line) 34% 100%);
+  opacity: .55;
+}
+
+/* ── 슬라이드 머리 ─────────────────────────────────────────── */
+.slide-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  flex: none;
+}
+.eyebrow {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+}
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+}
+.slide-title {
+  font-family: var(--f-display);
+  font-size: 42px;
+  line-height: 1.16;
+  font-weight: 700;
+  letter-spacing: -.022em;
+  margin: 0 0 6px;
+  text-wrap: balance;
+}
+.slide-title .em { color: var(--accent); }
+.slide-lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0 0 4px;
+  max-width: 72ch;
+}
+.rule {
+  height: 1px;
+  background: var(--line);
+  margin: 18px 0 22px;
+  flex: none;
+}
+.slide-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  font-size: 19px;
+  line-height: 1.6;
+}
+.slide-body.top { justify-content: flex-start; }
+
+/* ── 공용 조판 ─────────────────────────────────────────────── */
+.cols { display: grid; gap: 30px; align-items: start; }
+.c-2  { grid-template-columns: 1fr 1fr; }
+.c-2a { grid-template-columns: 1.15fr .85fr; }
+.c-2b { grid-template-columns: .82fr 1.18fr; }
+.c-3  { grid-template-columns: repeat(3, 1fr); }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.stack.tight { gap: 10px; }
+.grow { flex: 1; min-height: 0; }
+/* 높이를 채우는 2단 조판에서는 각 열이 늘어나고, 내용은 열 안에서 세로 중앙에 놓인다 */
+.cols.grow { align-items: stretch; }
+.cols.grow > .stack { justify-content: center; }
+
+ul.bul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 13px; }
+ul.bul > li { position: relative; padding-left: 26px; }
+ul.bul > li::before {
+  content: "";
+  position: absolute;
+  left: 4px; top: .62em;
+  width: 9px; height: 2px;
+  background: var(--accent);
+}
+ul.bul.teal > li::before { background: var(--teal); }
+.dim { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.hl { color: var(--accent); font-weight: 600; }
+.hl-teal { color: var(--teal); font-weight: 600; }
+b, strong { font-weight: 700; }
+
+/* ── 표 ────────────────────────────────────────────────────── */
+.tbl-wrap { overflow-x: auto; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink-faint);
+  padding: 0 14px 9px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: 11px 14px 11px 0;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  line-height: 1.45;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td:first-child { font-weight: 600; white-space: nowrap; }
+table.tbl.sm { font-size: 15.5px; }
+table.tbl.sm td { padding: 8px 12px 8px 0; }
+table.tbl tr.on td { background: var(--accent-soft); }
+table.tbl tr.on td:first-child { color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); padding-left: 12px; }
+.num-col { font-family: var(--f-mono); }
+
+/* ── 코드 ──────────────────────────────────────────────────── */
+.code {
+  font-family: var(--f-mono);
+  font-size: 15.5px;
+  line-height: 1.72;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+  padding: 14px 18px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+  tab-size: 2;
+}
+.code.sm { font-size: 14px; line-height: 1.66; padding: 12px 15px; }
+.code.xs { font-size: 12.6px; line-height: 1.6; padding: 11px 14px; }
+.code.plain { border-left-color: var(--line); }
+.code.teal { border-left-color: var(--teal); }
+.t-fn  { color: var(--accent); }
+.t-str { color: var(--teal); }
+.t-cm  { color: var(--ink-faint); }
+.t-num { color: var(--ink); font-weight: 600; }
+.t-key { color: var(--accent); font-weight: 600; }
+.t-bad { color: var(--red); }
+code.inl {
+  font-family: var(--f-mono);
+  font-size: .88em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  white-space: nowrap;
+}
+
+/* ── 카드 / 콜아웃 ─────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.card-t {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+.callout {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 14px 20px;
+  border-radius: 0 3px 3px 0;
+  font-size: 18px;
+  line-height: 1.55;
+}
+.callout.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+.callout .lbl {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.callout.teal .lbl { color: var(--teal); }
+
+/* ── 그림 ──────────────────────────────────────────────────── */
+.figure { display: flex; flex-direction: column; justify-content: center; gap: 10px; min-height: 0; }
+.figure img {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: var(--shadow);
+  background: var(--surface-2);
+}
+.figure figcaption, .cap {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.fit img { max-height: 100%; }
+
+/* ── 아키텍처 다이어그램 ───────────────────────────────────── */
+.arch {
+  display: grid;
+  grid-template-columns: 1fr 104px 1.02fr 104px 1fr;
+  align-items: center;
+  gap: 0;
+}
+.arch-col { display: flex; flex-direction: column; gap: 11px; }
+.node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 4px;
+  padding: 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.node .n-t { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.node .n-p { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-faint); }
+.node.hero {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  padding: 20px 18px;
+}
+.node.hero .n-t { font-size: 22px; color: var(--accent); }
+.node.hero .n-p { color: var(--ink-dim); }
+.node.mute { border-style: dashed; background: transparent; }
+.arch-link { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.arch-link .l-lbl {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.arch-link .l-line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  position: relative;
+}
+.arch-link .l-line::after {
+  content: "";
+  position: absolute;
+  right: 8px; top: -4px;
+  border: 4.5px solid transparent;
+  border-left-color: var(--accent);
+}
+
+/* ── 트리 ──────────────────────────────────────────────────── */
+.tree { font-family: var(--f-mono); font-size: 15px; line-height: 2.05; }
+.tree .lv { display: block; white-space: pre; }
+.tree .k { color: var(--accent); font-weight: 600; }
+.tree .v { color: var(--ink-dim); }
+
+/* ── 쿼리 해부도 ───────────────────────────────────────────── */
+.anat { display: flex; flex-direction: column; gap: 14px; }
+.anat-q {
+  font-family: var(--f-mono);
+  font-size: 24px;
+  letter-spacing: -.01em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.anat-q .p { padding: 3px 2px; border-bottom: 2px solid transparent; }
+.anat-q .p1 { border-bottom-color: var(--accent); }
+.anat-q .p2 { border-bottom-color: var(--teal); }
+.anat-q .p3 { border-bottom-color: var(--amber); }
+.anat-q .p4 { border-bottom-color: var(--ink-faint); }
+.legend { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.legend .lg-i { display: flex; flex-direction: column; gap: 4px; }
+.legend .lg-b { height: 3px; width: 34px; }
+.legend .lg-n { font-size: 15px; font-weight: 700; }
+.legend .lg-d { font-size: 14px; color: var(--ink-dim); line-height: 1.42; }
+
+/* ── 카디널리티 계산기 ─────────────────────────────────────── */
+.odo-row { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.odo {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 62px;
+  font-weight: 700;
+  letter-spacing: -.03em;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.odo.sm { font-size: 34px; color: var(--ink); }
+.odo-cap { font-size: 15px; color: var(--ink-dim); }
+.factor {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-family: var(--f-mono);
+  font-size: 19px;
+  color: var(--ink-dim);
+}
+.factor b { color: var(--ink); font-size: 22px; }
+
+/* ── 단계 목록 ─────────────────────────────────────────────── */
+.steps { display: flex; flex-direction: column; gap: 0; }
+.step {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.step:last-child { border-bottom: none; }
+.step .s-n {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 600;
+  padding-top: 3px;
+}
+.step .s-c { font-family: var(--f-mono); font-size: 14.5px; color: var(--ink); }
+.step .s-d { font-size: 15.5px; color: var(--ink-dim); line-height: 1.45; margin-top: 3px; }
+
+/* ── 표지 ──────────────────────────────────────────────────── */
+.cover { display: grid; grid-template-columns: 1.06fr .94fr; gap: 46px; align-items: center; height: 100%; }
+.cover-title {
+  font-family: var(--f-display);
+  font-size: 62px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -.032em;
+  margin: 14px 0 18px;
+  text-wrap: balance;
+}
+.cover-sub { font-size: 21px; color: var(--ink-dim); line-height: 1.5; margin: 0 0 30px; }
+.cover-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .06em;
+}
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+.panel-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+.panel-body { padding: 12px 8px 8px; }
+.panel canvas { display: block; width: 100%; height: 232px; }
+.panel-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 9px 15px 13px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 챕터 구분 ─────────────────────────────────────────────── */
+.slide[data-kind="chapter"] { justify-content: center; }
+.chap { display: grid; grid-template-columns: auto 1fr; gap: 46px; align-items: center; }
+.chap-n {
+  font-family: var(--f-mono);
+  font-size: 168px;
+  font-weight: 700;
+  line-height: .82;
+  letter-spacing: -.06em;
+  color: var(--accent);
+}
+.chap-t {
+  font-family: var(--f-display);
+  font-size: 50px;
+  font-weight: 700;
+  letter-spacing: -.028em;
+  line-height: 1.12;
+  margin: 0 0 14px;
+}
+.chap-d { font-size: 19px; color: var(--ink-dim); line-height: 1.55; margin: 0; max-width: 56ch; }
+.chap-l { border-left: 1px solid var(--line); padding-left: 46px; }
+
+/* ── 퀴즈 ──────────────────────────────────────────────────── */
+.quiz { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 20px; }
+.q {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.q-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 16.5px;
+  line-height: 1.42;
+  font-weight: 600;
+}
+.q-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+.q-btn .q-n { font-family: var(--f-mono); font-size: 12.5px; color: var(--accent); flex: none; }
+.q-a {
+  display: none;
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line-soft);
+  padding-top: 9px;
+}
+.q.is-open .q-a { display: block; }
+.q-a .ref { font-family: var(--f-mono); font-size: 12px; color: var(--ink-faint); }
+
+/* ── 토글 (Counter 슬라이드) ───────────────────────────────── */
+.toggle { display: flex; gap: 8px; }
+.tg {
+  all: unset;
+  cursor: pointer;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.tg[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.tg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.swap > .swap-i { display: none; }
+.swap > .swap-i.on { display: flex; }
+.swap > img.swap-i.on { display: block; }
+
+/* ── 하단 크롬 ─────────────────────────────────────────────── */
+.chrome {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  background: var(--bg);
+  border-top: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.chrome .deck-id { text-transform: uppercase; white-space: nowrap; }
+.rail { flex: 1; display: flex; gap: 2px; align-items: center; height: 22px; min-width: 0; }
+.tick { flex: 1; height: 4px; background: var(--line); border-radius: 1px; transition: background .18s ease, height .18s ease; }
+.tick.done { background: var(--ink-faint); }
+.tick.now  { background: var(--accent); height: 14px; }
+.tick.chap { height: 10px; }
+.counter { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--ink-dim); }
+.counter .cur { color: var(--accent); font-weight: 600; }
+.keys { display: flex; gap: 6px; }
+.kbtn {
+  all: unset;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 4px 8px;
+  color: var(--ink-dim);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+}
+.kbtn:hover { border-color: var(--accent); color: var(--accent); }
+.kbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.kbtn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+/* ── 발표자 노트 ───────────────────────────────────────────── */
+.notes-src { display: none; }
+.notes {
+  position: fixed;
+  left: 0; right: 0; bottom: 52px;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 16px 22px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  display: none;
+  z-index: 19;
+}
+.notes.on { display: block; }
+.notes .n-h {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+/* ── 개요(썸네일) 모드 ─────────────────────────────────────── */
+.deck.is-overview .stage-wrap { place-items: start center; overflow: auto; padding: 24px 18px; }
+.deck.is-overview .stage {
+  width: 100%; height: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 256px);
+  gap: 16px;
+  justify-content: center;
+}
+.deck.is-overview .holder {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  visibility: visible;
+  width: 256px;
+  height: 144px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deck.is-overview .holder.is-active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.deck.is-overview .holder::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 5px; bottom: 4px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  color: var(--ink-faint);
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.deck.is-overview .slide {
+  position: absolute;
+  top: 0; left: 0;
+  transform: scale(.2);
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+/* ── 도움말 ────────────────────────────────────────────────── */
+.help {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  display: none;
+  place-items: center;
+  z-index: 40;
+  padding: 24px;
+}
+.help.on { display: grid; }
+.help-box {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  padding: 26px 30px;
+  min-width: 360px;
+}
+.help-box h3 {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.help-box dl { display: grid; grid-template-columns: auto 1fr; gap: 9px 20px; margin: 0; font-size: 15px; }
+.help-box dt { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.help-box dd { margin: 0; color: var(--ink-dim); }
+
+/* ── 인쇄 ──────────────────────────────────────────────────── */
+@media print {
+  @page { size: 1280px 720px; margin: 0; }
+  body { overflow: visible; background: #fff; }
+  .chrome, .notes, .help { display: none !important; }
+  .stage-wrap { position: static; display: block; inset: auto; overflow: visible; }
+  .stage { width: auto; height: auto; transform: none !important; display: block; }
+  .holder { position: static; opacity: 1; visibility: visible; break-after: page; }
+  .slide { box-shadow: none; }
+}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+  <div class="stage-wrap" id="stageWrap">
+    <div class="stage" id="stage">
+
+    <!-- ═══════════ 01 표지 ═══════════ -->
+    <div class="holder" data-n="01">
+      <section class="slide" data-kind="cover">
+        <div class="cover">
+          <div>
+            <div class="eyebrow">Go · Dependency Injection</div>
+            <h1 class="cover-title">uber/fx로 시작하는<br />Go 의존성 주입</h1>
+            <p class="cover-sub">생성자를 등록하면 조립은 fx가 한다<br />— 타입으로 그래프를 만들고, 수명주기까지 관리하기</p>
+            <div class="cover-meta">
+              <span class="chip on">fx.Provide</span>
+              <span class="chip">fx.Invoke</span>
+              <span class="chip">fx.Module</span>
+              <span class="chip">fxtest</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-head">
+              <span><span class="dot"></span>fx가 자동으로 만드는 그래프</span>
+              <span>types only</span>
+            </div>
+            <div class="panel-body" style="display:block;padding:22px 20px;">
+              <div class="tree">
+                <span class="lv"><span class="k">config.New()</span></span>
+                <span class="lv">├─ <span class="k">database.New</span>(cfg)</span>
+                <span class="lv">│  ├─ NewMysqlArticleRepository(db)</span>
+                <span class="lv">│  └─ NewMysqlAuthorRepository(db)</span>
+                <span class="lv">│     └─ <span class="v">NewArticleUsecase(repo, authorRepo, timeout)</span></span>
+                <span class="lv">│        └─ <span class="v">NewArticleHandler(echo, usecase)</span></span>
+                <span class="lv">└─ <span class="k">NewEcho</span>(cfg)</span>
+                <span class="lv">   └─ <span class="v">registerHooks(lifecycle, echo, cfg)</span></span>
+              </div>
+            </div>
+            <div class="panel-foot">
+              <span>등록 순서는 상관없다. fx는 매개변수·반환 타입만 본다.</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">인사. 오늘은 uber/fx 한 바퀴. 오른쪽 트리가 fx가 자동으로 만들어주는 것이고, 우리는 생성자만 등록한다는 점을 먼저 각인시키고 시작한다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 02 문제 제기 ═══════════ -->
+    <div class="holder" data-n="02">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">문제</span><span class="stamp">why DI</span></div>
+        <h2 class="slide-title"><code class="inl">main()</code>이 조립 설명서가 되어간다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>생성자를 <b>순서대로</b> 직접 호출해야 한다</li>
+              <li>매개변수 순서를 손으로 맞춘다</li>
+              <li>새 서비스를 추가할 때마다 <code class="inl">main()</code>을 고친다</li>
+              <li>의존성이 늘수록 이 코드는 <b>급격히</b> 복잡해진다</li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">// 수동 DI: main()에서 직접 조립</span>
+cfg, _ := config.<span class="t-fn">New</span>()
+db, _  := database.<span class="t-fn">New</span>(cfg)
+
+authorRepo  := author.<span class="t-fn">NewMysqlAuthorRepository</span>(db)
+articleRepo := article.<span class="t-fn">NewMysqlArticleRepository</span>(db)
+
+timeout := time.<span class="t-fn">Duration</span>(cfg.Context.Timeout) * time.Second
+usecase := article.<span class="t-fn">NewArticleUsecase</span>(articleRepo, authorRepo, timeout)
+
+e := <span class="t-fn">NewEcho</span>()
+article.<span class="t-fn">NewArticleHandler</span>(e, usecase)
+
+e.<span class="t-fn">Start</span>(cfg.Server.Address)</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">여기서 진짜 비용</span>
+            조립 <b>순서</b>라는 지식이 코드 여기저기에 흩어진다. 그 지식은 사실 <b>타입 안에 이미 들어 있다</b>.
+          </div>
+        </div>
+        <div class="notes-src">"이 코드 익숙하시죠?"로 공감대부터. 순서를 틀리면 컴파일 에러가 나긴 하지만, 진짜 문제는 조립 지식이 main에 눌러앉는다는 점이라는 걸 짚는다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 03 fx의 해법 ═══════════ -->
+    <div class="holder" data-n="03">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">해법</span><span class="stamp">uber/fx</span></div>
+        <h2 class="slide-title">fx는 <b>타입</b>만 보고 순서를 정한다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">우리가 하는 일</div>
+              <p>생성자 함수를 <b>등록</b>만 한다. 순서는 신경 쓰지 않는다.</p>
+              <pre class="code xs">fx.<span class="t-fn">Provide</span>(
+    config.New,
+    database.New,
+    NewArticleUsecase,
+)</pre>
+            </div>
+            <div class="card">
+              <div class="card-t">fx가 하는 일</div>
+              <p>각 생성자의 <b>매개변수 타입</b>과 <b>반환 타입</b>을 읽어 그래프를 구성하고, 올바른 순서로 호출한다.</p>
+              <pre class="code xs"><span class="t-fn">New</span>(cfg *config.Config) (*sql.DB, error)
+     <span class="t-cm">↑ 필요</span>            <span class="t-cm">↑ 제공</span></pre>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">한 줄 요약</span>
+            <code class="inl">database.New</code>가 <code class="inl">*config.Config</code>를 요구하므로, 그 타입을 반환하는 <code class="inl">config.New</code>가 <b>먼저</b> 호출된다. 순환 의존성은 앱 시작 시점에 에러로 알려준다.
+          </div>
+          <pre class="code plain sm">go get go.uber.org/fx</pre>
+        </div>
+        <div class="notes-src">"리플렉션으로 타입을 본다"는 게 핵심. 컴파일 타임 안전성을 일부 내주는 대신 조립 지식을 타입에 위임하는 거래라는 프레임으로 설명하면 뒤의 트레이드오프 이야기(30번)와 연결된다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 04 목차 ═══════════ -->
+    <div class="holder" data-n="04">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">목차</span><span class="stamp">agenda</span></div>
+        <h2 class="slide-title">오늘 다루는 것</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>장</th><th>내용</th><th>핵심 메서드</th></tr></thead>
+              <tbody>
+                <tr class="on"><td>01</td><td>fx 기초 — 등록·실행·수명주기</td><td><code class="inl">Provide</code> <code class="inl">Invoke</code> <code class="inl">Supply</code> <code class="inl">Lifecycle</code></td></tr>
+                <tr><td>02</td><td>확장 패턴 — 커진 앱을 정리하는 도구들</td><td><code class="inl">Module</code> <code class="inl">Decorate</code> <code class="inl">Annotate</code> <code class="inl">Private</code></td></tr>
+                <tr><td>03</td><td>테스트 전략</td><td><code class="inl">fxtest</code> <code class="inl">Replace</code> <code class="inl">Populate</code></td></tr>
+                <tr><td>04</td><td>정리 — 언제 쓰고 언제 안 쓰나</td><td class="faint">선택 가이드</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="dim" style="margin:0;font-size:17px;">fx는 메서드가 많아 헷갈리기 쉽다. 다음 슬라이드의 <b>지도</b>를 먼저 펼쳐두고, 각 장에서 하나씩 실전 예제로 채워 나간다.</p>
+        </div>
+        <div class="notes-src">4장 구성. 시간이 모자라면 03(테스트)을 줄이고 01·02에 집중한다. 02의 group/Private은 실무에서 늦게 만나는 주제라 뒤로 밀어도 무방.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 05 [CH 01] ═══════════ -->
+    <div class="holder" data-n="05" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">01</div>
+          <div class="chap-l">
+            <h2 class="chap-t">fx 기초</h2>
+            <p class="chap-d">등록하고, 실행하고, 수명주기를 맡긴다.
+            이 네 가지 — <code class="inl">Provide</code> · <code class="inl">Invoke</code> · <code class="inl">Supply</code> · <code class="inl">Lifecycle</code> — 만 알아도 실전 앱 하나는 굴러간다.</p>
+          </div>
+        </div>
+        <div class="notes-src">여기가 오늘의 뿌리. 특히 Provide(lazy)와 Invoke(eager)의 차이는 뒤에서 계속 재등장하므로 시간을 아끼지 말 것.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 06 메서드 지도 ═══════════ -->
+    <div class="holder" data-n="06">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">지도</span><span class="stamp">cheat sheet</span></div>
+        <h2 class="slide-title">fx 메서드 한눈에 ① 기초</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>메서드</th><th>분류</th><th>역할</th></tr></thead>
+              <tbody>
+                <tr class="on"><td><code class="inl">fx.New</code></td><td>기초</td><td>앱 컨테이너 생성 — 모든 Option을 모아 그래프를 만든다</td></tr>
+                <tr class="on"><td><code class="inl">fx.Provide</code></td><td>기초</td><td>lazy 등록. 반환 타입 기준으로 그래프에 올린다</td></tr>
+                <tr class="on"><td><code class="inl">fx.Invoke</code></td><td>기초</td><td>eager 실행. 부수 효과의 시작점</td></tr>
+                <tr class="on"><td><code class="inl">fx.Supply</code></td><td>기초</td><td>생성자 없이 이미 만든 값을 등록</td></tr>
+                <tr class="on"><td><code class="inl">fx.Lifecycle</code></td><td>수명주기</td><td>OnStart / OnStop 훅</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">오늘의 8할</span>
+            이 다섯 개만 알아도 실전 앱 하나는 굴러간다. 다음 장의 확장·테스트 도구들은 <b>앱이 커진 뒤에</b> 필요해진다.
+          </div>
+        </div>
+        <div class="notes-src">읽어 내려가지 말 것. "지금은 이 다섯 개만" 하고 넘어간다. 뒤에서 하나씩 예제로 채운다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 07 메서드 지도 ② ═══════════ -->
+    <div class="holder" data-n="07">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">지도</span><span class="stamp">cheat sheet</span></div>
+        <h2 class="slide-title">fx 메서드 한눈에 ② 확장 · 테스트</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>메서드</th><th>분류</th><th>역할</th><th>도입</th></tr></thead>
+              <tbody>
+                <tr><td><code class="inl">fx.Module</code></td><td>확장</td><td>도메인별 그룹화</td><td>v1.17+</td></tr>
+                <tr><td><code class="inl">fx.Decorate</code></td><td>확장</td><td>기존 의존성 래핑 (로깅·캐싱·메트릭)</td><td>v1.18+</td></tr>
+                <tr><td><code class="inl">fx.Annotate</code></td><td>확장</td><td>생성자에 name / group / As 부여</td><td class="faint">—</td></tr>
+                <tr><td><code class="inl">fx.In</code> / <code class="inl">fx.Out</code></td><td>확장</td><td>파라미터·반환값을 구조체로 묶어 태그 매칭</td><td class="faint">—</td></tr>
+                <tr><td><code class="inl">fx.Private</code></td><td>확장</td><td>Module 내부 의존성 캡슐화</td><td>v1.20+</td></tr>
+                <tr class="on"><td><code class="inl">fxtest.New</code></td><td>테스트</td><td>테스트 전용 앱</td><td class="faint">—</td></tr>
+                <tr class="on"><td><code class="inl">fx.Replace</code></td><td>테스트</td><td>기존 Provide를 Mock으로 교체</td><td class="faint">—</td></tr>
+                <tr class="on"><td><code class="inl">fx.Populate</code></td><td>테스트</td><td>내부 인스턴스를 외부 변수로 추출</td><td class="faint">—</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="notes-src">버전 표기가 있는 셋(Module·Decorate·Private)은 실무에서 "왜 안 되지?" 하는 원인이 되곤 한다. go.mod 버전을 확인하라고 한마디 덧붙인다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 08 fx.Option ═══════════ -->
+    <div class="holder" data-n="08">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">구조</span><span class="stamp">fx.Option</span></div>
+        <h2 class="slide-title">거의 모든 것이 <code class="inl">fx.Option</code>을 반환한다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <pre class="code sm">app := fx.<span class="t-fn">New</span>(          <span class="t-cm">// ← Option 들을 모아 앱을 만든다</span>
+    fx.<span class="t-fn">Provide</span>(...),   <span class="t-cm">// fx.Option</span>
+    fx.<span class="t-fn">Supply</span>(...),    <span class="t-cm">// fx.Option</span>
+    UserModule,        <span class="t-cm">// fx.Option (fx.Module 이 반환)</span>
+    fx.<span class="t-fn">Decorate</span>(...),  <span class="t-cm">// fx.Option</span>
+    fx.<span class="t-fn">Invoke</span>(...),    <span class="t-cm">// fx.Option</span>
+)</pre>
+            <div class="stack">
+              <div class="card">
+                <div class="card-t">① Option을 반환하는 것들</div>
+                <p class="dim"><code class="inl">Provide</code> · <code class="inl">Invoke</code> · <code class="inl">Supply</code> · <code class="inl">Module</code> · <code class="inl">Decorate</code> · <code class="inl">Replace</code> · <code class="inl">Populate</code><br />→ <code class="inl">fx.New</code>의 인자로 들어간다</p>
+              </div>
+              <div class="card">
+                <div class="card-t">② Annotation을 반환하는 것들</div>
+                <p class="dim"><code class="inl">Annotate</code> · <code class="inl">ResultTags</code> · <code class="inl">ParamTags</code><br />→ <code class="inl">Provide</code> · <code class="inl">Supply</code> <b>안에서</b> 쓰인다</p>
+              </div>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">이 둘만 구분하면</span>
+            fx API가 갑자기 단순해진다. 어디에 넣어야 할지 헷갈릴 일이 없다.
+          </div>
+        </div>
+        <div class="notes-src">fx 문서를 처음 볼 때 가장 헷갈리는 지점. Option인지 Annotation인지만 구분되면 "이걸 어디에 넣지?" 하는 고민이 사라진다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 09 fx.Provide ═══════════ -->
+    <div class="holder" data-n="09">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">기초</span><span class="stamp">fx.Provide</span></div>
+        <h2 class="slide-title"><code class="inl">Provide</code>는 등록만 한다 — 실행은 미룬다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm">app := fxtest.<span class="t-fn">New</span>(t,
+    <span class="t-cm">// Provide: 생성자를 등록만 한다. 즉시 실행되지 않는다.</span>
+    fx.<span class="t-fn">Provide</span>(
+        NewLogger,        <span class="t-cm">// Logger 반환</span>
+        NewMysqlUserRepo, <span class="t-cm">// UserRepository 반환 (Logger 필요)</span>
+        NewUserService,   <span class="t-cm">// *UserService 반환 (UserRepository 필요)</span>
+    ),
+    <span class="t-cm">// Invoke: 여기서 비로소 그래프가 조립된다</span>
+    fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(s *UserService) { svc = s }),
+)</pre>
+          <div class="cols c-2">
+            <div class="callout">
+              <span class="lbl">lazy 라는 뜻</span>
+              등록된 생성자는 <b>그 타입을 요구하는 쪽이 생길 때</b> 비로소 호출된다. 아무도 안 찾으면 영영 호출되지 않는다.
+            </div>
+            <div class="callout teal">
+              <span class="lbl">그래서 순서 무관</span>
+              위에서 <code class="inl">NewUserService</code>를 먼저 써도 결과는 같다. fx가 타입으로 정렬한다.
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">"Provide만 잔뜩 써놓고 왜 아무것도 안 도나요?"가 fx 첫 입문자의 단골 질문. 다음 슬라이드로 바로 이어진다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 10 fx.Invoke ═══════════ -->
+    <div class="holder" data-n="10">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">기초</span><span class="stamp">fx.Invoke</span></div>
+        <h2 class="slide-title"><code class="inl">Invoke</code>가 없으면 아무 일도 일어나지 않는다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t"><code class="inl">fx.Provide</code> — lazy</div>
+              <p>그래프에 <b>올려만</b> 둔다. 부수 효과 없음.</p>
+              <p class="dim">대부분의 <code class="inl">NewXxx</code> 생성자</p>
+            </div>
+            <div class="card">
+              <div class="card-t"><code class="inl">fx.Invoke</code> — eager</div>
+              <p>앱 시작 시 <b>반드시 실행</b>된다. 여기서 요구한 타입이 그래프 조립의 <b>출발점</b>이 된다.</p>
+              <p class="dim">서버 기동 · 라우터 등록 · 훅 등록</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">기억법</span>
+            <b>부수 효과면 Invoke.</b> 값을 만들어 돌려주면 Provide.
+          </div>
+          <pre class="code xs plain"><span class="t-bad">// Provide만 있고 Invoke가 없는 앱</span>
+<span class="t-cm">→ 생성자는 단 하나도 호출되지 않는다. 앱은 조용히 뜨고 조용히 끝난다.</span></pre>
+        </div>
+        <div class="notes-src">여기서 손을 들게 해도 좋다 — "Provide 20개 등록하고 Invoke 없이 실행하면 몇 개가 호출될까요?" 답은 0개.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 11 fx.Supply ═══════════ -->
+    <div class="holder" data-n="11">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">기초</span><span class="stamp">fx.Supply</span></div>
+        <h2 class="slide-title">만들 게 없는 값은 <code class="inl">Supply</code>로</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <pre class="code sm"><span class="t-key">type</span> Config <span class="t-key">struct</span> {
+    DBHost <span class="t-key">string</span>
+    DBPort <span class="t-key">int</span>
+}
+
+cfg := &amp;Config{DBHost: <span class="t-str">"localhost"</span>, DBPort: <span class="t-num">3306</span>}
+
+app := fxtest.<span class="t-fn">New</span>(t,
+    fx.<span class="t-fn">Supply</span>(cfg),   <span class="t-cm">// 생성자 없이 값 그대로 등록</span>
+    fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(c *Config) {
+        <span class="t-cm">// c.DBHost == "localhost"</span>
+    }),
+)</pre>
+            <div class="stack">
+              <div class="callout">
+                <span class="lbl">언제 쓰나</span>
+                설정 구조체, 상수처럼 <b>생성 로직이 없는</b> 값. <code class="inl">Provide</code>로 감싸면 <code class="inl">func() *Config { return cfg }</code> 같은 군더더기가 생긴다.
+              </div>
+              <div class="callout teal">
+                <span class="lbl">차이 한 줄</span>
+                <code class="inl">Provide</code>는 <b>생성자 함수</b>를, <code class="inl">Supply</code>는 <b>이미 만든 값</b>을 등록한다.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Supply는 테스트에서 특히 자주 쓴다. 실제 설정 파일을 읽는 대신 구조체를 손으로 만들어 넣는 식.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 12 실전 적용 ═══════════ -->
+    <div class="holder" data-n="12">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">실전</span><span class="stamp">before → after</span></div>
+        <h2 class="slide-title">수동 조립을 fx로 옮기면</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm">// cmd/main.go</span>
+app := fx.<span class="t-fn">New</span>(
+    fx.<span class="t-fn">Provide</span>(
+        config.New,              <span class="t-cm">// *config.Config</span>
+        database.New,            <span class="t-cm">// *sql.DB          (*config.Config 필요)</span>
+        NewEcho,                 <span class="t-cm">// *echo.Echo</span>
+
+        <span class="t-cm">// 익명 함수도 그대로 생성자가 된다 — 타입만 맞으면 된다</span>
+        <span class="t-key">func</span>(cfg *config.Config) time.Duration {
+            <span class="t-key">return</span> time.<span class="t-fn">Duration</span>(cfg.Context.Timeout) * time.Second
+        },
+
+        article.NewArticleHandler,         <span class="t-cm">// Echo, UseCase 필요</span>
+        article.NewArticleUsecase,         <span class="t-cm">// Repo, AuthorRepo, Duration 필요</span>
+        article.NewMysqlArticleRepository, <span class="t-cm">// DB 필요</span>
+        author.NewMysqlAuthorRepository,   <span class="t-cm">// DB 필요</span>
+    ),
+    fx.<span class="t-fn">Invoke</span>(registerHooks),   <span class="t-cm">// 서버 시작</span>
+)</pre>
+          <div class="callout teal">
+            <span class="lbl">달라진 것</span>
+            조립 <b>순서가 사라졌다.</b> 남은 건 "무엇이 있는가"의 목록뿐이고, "어떤 순서로"는 fx가 타입에서 읽어낸다.
+          </div>
+        </div>
+        <div class="notes-src">2번 슬라이드의 수동 코드와 나란히 놓고 보면 효과가 크다. 필요하면 2번으로 잠깐 돌아갔다 와도 좋다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 13 의존성 그래프 ═══════════ -->
+    <div class="holder" data-n="13">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">원리</span><span class="stamp">graph</span></div>
+        <h2 class="slide-title">그래프는 시그니처에서 나온다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">config.New</span><span class="n-p">() → *Config</span></div>
+              <div class="node"><span class="n-t">NewEcho</span><span class="n-p">() → *echo.Echo</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">*Config</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">database.New</span><span class="n-p">(*Config) → *sql.DB</span></div>
+              <div class="node"><span class="n-t">ArticleRepo</span><span class="n-p">(*sql.DB)</span></div>
+              <div class="node"><span class="n-t">AuthorRepo</span><span class="n-p">(*sql.DB)</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">repos</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">ArticleUsecase</span><span class="n-p">(repo, authorRepo, timeout)</span></div>
+              <div class="node"><span class="n-t">ArticleHandler</span><span class="n-p">(echo, usecase)</span></div>
+              <div class="node mute"><span class="n-t">registerHooks</span><span class="n-p">lifecycle, echo, cfg</span></div>
+            </div>
+          </div>
+          <p class="cap">화살표는 <b>의존 방향</b>이다. fx는 이 그래프를 <b>선언 없이</b> 매개변수·반환 타입만으로 만든다.
+          순환이 생기면 앱 시작 시점에 어디가 물렸는지 알려준다.</p>
+        </div>
+        <div class="notes-src">"이 그림을 우리가 그린 적이 없다"는 게 포인트. 코드 어디에도 이 순서를 적어두지 않았는데 fx가 만들어낸다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 14 Lifecycle ═══════════ -->
+    <div class="holder" data-n="14">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">수명주기</span><span class="stamp">fx.Lifecycle</span></div>
+        <h2 class="slide-title">시작과 종료를 짝으로 묶는다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">registerHooks</span>(lifecycle fx.Lifecycle, e *echo.Echo, cfg *config.Config) {
+    lifecycle.<span class="t-fn">Append</span>(fx.Hook{
+        OnStart: <span class="t-key">func</span>(context.Context) <span class="t-key">error</span> {
+            fmt.<span class="t-fn">Println</span>(<span class="t-str">"Starting server"</span>)
+            <span class="t-key">go</span> e.<span class="t-fn">Start</span>(cfg.Server.Address)
+            <span class="t-key">return</span> <span class="t-key">nil</span>
+        },
+        OnStop: <span class="t-key">func</span>(context.Context) <span class="t-key">error</span> {
+            fmt.<span class="t-fn">Println</span>(<span class="t-str">"Stopping server"</span>)
+            <span class="t-key">return</span> <span class="t-key">nil</span>
+        },
+    })
+}</pre>
+          <div class="callout">
+            <span class="lbl">쓰는 곳</span>
+            서버 기동/종료, DB 커넥션 open/close처럼 <b>시작과 정리가 짝을 이루는</b> 리소스. <code class="inl">fx.Invoke(registerHooks)</code>로 등록한다.
+          </div>
+        </div>
+        <div class="notes-src">Graceful Shutdown이 공짜로 따라온다는 점을 강조. OnStop은 등록의 역순으로 호출된다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 15 실행 시점 ═══════════ -->
+    <div class="holder" data-n="15">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">주의</span><span class="stamp">타이밍</span></div>
+        <h2 class="slide-title">서버는 정확히 <b>언제</b> 뜨는가</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="steps">
+            <div class="step"><span class="s-n">1</span><div><div class="s-c">fx.New() / fxtest.New()</div><div class="s-d"><code class="inl">fx.Invoke</code> 함수 <b>본문</b>이 즉시 실행된다. 여기서 하는 일은 Lifecycle에 훅을 <b>등록</b>하는 것뿐. (<code class="inl">fx.Populate</code>도 이 시점에 채워진다)</div></div></div>
+            <div class="step"><span class="s-n">2</span><div><div class="s-c">app.Start(ctx)</div><div class="s-d">등록된 <code class="inl">OnStart</code> 훅이 실행된다 — <b>실제 서버 기동</b>은 여기서 일어난다</div></div></div>
+            <div class="step"><span class="s-n">3</span><div><div class="s-c">app.Stop(ctx)</div><div class="s-d">등록된 <code class="inl">OnStop</code> 훅이 실행된다 — Graceful Shutdown</div></div></div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Lifecycle이 2단계인 이유</span>
+            Invoke로 훅을 <b>일찍 등록</b>해두고, 훅 <b>본문 실행</b>은 <code class="inl">Start</code>까지 미루기 위해서다.
+          </div>
+        </div>
+        <div class="notes-src">여기가 실무에서 제일 많이 헷갈리는 지점. "Invoke에 넣었는데 왜 벌써 실행되죠?" / "왜 아직 안 뜨죠?" 둘 다 이 표로 설명된다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 16 [CH 02] ═══════════ -->
+    <div class="holder" data-n="16" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">02</div>
+          <div class="chap-l">
+            <h2 class="chap-t">확장 패턴</h2>
+            <p class="chap-d">앱이 커지면 <code class="inl">Provide</code> 목록이 수십 줄이 된다.
+            묶고(<code class="inl">Module</code>), 덧씌우고(<code class="inl">Decorate</code>), 구분하고(<code class="inl">name</code>/<code class="inl">group</code>), 감추는(<code class="inl">Private</code>) 도구들.</p>
+          </div>
+        </div>
+        <div class="notes-src">여기부터는 "당장 필요하진 않지만 언젠가 반드시 만나는" 것들. 지금 다 외우지 말고 이런 게 있다는 것만 기억하라고 안내한다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 17 fx.Module ═══════════ -->
+    <div class="holder" data-n="17">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Module · v1.17+</span></div>
+        <h2 class="slide-title">도메인별로 묶는다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <pre class="code sm"><span class="t-key">var</span> UserModule = fx.<span class="t-fn">Module</span>(<span class="t-str">"user"</span>,
+    fx.<span class="t-fn">Provide</span>(
+        NewMysqlUserRepo,
+        NewUserService,
+    ),
+)
+
+<span class="t-key">var</span> OrderModule = fx.<span class="t-fn">Module</span>(<span class="t-str">"order"</span>,
+    fx.<span class="t-fn">Provide</span>(
+        NewMysqlOrderRepo,
+        NewOrderService,
+    ),
+)</pre>
+            <pre class="code sm"><span class="t-cm">// 실전: 각 도메인 패키지가 Module 을 노출하고</span>
+<span class="t-cm">// main 에서 조합한다</span>
+app := fx.<span class="t-fn">New</span>(
+    fx.<span class="t-fn">Provide</span>(config.New, database.New, NewEcho),
+
+    article.Module,   <span class="t-cm">// article 도메인</span>
+    author.Module,    <span class="t-cm">// author 도메인</span>
+    payment.Module,   <span class="t-cm">// payment 도메인</span>
+
+    fx.<span class="t-fn">Invoke</span>(registerHooks),
+)</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">주의</span>
+            <code class="inl">Module</code>은 <b>이름을 붙여 묶어줄 뿐</b>이다. 안의 <code class="inl">Provide</code>는 여전히 <b>전역 그래프에 노출</b>된다. 감추려면 23번의 <code class="inl">fx.Private</code>이 필요하다.
+          </div>
+        </div>
+        <div class="notes-src">"Module = 캡슐화"라고 오해하기 쉬운데 아니다. 이 오해가 23번 슬라이드의 출발점이므로 여기서 미리 심어둔다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 18 fx.Decorate ═══════════ -->
+    <div class="holder" data-n="18">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Decorate · v1.18+</span></div>
+        <h2 class="slide-title">원본을 안 건드리고 덧씌운다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm">// 로깅 데코레이터: 기존 UserRepository 를 래핑</span>
+<span class="t-key">type</span> loggingUserRepo <span class="t-key">struct</span> {
+    inner  UserRepository
+    logger Logger
+}
+
+<span class="t-key">func</span> (r *loggingUserRepo) <span class="t-fn">FindByID</span>(id <span class="t-key">int</span>) <span class="t-key">string</span> {
+    r.calls = <span class="t-fn">append</span>(r.calls, fmt.<span class="t-fn">Sprintf</span>(<span class="t-str">"FindByID(%d)"</span>, id))
+    <span class="t-key">return</span> r.inner.<span class="t-fn">FindByID</span>(id)   <span class="t-cm">// 원본 호출</span>
+}
+
+app := fxtest.<span class="t-fn">New</span>(t,
+    fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
+    fx.<span class="t-fn">Decorate</span>(<span class="t-key">func</span>(repo UserRepository, logger Logger) UserRepository {
+        <span class="t-key">return</span> &amp;loggingUserRepo{inner: repo, logger: logger}
+    }),
+)</pre>
+          <div class="callout teal">
+            <span class="lbl">핵심</span>
+            원본을 매개변수로 받아 <b>같은 타입</b>을 반환하면 fx가 그래프의 그 노드를 교체한다.
+            <code class="inl">UserService</code>는 <b>코드 한 줄 안 고치고</b> 래퍼를 주입받는다.
+          </div>
+        </div>
+        <div class="notes-src">로깅·캐싱·메트릭 같은 횡단 관심사에 쓴다. Java의 AOP를 떠올리면 이해가 빠른 청중도 있다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 19 name 태그 ═══════════ -->
+    <div class="holder" data-n="19">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Annotate + name:</span></div>
+        <h2 class="slide-title">같은 타입이 둘일 때 — read / write DB</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack tight">
+              <div class="card-t">① 등록: 생성자에 이름을 붙인다</div>
+              <pre class="code xs">fx.<span class="t-fn">Provide</span>(
+    fx.<span class="t-fn">Annotate</span>(NewReadDB,
+        fx.<span class="t-fn">ResultTags</span>(<span class="t-str">`name:"readDB"`</span>)),
+    fx.<span class="t-fn">Annotate</span>(NewWriteDB,
+        fx.<span class="t-fn">ResultTags</span>(<span class="t-str">`name:"writeDB"`</span>)),
+    NewDBService,
+)</pre>
+            </div>
+            <div class="stack tight">
+              <div class="card-t">② 수신: <code class="inl">fx.In</code> 구조체로 매칭</div>
+              <pre class="code xs"><span class="t-key">type</span> DBParams <span class="t-key">struct</span> {
+    fx.In
+    ReadDB  *DBConnection <span class="t-str">`name:"readDB"`</span>
+    WriteDB *DBConnection <span class="t-str">`name:"writeDB"`</span>
+}
+
+<span class="t-key">func</span> <span class="t-fn">NewDBService</span>(p DBParams) *DBService {
+    <span class="t-key">return</span> &amp;DBService{
+        readDB:  p.ReadDB,
+        writeDB: p.WriteDB,
+    }
+}</pre>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">fx.In 이란</span>
+            여러 의존성을 <b>하나의 파라미터 구조체</b>로 묶어 받게 해주는 임베디드 마커. 필드마다 태그로 특정 인스턴스를 지목할 수 있다. (반환값을 묶을 땐 <code class="inl">fx.Out</code>)
+          </div>
+        </div>
+        <div class="notes-src">타입이 같으면 fx가 구분할 방법이 없다는 게 출발점. 이름표를 붙여주는 것뿐이라고 설명하면 직관적이다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 20 group 태그 ═══════════ -->
+    <div class="holder" data-n="20">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">group:</span></div>
+        <h2 class="slide-title">같은 인터페이스 구현체를 <b>모아서</b> 받는다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <pre class="code xs">fx.<span class="t-fn">Provide</span>(
+    fx.<span class="t-fn">Annotate</span>(<span class="t-key">func</span>() Notifier { <span class="t-key">return</span> &amp;EmailNotifier{} },
+        fx.<span class="t-fn">ResultTags</span>(<span class="t-str">`group:"notifiers"`</span>)),
+    fx.<span class="t-fn">Annotate</span>(<span class="t-key">func</span>() Notifier { <span class="t-key">return</span> &amp;SlackNotifier{} },
+        fx.<span class="t-fn">ResultTags</span>(<span class="t-str">`group:"notifiers"`</span>)),
+    fx.<span class="t-fn">Annotate</span>(<span class="t-key">func</span>() Notifier { <span class="t-key">return</span> &amp;SMSNotifier{} },
+        fx.<span class="t-fn">ResultTags</span>(<span class="t-str">`group:"notifiers"`</span>)),
+    NewNotifierService,
+)</pre>
+            <pre class="code xs"><span class="t-key">type</span> NotifierParams <span class="t-key">struct</span> {
+    fx.In
+    Notifiers []Notifier <span class="t-str">`group:"notifiers"`</span>
+}
+
+<span class="t-key">func</span> <span class="t-fn">NewNotifierService</span>(p NotifierParams) *NotifierService {
+    <span class="t-key">return</span> &amp;NotifierService{notifiers: p.Notifiers}
+}</pre>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">이게 좋은 이유</span>
+            새 구현체를 추가해도 <b>수신 측 코드는 그대로</b>다. 플러그인·핸들러·외부 클라이언트를 모을 때의 정석.
+          </div>
+        </div>
+        <div class="notes-src">"Notifier 하나 더 추가하려면 어디를 고쳐야 하나?" → Provide 한 줄만. 수신 측은 안 건드린다는 게 핵심 가치.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 21 name vs group ═══════════ -->
+    <div class="holder" data-n="21">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">비교</span><span class="stamp">name vs group</span></div>
+        <h2 class="slide-title">개별로 지목할까, 모아서 받을까</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>패턴</th><th>용도</th><th>수신 측</th><th>구현체가 늘면</th></tr></thead>
+              <tbody>
+                <tr><td><code class="inl">name:"X"</code></td><td>동일 타입을 <b>개별</b> 식별</td><td>단일 필드</td><td class="faint">수신 코드도 고쳐야 한다</td></tr>
+                <tr class="on"><td><code class="inl">group:"Y"</code></td><td>동일 타입·인터페이스를 <b>모음</b></td><td>슬라이스 필드</td><td>수신 코드는 그대로</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="cols c-2">
+            <div class="callout">
+              <span class="lbl">name: 이 맞는 상황</span>
+              read/write DB처럼 <b>역할이 다른</b> 소수의 인스턴스. 각각을 정확히 지목해야 한다.
+            </div>
+            <div class="callout teal">
+              <span class="lbl">group: 이 맞는 상황</span>
+              Notifier·Handler처럼 <b>같은 취급</b>을 받는 구현체 묶음. 하나씩 이름 붙이면 확장할 때마다 아프다.
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">이 슬라이드 하나만 기억해도 실무에서 헷갈릴 일이 없다. "개별 지목이면 name, 한꺼번에면 group".</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 22 fx.Private ═══════════ -->
+    <div class="holder" data-n="22">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Private · v1.20+</span></div>
+        <h2 class="slide-title">Module 내부 의존성을 감춘다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <pre class="code sm">PrivateModule := fx.<span class="t-fn">Module</span>(<span class="t-str">"private"</span>,
+    fx.<span class="t-fn">Provide</span>(
+        newInternalDB,
+        fx.Private,    <span class="t-cm">// ← 이 Provide 그룹 전체를</span>
+                       <span class="t-cm">//   Module 내부 전용으로</span>
+    ),
+    fx.<span class="t-fn">Provide</span>(newModuleService),  <span class="t-cm">// 이건 외부 노출</span>
+)
+
+<span class="t-cm">// 외부에서 *internalDB 를 요청하면?</span>
+leakApp := fx.<span class="t-fn">New</span>(
+    PrivateModule,
+    fx.<span class="t-fn">Populate</span>(&amp;leaked),
+    fx.NopLogger,
+)
+<span class="t-cm">// leakApp.Err() != nil  →</span> <span class="t-bad">그래프 구성 단계에서 에러</span></pre>
+            <div class="stack">
+              <div class="callout">
+                <span class="lbl">해결하는 문제</span>
+                DB 핸들·외부 API 클라이언트 같은 <b>인프라 의존성</b>을 다른 Module이 <b>우연히 공유</b>하는 것을 막는다.
+              </div>
+              <div class="callout teal">
+                <span class="lbl">범위</span>
+                <code class="inl">*internalDB</code>는 같은 Module 안의 <code class="inl">newModuleService</code>만 주입받을 수 있다.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">16번에서 심어둔 "Module은 캡슐화가 아니다"의 답. 실무에서 DB 커넥션 풀이 의도치 않게 공유되는 사고를 막아준다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 23 [CH 03] ═══════════ -->
+    <div class="holder" data-n="23" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">03</div>
+          <div class="chap-l">
+            <h2 class="chap-t">테스트 전략</h2>
+            <p class="chap-d">fx로 조립한 앱을 테스트에서 어떻게 띄우고,
+            어떻게 Mock을 끼워 넣고, 조립된 인스턴스를 어떻게 꺼내는가.</p>
+          </div>
+        </div>
+        <div class="notes-src">DI 프레임워크의 실질적 이점이 드러나는 부분. 조립 지점이 한 곳이라 갈아끼우기가 쉽다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 24 fxtest ═══════════ -->
+    <div class="holder" data-n="24">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">테스트</span><span class="stamp">fxtest.New</span></div>
+        <h2 class="slide-title">테스트 전용 앱 컨테이너</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm">app := fxtest.<span class="t-fn">New</span>(t,
+    fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
+    fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(svc *UserService) { <span class="t-cm">/* ... */</span> }),
+)
+<span class="t-key">defer</span> app.<span class="t-fn">RequireStop</span>()
+app.<span class="t-fn">RequireStart</span>()</pre>
+          <div class="cols c-2">
+            <div class="callout">
+              <span class="lbl">fx.New 대신 쓰는 이유</span>
+              실패를 <code class="inl">t</code>로 리포트하고, 정리를 도와주며, fx 로그가 테스트 출력에 포함된다.
+            </div>
+            <div class="callout teal">
+              <span class="lbl">Require 접두사</span>
+              <code class="inl">RequireStart</code>/<code class="inl">RequireStop</code>은 실패하면 테스트를 즉시 중단시킨다.
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">앞 슬라이드들의 예제가 전부 fxtest였다는 점을 여기서 밝히면 자연스럽게 이어진다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 25 fx.Replace ═══════════ -->
+    <div class="holder" data-n="25">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">테스트</span><span class="stamp">fx.Replace + fx.As</span></div>
+        <h2 class="slide-title">Mock으로 갈아끼우기</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm">app := fxtest.<span class="t-fn">New</span>(t,
+    fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
+
+    <span class="t-cm">// 실제 UserRepository 를 Mock 으로 교체</span>
+    fx.<span class="t-fn">Replace</span>(fx.<span class="t-fn">Annotate</span>(&amp;mockUserRepo{}, fx.<span class="t-fn">As</span>(<span class="t-fn">new</span>(UserRepository)))),
+
+    fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(svc *UserService) {
+        result := svc.repo.<span class="t-fn">FindByID</span>(<span class="t-num">1</span>)
+        <span class="t-cm">// result == "mock-user-1"</span>
+    }),
+)</pre>
+          <div class="callout">
+            <span class="lbl"><code class="inl">fx.As</code>가 왜 필요한가</span>
+            fx는 <b>타입으로 매칭</b>한다. <code class="inl">&amp;mockUserRepo{}</code>의 타입은 <code class="inl">*mockUserRepo</code>이지 <code class="inl">UserRepository</code>가 아니다.
+            <code class="inl">fx.As(new(UserRepository))</code>로 <b>인터페이스 타입으로 등록</b>해야 기존 Provide를 교체한다.
+          </div>
+        </div>
+        <div class="notes-src">fx 입문자가 가장 자주 넘어지는 함정. Replace만 쓰고 As를 빼면 "교체가 안 되는데요?"가 된다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 26 Populate vs Invoke ═══════════ -->
+    <div class="holder" data-n="26">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">테스트</span><span class="stamp">Populate vs Invoke</span></div>
+        <h2 class="slide-title">조립된 인스턴스 꺼내기</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <pre class="code xs"><span class="t-cm">// 방식 1: Invoke 클로저로 캡처</span>
+<span class="t-key">var</span> svc1 *UserService
+app1 := fxtest.<span class="t-fn">New</span>(t,
+    fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
+    fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(s *UserService) {
+        svc1 = s
+    }),
+)</pre>
+            <pre class="code xs"><span class="t-cm">// 방식 2: Populate 로 직접 추출</span>
+<span class="t-key">var</span> svc2 *UserService
+app2 := fxtest.<span class="t-fn">New</span>(t,
+    fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
+    fx.<span class="t-fn">Populate</span>(&amp;svc2),
+)
+
+<span class="t-cm">// 여러 개도 한 번에</span>
+fx.<span class="t-fn">Populate</span>(&amp;svc, &amp;logger)</pre>
+          </div>
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>구분</th><th><code class="inl">fx.Invoke</code></th><th><code class="inl">fx.Populate</code></th></tr></thead>
+              <tbody>
+                <tr><td>본질</td><td>함수를 <b>실행</b>한다</td><td>변수에 값을 <b>채운다</b></td></tr>
+                <tr><td>넘기는 것</td><td>함수(클로저)</td><td>포인터</td></tr>
+                <tr><td>고르는 기준</td><td>꺼낸 뒤 <b>호출·검증까지</b> 할 때</td><td>꺼내는 것 <b>자체가 목적</b>일 때</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="notes-src">Populate는 내부적으로 Invoke로 구현된 편의 함수다. 본질이 같고 목적만 다르다는 걸 알면 선택이 쉬워진다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 27 [CH 04] ═══════════ -->
+    <div class="holder" data-n="27" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">04</div>
+          <div class="chap-l">
+            <h2 class="chap-t">정리</h2>
+            <p class="chap-d">무엇을 언제 고를지, 그리고 — 어디까지 fx에 맡기지 <b>않을</b> 것인지.</p>
+          </div>
+        </div>
+        <div class="notes-src">마지막 장. 선택 가이드 표는 자료로 남겨두고, 마지막 메시지(30번)에 시간을 더 쓴다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 28 선택 가이드 ═══════════ -->
+    <div class="holder" data-n="28">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">정리</span><span class="stamp">선택 가이드</span></div>
+        <h2 class="slide-title">하고 싶은 일 → 쓸 메서드</h2>
+        <div class="rule"></div>
+        <div class="slide-body top">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>하고 싶은 일</th><th>메서드</th><th>기억법</th></tr></thead>
+              <tbody>
+                <tr><td>의존성을 그래프에 등록 (lazy)</td><td><code class="inl">fx.Provide</code></td><td class="faint">즉시 실행 아님</td></tr>
+                <tr><td>앱 시작 시 즉시 실행 (서버 기동)</td><td><code class="inl">fx.Invoke</code></td><td>부수 효과면 Invoke</td></tr>
+                <tr><td>이미 만든 값·설정을 주입</td><td><code class="inl">fx.Supply</code></td><td class="faint">상수·구성값</td></tr>
+                <tr><td>시작/종료 훅 (Graceful Shutdown)</td><td><code class="inl">fx.Lifecycle</code></td><td>Invoke 안에서 Append</td></tr>
+                <tr><td>도메인별로 의존성 묶기</td><td><code class="inl">fx.Module</code></td><td class="faint">커진 Provide 분리</td></tr>
+                <tr><td>기존 의존성에 로깅·캐싱 덧입히기</td><td><code class="inl">fx.Decorate</code></td><td>원본 수정 없이 래핑</td></tr>
+                <tr><td>동일 타입을 <b>개별</b> 식별 (read/write)</td><td><code class="inl">Annotate</code> + <code class="inl">name:</code></td><td class="faint">수신 측 단일 필드</td></tr>
+                <tr><td>동일 인터페이스를 <b>모아서</b> 주입</td><td><code class="inl">group:</code></td><td>수신 측 슬라이스</td></tr>
+                <tr><td>Module 내부 의존성 숨기기</td><td><code class="inl">fx.Private</code></td><td class="faint">인프라 핸들 격리</td></tr>
+                <tr><td>테스트에서 Mock 주입</td><td><code class="inl">fx.Replace</code></td><td><code class="inl">fx.As</code>로 인터페이스 매칭</td></tr>
+                <tr><td>테스트에서 인스턴스 꺼내기</td><td><code class="inl">fx.Populate</code></td><td class="faint">검증까지면 Invoke</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="notes-src">읽어 내려가지 말고 "자료로 가져가시라"고 안내. 대신 앞에서 다룬 것 중 두어 개만 짚어 복습한다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 29 마지막 메시지 ═══════════ -->
+    <div class="holder" data-n="29">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">마무리</span><span class="stamp">trade-off</span></div>
+        <h2 class="slide-title">모든 것을 fx로 관리할 필요는 없다</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">fx가 빛나는 곳</div>
+              <p><b>수명주기 관리가 필요한 컴포넌트</b></p>
+              <p class="dim">DB 연결 · HTTP 서버 · 외부 클라이언트 — 시작과 정리가 짝을 이루고, 여러 곳에서 공유되는 것들</p>
+            </div>
+            <div class="card">
+              <div class="card-t">직접 만드는 게 나은 곳</div>
+              <p><b>단순한 값 객체와 유틸리티</b></p>
+              <p class="dim">생성 비용이 없고 수명주기도 없는 것을 그래프에 올리면 얻는 것 없이 간접성만 늘어난다</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">치르는 대가</span>
+            리플렉션 기반이라 <b>컴파일 타임 타입 안전성을 일부 포기</b>한다. 대신 상세한 런타임 에러 메시지와 실전 생산성을 얻는다 — 이 거래가 맞는지는 앱 규모가 답한다.
+          </div>
+        </div>
+        <div class="notes-src">"DI 프레임워크를 쓰면 다 좋아진다"는 인상으로 끝내지 않는 게 중요. 작은 앱에서는 수동 조립이 더 명확하다는 말을 꼭 덧붙인다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 30 퀴즈 1 ═══════════ -->
+    <div class="holder" data-n="30">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">확인</span><span class="stamp">클릭하면 답이 열립니다</span></div>
+        <h2 class="slide-title">스스로 답해보기 ①</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span><code class="inl">fx.Provide</code>에 생성자를 잔뜩 등록했는데 앱을 띄워도 아무것도 실행되지 않는다. 왜일까?</span></button>
+              <div class="q-a"><code class="inl">Provide</code>는 등록만 하고 실행은 미루는 lazy 등록이기 때문이다. 그래프가 조립되려면 그 타입을 요구하는 쪽이 있어야 하고, 그 시작점이 <code class="inl">fx.Invoke</code>다. <span class="ref">→ 슬라이드 09 · 10</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span><code class="inl">fx.Provide</code>와 <code class="inl">fx.Supply</code>는 무엇이 다른가?</span></button>
+              <div class="q-a"><code class="inl">Provide</code>는 <b>생성자 함수</b>를 등록하고 fx가 반환 타입으로 그래프에 연결한다. <code class="inl">Supply</code>는 <b>이미 만들어진 값</b>을 그대로 등록한다. 설정 구조체·상수처럼 생성 로직이 없는 값에 맞다. <span class="ref">→ 슬라이드 11</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>fx는 생성자를 어떤 순서로 호출할지 어떻게 결정하나?</span></button>
+              <div class="q-a">각 생성자의 <b>매개변수 타입과 반환 타입</b>만 본다. 등록 순서는 상관없고, 순환 의존성이 있으면 앱 시작 시점에 에러로 알려준다. <span class="ref">→ 슬라이드 03 · 13</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span><code class="inl">registerHooks</code>를 <code class="inl">fx.Invoke</code>로 등록했다. 서버는 정확히 언제 뜨나?</span></button>
+              <div class="q-a">두 시점으로 나뉜다. <code class="inl">Invoke</code> 본문은 <code class="inl">fx.New()</code> 때 즉시 실행되지만 거기서 하는 일은 훅 <b>등록</b>뿐이고, <code class="inl">OnStart</code> 본문은 <code class="inl">app.Start(ctx)</code>에서 실행된다. <span class="ref">→ 슬라이드 15</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>도메인별로 <code class="inl">fx.Module</code>을 나눴는데 다른 Module이 같은 DB 핸들을 주입받아 버렸다. 무엇을 빠뜨렸나?</span></button>
+              <div class="q-a"><code class="inl">fx.Private</code>이다. <code class="inl">Module</code>은 이름을 붙여 묶어줄 뿐, 안의 <code class="inl">Provide</code>는 전역 그래프에 노출된다. 같은 <code class="inl">Provide</code> 그룹에 <code class="inl">fx.Private</code>을 넣어야 감춰진다. <span class="ref">→ 슬라이드 17 · 22</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">한 문제씩 열기 전에 3초쯤 기다린다. Q4는 오답이 많이 나오는 문제라 특히 천천히.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 31 퀴즈 2 ═══════════ -->
+    <div class="holder" data-n="31">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">확인</span><span class="stamp">클릭하면 답이 열립니다</span></div>
+        <h2 class="slide-title">스스로 답해보기 ②</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q6</span><span>기존 Repository 코드를 한 줄도 건드리지 않고 로깅을 붙이고 싶다.</span></button>
+              <div class="q-a"><code class="inl">fx.Decorate</code>다. 원본을 매개변수로 받아 래핑한 <b>같은 타입</b>을 반환하면 fx가 그래프의 해당 노드를 교체한다. 주입받는 쪽은 코드 변경 없이 래퍼를 받는다. <span class="ref">→ 슬라이드 18</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q7</span><span>같은 <code class="inl">*DBConnection</code> 타입인 read용·write용 커넥션을 각각 주입받으려면?</span></button>
+              <div class="q-a"><code class="inl">fx.Annotate</code> + <code class="inl">fx.ResultTags</code>로 생성자마다 <code class="inl">name:"readDB"</code> 같은 이름을 붙이고, 수신 측은 <code class="inl">fx.In</code>을 임베드한 구조체 필드에 같은 태그를 단다. <span class="ref">→ 슬라이드 19</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q8</span><span><code class="inl">Notifier</code> 구현체가 셋인데 전부 한꺼번에 주입받고 싶다. <code class="inl">name:</code> 태그로 되나?</span></button>
+              <div class="q-a">되긴 하지만 나쁜 방법이다. 구현체가 늘 때마다 수신 코드를 고쳐야 한다. <code class="inl">group:"notifiers"</code>로 등록하고 <code class="inl">[]Notifier</code> 슬라이스로 받으면 수신 코드는 그대로다. <span class="ref">→ 슬라이드 20 · 21</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q9</span><span>테스트에서 <code class="inl">fx.Replace(&amp;mockUserRepo{})</code>만으로는 왜 부족한가?</span></button>
+              <div class="q-a">fx는 타입으로 매칭하는데 <code class="inl">&amp;mockUserRepo{}</code>의 타입은 <code class="inl">*mockUserRepo</code>이지 인터페이스가 아니기 때문이다. <code class="inl">fx.Annotate(..., fx.As(new(UserRepository)))</code>로 감싸야 교체된다. <span class="ref">→ 슬라이드 25</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q10</span><span>조립된 인스턴스를 테스트로 꺼낼 때 <code class="inl">fx.Invoke</code>와 <code class="inl">fx.Populate</code> 중 무엇을 쓰나?</span></button>
+              <div class="q-a">본질은 같다 — <code class="inl">Populate</code>는 내부적으로 <code class="inl">Invoke</code>로 구현된 편의 함수다. 차이는 목적이다. 담는 것만이 목적이면 <code class="inl">Populate</code>, 꺼낸 뒤 호출·검증까지 하면 <code class="inl">Invoke</code>. <span class="ref">→ 슬라이드 26</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Q9는 실제로 많이 겪는 함정이라 "당해보신 분?" 하고 물어보면 반응이 온다.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 32 마무리 ═══════════ -->
+    <div class="holder" data-n="32">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">끝</span><span class="stamp">thank you</span></div>
+        <h2 class="slide-title">오늘 정리</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <ul class="bul">
+            <li>fx는 생성자의 <b>매개변수·반환 타입</b>만으로 의존성 그래프를 만든다 — 조립 순서를 코드에서 지운다</li>
+            <li><code class="inl">Provide</code>는 lazy 등록, <code class="inl">Invoke</code>는 eager 실행. <b>Invoke가 없으면 아무 일도 일어나지 않는다</b></li>
+            <li><code class="inl">Lifecycle</code>은 2단계다 — <code class="inl">New</code>에서 훅을 등록하고, <code class="inl">Start</code>에서 본문을 실행한다</li>
+            <li>앱이 커지면 <code class="inl">Module</code>로 묶고, <code class="inl">Decorate</code>로 덧씌우고, <code class="inl">name</code>/<code class="inl">group</code>으로 구분하고, <code class="inl">Private</code>으로 감춘다</li>
+            <li>테스트는 <code class="inl">fxtest</code> + <code class="inl">Replace</code>(<code class="inl">fx.As</code> 잊지 말 것) + <code class="inl">Populate</code></li>
+            <li>모든 것을 fx로 관리하지 않는다. <b>수명주기가 있는 컴포넌트</b>에 집중할 때 가장 빛난다</li>
+          </ul>
+          <div class="cols c-2">
+            <div class="callout">
+              <span class="lbl">메서드별 학습 예제</span>
+              github.com/kenshin579/tutorials-go<br /><span class="dim">golang/third-party/fx</span>
+            </div>
+            <div class="callout teal">
+              <span class="lbl">실전 적용 (Clean Architecture)</span>
+              github.com/kenshin579/tutorials-go<br /><span class="dim">project-layout/go-clean-arch-v2</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">저장소 주소를 띄워둔 채로 Q&amp;A를 받는다. 시간이 남으면 6번 지도 슬라이드로 돌아가 못 다룬 메서드를 짚어줘도 좋다.</div>
+      </section>
+    </div>
+
+    </div><!-- /stage -->
+  </div><!-- /stage-wrap -->
+
+  <div class="notes" id="notes" aria-live="polite">
+    <div class="n-h">발표자 노트</div>
+    <div id="notesBody"></div>
+  </div>
+
+  <div class="chrome">
+    <span class="deck-id">uber/fx 의존성 주입</span>
+    <div class="rail" id="rail"></div>
+    <span class="counter" id="counter"><span class="cur">01</span> / 32</span>
+    <div class="keys">
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="개요 (O)">개요</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="발표자 노트 (N)">노트</button>
+      <button class="kbtn" id="btnTheme" type="button" title="테마 전환 (T)">테마</button>
+      <button class="kbtn" id="btnHelp" type="button" title="단축키 (?)">?</button>
+    </div>
+  </div>
+
+  <div class="help" id="help">
+    <div class="help-box">
+      <h3>단축키</h3>
+      <dl>
+        <dt>→ · Space · PgDn</dt><dd>다음 슬라이드</dd>
+        <dt>← · PgUp</dt><dd>이전 슬라이드</dd>
+        <dt>Home · End</dt><dd>처음 · 마지막</dd>
+        <dt>O</dt><dd>전체 슬라이드 개요</dd>
+        <dt>N</dt><dd>발표자 노트</dd>
+        <dt>T</dt><dd>밝은 테마 / 어두운 테마</dd>
+        <dt>F</dt><dd>전체 화면</dd>
+        <dt>Esc</dt><dd>닫기</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var deck     = document.getElementById("deck");
+  var stage    = document.getElementById("stage");
+  var wrap     = document.getElementById("stageWrap");
+  var rail     = document.getElementById("rail");
+  var counter  = document.getElementById("counter");
+  var notesEl  = document.getElementById("notes");
+  var notesBody= document.getElementById("notesBody");
+  var helpEl   = document.getElementById("help");
+  var holders  = Array.prototype.slice.call(stage.querySelectorAll(".holder"));
+  var total    = holders.length;
+  var idx      = 0;
+  var overview = false;
+  var reduce   = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ── 눈금 레일 ─────────────────────────────────── */
+  var ticks = holders.map(function (h, i) {
+    var t = document.createElement("span");
+    t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
+    t.title = "슬라이드 " + (i + 1);
+    t.addEventListener("click", function () { go(i); });
+    rail.appendChild(t);
+    return t;
+  });
+
+  function pad(n) { return (n < 10 ? "0" : "") + n; }
+
+  /* ── 무대 스케일 ───────────────────────────────── */
+  /* 무대는 stage-wrap 의 좌상단에 고정(place-items:start)해 두고,
+     축소한 뒤 남는 여백만큼 직접 translate 해서 가운데로 옮긴다.
+     transform-origin 을 center 로 두고 grid 중앙 정렬에 맡기면,
+     뷰포트가 1280x720 보다 작을 때 브라우저가 넘치는 항목을
+     좌상단에 고정(safe alignment)해 버려서 축소 결과가 오른쪽 아래로 쏠린다. */
+  function fit() {
+    if (overview) { stage.style.transform = ""; return; }
+    var k = Math.min(wrap.clientWidth / 1280, wrap.clientHeight / 720);
+    var tx = (wrap.clientWidth - 1280 * k) / 2;
+    var ty = (wrap.clientHeight - 720 * k) / 2;
+    stage.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + k + ")";
+  }
+
+  /* ── 이동 ──────────────────────────────────────── */
+  function go(n, silent) {
+    n = Math.max(0, Math.min(total - 1, n));
+    idx = n;
+    holders.forEach(function (h, i) { h.classList.toggle("is-active", i === n); });
+    ticks.forEach(function (t, i) {
+      t.classList.toggle("done", i < n);
+      t.classList.toggle("now", i === n);
+    });
+    counter.innerHTML = '<span class="cur">' + pad(n + 1) + "</span> / " + total;
+    var src = holders[n].querySelector(".notes-src");
+    notesBody.textContent = src ? src.textContent.trim() : "—";
+    if (!silent) { history.replaceState(null, "", "#" + (n + 1)); }
+    runOdometers(holders[n]);
+    if (overview) {
+      holders[n].scrollIntoView({ block: "nearest", behavior: reduce ? "auto" : "smooth" });
+    }
+  }
+
+  /* ── 카디널리티 카운터 ─────────────────────────── */
+  function runOdometers(holder) {
+    var list = holder.querySelectorAll("[data-odo]");
+    Array.prototype.forEach.call(list, function (el, i) {
+      var to = parseInt(el.getAttribute("data-odo"), 10);
+      if (reduce) { el.textContent = to.toLocaleString("en-US"); return; }
+      var dur = 900, delay = i * 420, t0 = null;
+      el.textContent = "0";
+      function frame(ts) {
+        if (t0 === null) { t0 = ts; }
+        var p = (ts - t0 - delay) / dur;
+        if (p < 0) { requestAnimationFrame(frame); return; }
+        if (p > 1) { p = 1; }
+        var e = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(to * e).toLocaleString("en-US");
+        if (p < 1) { requestAnimationFrame(frame); }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
+  /* ── 개요 모드 ─────────────────────────────────── */
+  function setOverview(on) {
+    overview = on;
+    deck.classList.toggle("is-overview", on);
+    document.getElementById("btnOverview").setAttribute("aria-pressed", String(on));
+    fit();
+    if (on) { holders[idx].scrollIntoView({ block: "center" }); }
+  }
+
+  holders.forEach(function (h, i) {
+    h.addEventListener("click", function () { if (overview) { setOverview(false); go(i); } });
+  });
+
+  /* ── 노트 · 테마 · 도움말 ──────────────────────── */
+  function setNotes(on) {
+    notesEl.classList.toggle("on", on);
+    document.getElementById("btnNotes").setAttribute("aria-pressed", String(on));
+  }
+  function toggleTheme() {
+    var cur = document.documentElement.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try { localStorage.setItem("deck-theme", next); } catch (e) {}
+    drawHero();
+  }
+  try {
+    var saved = localStorage.getItem("deck-theme");
+    if (saved) { document.documentElement.setAttribute("data-theme", saved); }
+  } catch (e) {}
+
+  document.getElementById("btnOverview").addEventListener("click", function () { setOverview(!overview); });
+  document.getElementById("btnNotes").addEventListener("click", function () { setNotes(!notesEl.classList.contains("on")); });
+  document.getElementById("btnTheme").addEventListener("click", toggleTheme);
+  document.getElementById("btnHelp").addEventListener("click", function () { helpEl.classList.toggle("on"); });
+  helpEl.addEventListener("click", function () { helpEl.classList.remove("on"); });
+
+  /* ── 클릭 리빌 · 이미지 토글 ───────────────────── */
+  document.addEventListener("click", function (e) {
+    var qb = e.target.closest ? e.target.closest(".q-btn") : null;
+    if (qb) { qb.parentNode.classList.toggle("is-open"); return; }
+
+    var tg = e.target.closest ? e.target.closest(".tg") : null;
+    if (tg) {
+      var group = tg.getAttribute("data-swap");
+      var target = tg.getAttribute("data-target");
+      Array.prototype.forEach.call(document.querySelectorAll('.tg[data-swap="' + group + '"]'), function (b) {
+        b.setAttribute("aria-pressed", String(b === tg));
+      });
+      Array.prototype.forEach.call(document.querySelectorAll('[data-swap-group="' + group + '"] > .swap-i'), function (item) {
+        item.classList.toggle("on", item.getAttribute("data-swap-item") === target);
+      });
+    }
+  });
+
+  /* ── 키보드 ────────────────────────────────────── */
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) { return; }
+    var k = e.key;
+    if (k === "ArrowRight" || k === "PageDown" || k === " " || k === "Spacebar") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowLeft" || k === "PageUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "ArrowDown") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "Home") { e.preventDefault(); go(0); }
+    else if (k === "End") { e.preventDefault(); go(total - 1); }
+    else if (k === "o" || k === "O" || k === "ㅐ") { setOverview(!overview); }
+    else if (k === "n" || k === "N" || k === "ㅜ") { setNotes(!notesEl.classList.contains("on")); }
+    else if (k === "t" || k === "T" || k === "ㅅ") { toggleTheme(); }
+    else if (k === "f" || k === "F" || k === "ㄹ") {
+      if (document.fullscreenElement) { document.exitFullscreen(); }
+      else if (document.documentElement.requestFullscreen) { document.documentElement.requestFullscreen(); }
+    }
+    else if (k === "?" || k === "/") { helpEl.classList.toggle("on"); }
+    else if (k === "Escape") {
+      if (helpEl.classList.contains("on")) { helpEl.classList.remove("on"); }
+      else if (overview) { setOverview(false); }
+    }
+  });
+
+  /* ── 표지 스파크라인 ───────────────────────────── */
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  function drawHero() {
+    var cv = document.getElementById("heroCanvas");
+    if (!cv) { return; }
+    var ctx = cv.getContext("2d");
+    var W = cv.width, H = cv.height;
+    ctx.clearRect(0, 0, W, H);
+
+    var accent = css("--accent") || "#3FC7EF";
+    var line   = css("--line") || "#272F3A";
+    var faint  = css("--ink-faint") || "#6B7688";
+
+    /* 격자 */
+    ctx.strokeStyle = line;
+    ctx.lineWidth = 1;
+    var i, y, x;
+    for (i = 1; i <= 4; i++) {
+      y = Math.round((H / 5) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    for (i = 1; i <= 5; i++) {
+      x = Math.round((W / 6) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+    }
+
+    /* 결정적인 CPU 곡선 (난수 없이 재현 가능하게) */
+    var N = 180, pts = [];
+    for (i = 0; i < N; i++) {
+      var t = i / (N - 1);
+      var v = 0.42
+        + 0.16 * Math.sin(t * 8.1 + 0.6)
+        + 0.09 * Math.sin(t * 21.3 + 1.9)
+        + 0.05 * Math.sin(t * 47.7 + 4.2)
+        + 0.10 * Math.exp(-Math.pow((t - 0.68) * 9, 2));
+      v = Math.max(0.08, Math.min(0.92, v));
+      pts.push([6 + t * (W - 12), H - v * H]);
+    }
+
+    var steps = reduce ? N : 0;
+    function render(n) {
+      ctx.clearRect(0, 0, W, H);
+      ctx.strokeStyle = line;
+      for (i = 1; i <= 4; i++) {
+        y = Math.round((H / 5) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+      }
+      for (i = 1; i <= 5; i++) {
+        x = Math.round((W / 6) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+      }
+
+      var m = Math.max(2, n);
+      var grad = ctx.createLinearGradient(0, 0, 0, H);
+      grad.addColorStop(0, accent + "55");
+      grad.addColorStop(1, accent + "00");
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], H);
+      for (i = 0; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.lineTo(pts[m - 1][0], H);
+      ctx.closePath();
+      ctx.fillStyle = grad;
+      ctx.fill();
+
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (i = 1; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.strokeStyle = accent;
+      ctx.lineWidth = 2.4;
+      ctx.lineJoin = "round";
+      ctx.stroke();
+
+      /* 마지막 점 강조 */
+      ctx.beginPath();
+      ctx.arc(pts[m - 1][0], pts[m - 1][1], 4.5, 0, Math.PI * 2);
+      ctx.fillStyle = accent;
+      ctx.fill();
+
+      ctx.font = "500 20px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = faint;
+      ctx.textAlign = "left";
+      ctx.fillText("100%", 8, 22);
+      ctx.fillText("0", 8, H - 8);
+    }
+
+    if (reduce) { render(N); return; }
+    var n0 = 2, t0 = null;
+    function frame(ts) {
+      if (t0 === null) { t0 = ts; }
+      var p = Math.min(1, (ts - t0) / 1100);
+      var e = 1 - Math.pow(1 - p, 3);
+      render(Math.max(n0, Math.round(N * e)));
+      if (p < 1) { requestAnimationFrame(frame); }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  /* ── 초기화 ────────────────────────────────────── */
+  window.addEventListener("resize", fit);
+  window.addEventListener("hashchange", function () {
+    var n = parseInt(location.hash.replace("#", ""), 10);
+    if (!isNaN(n)) { go(n - 1, true); }
+  });
+
+  var start = parseInt(location.hash.replace("#", ""), 10);
+  fit();
+  go(isNaN(start) ? 0 : start - 1, true);
+  drawHero();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

`contents/go/go-fx-의존성-주입/`에 발표용 슬라이드 32장을 추가하고, 들어가며 섹션 끝에 `<!-- slides -->` 마커를 넣었다.

공개 주소: `/go-fx-의존성-주입/slides/`

## 구성

글의 4개 장을 발표 흐름에 맞게 재구성했다.

| 장 | 슬라이드 | 내용 |
|---|---|---|
| — | 01–04 | 표지 · 문제 제기(수동 조립) · fx의 해법 · 목차 |
| 01 | 05–15 | fx 기초 — 메서드 지도 ①② · `fx.Option` 구조 · Provide/Invoke/Supply · 실전 적용 · 의존성 그래프 · Lifecycle 2단계 |
| 02 | 16–22 | 확장 패턴 — Module · Decorate · name: · group: · 비교 · Private |
| 03 | 23–26 | 테스트 — fxtest · Replace+As · Populate vs Invoke |
| 04 | 27–32 | 정리 — 선택 가이드 · 트레이드오프 · 퀴즈 ①② · 마무리 |

퀴즈는 글의 Q1~Q10을 그대로 옮기고 각 답에 해당 슬라이드 번호를 참조로 달았다. 발표자 노트는 32장 전부에 작성했다.

## 참고 슬라이드와의 관계

`contents/cloud/grafana-완벽-가이드-1-.../slides.html`의 CSS(770줄)와 JS 엔진(277줄)을 **그대로 재사용**했다. 덕분에 이전 PR에서 고친 무대 정렬 버그(`transform-origin: 0 0` + 직접 translate)도 그대로 따라왔다.

주제에 맞게 바꾼 것은 액센트 색뿐이다 — Grafana 오렌지(`#C24A12` / `#FF7A45`) → Go 시안(`#0A6E8A` / `#3FC7EF`). 라이트/다크 4개 블록과 `drawHero()`의 폴백 값까지 함께 교체했다.

표지 패널은 캔버스 스파크라인 대신 fx가 자동 구성하는 의존성 트리를 넣었다. `drawHero()`가 `if (!cv) return;`으로 가드하고 있어 캔버스를 빼도 안전하다.

## Test plan

- [x] `npm run build` 성공 — 슬라이드 2개 복사, 테마 동기화 스크립트 주입 확인
- [x] `out/go-fx-의존성-주입/slides/index.html` 생성, `/go-fx-의존성-주입/slides/` 200
- [x] 글 페이지 임베드가 `1. 들어가며`와 `2. fx 기초` 사이에 위치, `<p>` 중첩 없음
- [x] 32장 전부 본문 넘침 없음 — `scrollHeight > clientHeight` 로 프로그램 검사
- [x] 개요 모드(썸네일 32장) 정상, 슬라이드 번호 01~32 연속, 카운터 총 장수 일치
- [x] 퀴즈 참조 번호가 실제 슬라이드와 일치
- [x] 잔존 grafana 문구 0건

## 작업 중 고친 것

- **표지 트리가 줄바꿈을 잃던 문제** — `.tree`는 각 줄을 `<span class="lv">`로 감싸야 `white-space: pre`가 걸린다. raw 텍스트로 넣었더니 한 줄로 흘렀다
- **메서드 지도 표가 잘리던 문제** — 13행은 한 장에 안 들어가 `fx.Private` 이하 4행이 화면 밖으로 나갔다. 기초 5행 / 확장·테스트 8행 두 장으로 나누고, 뒤 슬라이드 번호와 퀴즈 참조를 일괄 갱신했다

🤖 Generated with [Claude Code](https://claude.com/claude-code)