### PR TITLE
fix: 영문 페이지에서 홈 메뉴가 항상 활성으로 표시되던 문제

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -27,9 +27,25 @@ const NAV = [
 
 const FOCUS_RING = 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bento-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bento-bg';
 
-function isActive(pathname: string, href: string): boolean {
-  if (href === '/') return pathname === '/';
-  return pathname === href || pathname.startsWith(href + '/');
+/** 끝 슬래시를 떼어 경로를 비교 가능한 형태로 맞춘다.
+ *  next.config.js 의 trailingSlash: true 때문에 pathname 과 href 의
+ *  끝 슬래시 유무가 어긋날 수 있다. */
+function normalizePath(p: string): string {
+  return p !== '/' && p.endsWith('/') ? p.slice(0, -1) : p;
+}
+
+/**
+ * 현재 경로가 이 메뉴 항목에 속하는가.
+ *
+ * exact 는 홈 전용이다. 홈 주소는 다른 모든 경로의 접두사라서
+ * (한국어 `/`, 영문 `/en`) 접두사 규칙을 그대로 적용하면 어느 페이지에서나
+ * 홈이 활성으로 켜진다.
+ */
+function isActive(pathname: string, href: string, exact = false): boolean {
+  const p = normalizePath(pathname);
+  const h = normalizePath(href);
+  if (exact) return p === h;
+  return p === h || p.startsWith(h + '/');
 }
 
 export function SiteHeader() {
@@ -81,7 +97,7 @@ export function SiteHeader() {
           >
             {NAV.map((n) => {
               const href = localizeHref(n.href, lang);
-              const active = isActive(pathname, href);
+              const active = isActive(pathname, href, n.key === 'home');
               return (
                 <Link
                   key={n.key}
@@ -212,7 +228,7 @@ export function SiteHeader() {
                 <nav aria-label="모바일 메뉴" className="mt-6 flex flex-col gap-1">
                   {NAV.map((n) => {
                     const href = localizeHref(n.href, lang);
-                    const active = isActive(pathname, href);
+                    const active = isActive(pathname, href, n.key === 'home');
                     return (
                       <Link
                         key={n.key}


### PR DESCRIPTION
## 배경

모든 `/en/*` 페이지에서 헤더의 `Home` 메뉴가 활성 상태로 표시됐다. 실제로 보고 있는 페이지(예: `Slides`)와 `Home`이 **동시에** 켜져 있었다.

원인은 `components/site-header.tsx` 의 `isActive` 다.

```ts
function isActive(pathname: string, href: string): boolean {
  if (href === '/') return pathname === '/';
  return pathname === href || pathname.startsWith(href + '/');
}
```

홈 주소는 다른 모든 경로의 **접두사**라서 접두사 규칙을 그대로 적용하면 어느 페이지에서나 켜진다. 그래서 한국어 홈(`/`)은 예외 처리가 되어 있었는데, **영문 홈은 `/en` 이라 그 예외에 걸리지 않았다.** `isActive('/en/slides', '/en')` → `'/en/slides'.startsWith('/en/')` → `true`.

이번 슬라이드 갤러리 작업 중 발견했고, 그 작업과는 무관한 기존 버그다.

## 변경 사항

`isActive` 에 `exact` 인자를 추가하고 홈 항목(`n.key === 'home'`)에만 적용한다. 호출부는 데스크톱 pill nav와 모바일 메뉴 두 곳.

**끝 슬래시 정규화를 함께 넣었다.** `next.config.js` 에 `trailingSlash: true` 가 있어 런타임 `pathname` 은 끝 슬래시를 포함한다(실측: `/en/`, `/en/slides/`). 정규화 없이 `pathname === href` 로 정확 비교하면 `/en/` !== `/en` 이 되어 **영문 홈에서 홈이 반대로 안 켜지는 새 버그**가 생긴다.

## 테스트 계획

- [x] `npm run check` exit 0, `npm run build` 성공
- [x] **프리렌더 HTML** — `/`, `/posts/`, `/slides/`, `/series/`, `/tags/`, `/en/`, `/en/posts/`, `/en/slides/`, `/en/series/`, `/en/tags/` 각각에서 헤더 네비의 활성 항목이 정확히 자기 자신 하나
- [x] **하이드레이션 후 실제 브라우저** — 같은 오리진 iframe으로 5개 경로를 띄워 확인. `pathname` 이 끝 슬래시를 포함하는 것도 여기서 확인했다
- [x] 글 페이지(ko/en)에서는 네비 활성 항목 없음
- [x] 데스크톱 pill nav와 모바일 메뉴 양쪽 모두 반영
- [ ] 배포 후 실제 도메인에서 `/en/*` 이동하며 확인

### 수정 전후

| 경로 | 이전 | 이후 |
|---|---|---|
| `/en/slides/` | `/en/` + `/en/slides/` | `/en/slides/` |
| `/en/` | `/en/` | `/en/` (변화 없음) |
| `/slides/` | `/slides/` | `/slides/` (변화 없음) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)