### PR TITLE
feat: generate-slides 스킬에 영문 데크 모드 추가하고 go-fx 에 적용

### DIFF
--- a/.claude/skills/generate-slides/SKILL.md
+++ b/.claude/skills/generate-slides/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generate-slides
-description: Use when creating a presentation slide deck for a blog article (contents/{category}/{slug}/slides.html) and embedding it into the article
+description: Use when creating a presentation slide deck for a blog article (contents/{category}/{slug}/slides.html), translating an existing deck into English (slides_en.html), and embedding it into the article
 ---
 
 # Generate Presentation Slides (slides.html)
@@ -16,12 +16,14 @@ description: Use when creating a presentation slide deck for a blog article (con
 ## When to Use
 
 - 특정 글의 발표 자료를 만들 때 (`contents/{category}/{slug}/` → 같은 폴더 `slides.html`)
-- 이미 `slides.html`이 있으면 덮어쓰기 전에 사용자에게 확인
+- 기존 데크의 **영문판**을 만들 때 (`slides.html` → 같은 폴더 `slides_en.html`) — 아래 "영문 데크" 절로 간다
+- 이미 대상 파일이 있으면 덮어쓰기 전에 사용자에게 확인
 
 ## 대상 지정
 
 - **단일 글**: slug(`go/go-fx-의존성-주입`) 또는 `index.md` 경로
 - 한 번에 **한 글만** 처리한다. 슬라이드는 글 내용을 재구성하는 작업이라 배치로 돌리면 품질이 급격히 떨어진다.
+- **언어**: 지정이 없으면 한국어 데크로 본다. 영문판은 한국어 데크가 **이미 있을 때만** 만든다 — 글에서 새로 설계하지 않는다.
 
 ## Procedure
 
@@ -117,7 +119,7 @@ print('퀴즈 참조:',sorted(set(re.findall(r'슬라이드 [0-9][0-9 ·]*',s)))
 섹션 이름은 글마다 다르므로(`들어가며`·`개요`·`시작하며`) **이름이 아니라 위치**로 찾는다. 첫 섹션에 넣는 이유는 마무리에 두면 끝까지 읽은 사람만 보게 되기 때문이다.
 
 - 이미 마커가 있으면 **건너뛰고 보고**한다
-- **`index_en.md`는 건드리지 않는다** — 영문 슬라이드(`slides_en.html`)가 없으면 존재하지 않는 경로를 가리키는 깨진 임베드가 된다
+- **`index_en.md`는 건드리지 않는다** — 영문 슬라이드(`slides_en.html`)가 없으면 존재하지 않는 경로를 가리키는 깨진 임베드가 된다. 영문 데크를 만들었다면 "영문 데크" 절의 5번에서 넣는다
 - 사용자가 위치를 지정하거나 넣지 말라고 하면 그에 따른다
 
 ### 7. 검증한다
@@ -158,6 +160,93 @@ npx serve@latest out -l 3100 &
 
 데크를 만들면 `/slides` 목록 페이지에 자동으로 올라간다. 별도 등록 작업은 없다. 빌드 후 `out/slides/index.html`에 카드가 하나 늘었는지 함께 확인하면 좋다.
 
+## 영문 데크 (slides_en.html)
+
+한국어 데크가 이미 있는 글에 영문판을 붙인다. **새로 설계하지 않는다** — 구조·장수·번호·액센트를 그대로 두고 **텍스트만 번역**한다. 그래야 두 데크가 같은 발표로 남고, 나중에 한쪽을 고칠 때 다른 쪽을 찾아가기 쉽다.
+
+번역 규칙은 `translate-article-en` 스킬을 따른다: **코드의 로직·식별자는 한 글자도 바꾸지 않고, 코드 안의 한글 주석·문자열만 영어로.**
+
+### 1. 세 조각으로 자른다
+
+엔진을 손으로 다시 옮기면 반드시 어긋난다. 스크립트로 자르고 본문만 새로 쓴 뒤 도로 붙인다.
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+src = Path('contents/{category}/{slug}/slides.html').read_text(encoding='utf-8')
+lines = src.split('\n')
+i = next(n for n, l in enumerate(lines) if 'id="stage"' in l) + 1   # head 끝
+j = next(n for n, l in enumerate(lines) if '/stage -->' in l)       # tail 시작
+Path('/tmp/head.html').write_text('\n'.join(lines[:i]), encoding='utf-8')
+Path('/tmp/tail.html').write_text('\n'.join(lines[j:]), encoding='utf-8')
+print('본문 범위', i + 1, '~', j)
+PY
+```
+
+head(`<!doctype>`+CSS)와 tail(chrome+help+JS)은 **바이트 그대로 재사용**하고, 정해진 문자열만 치환한다.
+
+### 2. 본문을 번역해 새로 쓴다
+
+잘라낸 본문 범위를 영어로 다시 쓴다. `data-n`·`class`·`data-chapter`·코드 하이라이팅 `<span>`은 전부 그대로 두고 텍스트 노드만 바꾼다.
+
+`eyebrow`·`stamp`처럼 짧은 라벨은 소문자 한 단어로 옮기면(`문제`→`problem`, `확장`→`scaling`) 원본의 밀도가 유지된다. **발표자 노트(`notes-src`)도 빠짐없이 번역한다** — 노트가 한국어로 남으면 영문 발표에 쓸 수 없다.
+
+### 3. head · tail의 정해진 자리를 치환한다
+
+| 조각 | 바꿀 것 |
+|---|---|
+| head | `<html lang="ko">` → `lang="en"` · `<title>` |
+| tail | `deck-id` · `발표자 노트` → `Speaker notes` · 버튼 4개(`개요`/`노트`/`테마`/`?`)와 각 `title` 속성 · `단축키` 도움말 `<h3>`과 `<dd>` 8개 |
+| tail(JS) | `t.title = "슬라이드 "` → `"Slide "` |
+
+치환은 **건수를 검증하며** 하는 게 안전하다. 각 문자열이 정확히 1건 매칭되지 않으면 중단시킨다.
+
+**엔진의 CSS/JS 주석은 한국어로 그대로 둔다.** 화면에 안 보이고, 엔진을 원본과 동일하게 유지해야 나중에 엔진을 고칠 때 diff가 깨끗하다.
+
+액센트 색은 **바꾸지 않는다.** 같은 글의 두 데크는 같은 색을 쓴다.
+
+### 4. 합치고 검증한다
+
+```bash
+cat /tmp/head.html body_en.html /tmp/tail.html > "contents/{category}/{slug}/slides_en.html"
+file -I "contents/{category}/{slug}/slides_en.html"   # charset=utf-8 확인
+```
+
+5번(번호 맞추기)을 **영문 데크에도 그대로** 돌린다. 장 수·카운터가 한국어 데크와 같아야 하고, 퀴즈 참조는 `→ 슬라이드 NN`이 아니라 `→ Slide NN`이 된다.
+
+그리고 화면에 노출되는 한글이 남았는지 훑는다 — 주석 밖에 한글이 있으면 번역을 빠뜨린 것이다.
+
+```bash
+python3 -c "
+import re
+for i, l in enumerate(open('contents/{category}/{slug}/slides_en.html',encoding='utf-8'), 1):
+    s = l.strip()
+    if re.search(r'[가-힣]', l) and not s.startswith(('/*','*','//','<!--')):
+        print(i, s[:100])
+"
+```
+
+### 5. 마커를 `index_en.md`에 넣는다
+
+**영문 데크를 만든 뒤에만** 넣는다. 위치는 한국어와 같은 규칙 — 첫 번째 `#` 섹션 끝, 두 번째 `#` 헤딩 바로 앞.
+
+### 6. 넘침을 다시 검사한다
+
+**영문은 같은 내용이라도 한국어보다 길어져 넘치기 쉽다.** 한국어 데크가 멀쩡했다는 건 아무 보장도 아니므로, 7번의 넘침 검사 스크립트를 `/en/{slug}/slides/`에 대해 **반드시 다시 돌린다.**
+
+표가 많은 장(9행 이상)과 퀴즈 장이 가장 위험하다. 넘치면 문장을 줄이는 쪽을 먼저 시도하고, 그래도 넘치면 장을 나눈 뒤 **양쪽 데크의 번호를 함께** 맞춘다.
+
+하단 크롬도 함께 본다. 버튼 라벨이 영어로 길어지므로 `.chrome`·`.keys`의 가로 넘침과 `deck-id` 잘림을 확인한다. `deck-id`는 대문자 변환·nowrap이라 길면 레일을 밀어낸다 — 짧게 잡는다(예: `uber/fx · Go DI`).
+
+```js
+() => {
+  const c = document.querySelector('.chrome'), id = document.querySelector('.deck-id');
+  return { chromeOverflowX: c.scrollWidth - c.clientWidth, deckIdClipped: id.scrollWidth > id.clientWidth };
+}
+```
+
+마지막으로 `/en/slides` 목록에 카드가 늘었는지, 영문 글의 임베드 `src`가 `/en/...`을 가리키는지 확인한다.
+
 ## 슬라이드 작성 원칙
 
 - **한 장에 한 가지 주장.** 제목이 곧 그 주장이 되게 쓴다 ("fx.Provide 설명" ❌ → "Provide는 등록만 한다 — 실행은 미룬다" ✅)
@@ -171,18 +260,23 @@ npx serve@latest out -l 3100 &
 - ❌ 표에 10행 넘게 넣음 → ✅ 본문에 표만 있으면 9행, 콜아웃과 함께면 5~6행. 넘치면 두 장으로
 - ❌ 슬라이드를 나눈 뒤 뒤 번호를 안 고침 → ✅ `data-n`·카운터·퀴즈 참조를 모두 갱신 (특히 `슬라이드 08 · 09`의 뒤 숫자)
 - ❌ 액센트를 CSS만 바꾸고 JS 폴백을 빠뜨림 → ✅ `grep -c` 로 템플릿 기본색이 0인지 확인
-- ❌ `index_en.md`에도 마커를 넣음 → ✅ 영문 슬라이드가 없으면 넣지 않는다
+- ❌ 영문 데크 없이 `index_en.md`에 마커를 넣음 → ✅ `slides_en.html`을 먼저 만든다
+- ❌ 영문 데크를 글(`index_en.md`)에서 새로 설계함 → ✅ 한국어 데크를 번역한다. 구조가 갈리면 두 데크가 다른 발표가 된다
+- ❌ 영문 데크에서 넘침 검사를 생략함 → ✅ 영어가 길어 새로 넘치는 장이 생긴다. 한국어가 멀쩡했던 건 보장이 아니다
+- ❌ 엔진의 한국어 CSS/JS 주석까지 번역함 → ✅ 그대로 둔다. 엔진은 두 데크가 동일해야 한다
 - ❌ 코드 안의 `<`·`&`를 그대로 씀 → ✅ `&lt;`·`&amp;`로 이스케이프. `[]Notifier`, `&Config{}` 같은 코드에서 자주 걸린다
 - ❌ 넘침 검사를 생략하고 눈으로만 확인 → ✅ 잘린 슬라이드는 개요 모드에서도 멀쩡해 보인다. 반드시 스크립트로 검사
 - ❌ 엔진(CSS/JS)을 손봄 → ✅ 템플릿에서 그대로 가져온다. 무대 정렬·테마 동기화 등이 이미 맞춰져 있다
 
 ## 엔진을 고쳐야 할 때
 
-CSS나 JS 자체를 고쳐야 하는 상황이면 **템플릿과 기존 슬라이드를 모두** 갱신해야 한다. 현재 엔진 복사본이 있는 곳:
+CSS나 JS 자체를 고쳐야 하는 상황이면 **템플릿과 기존 슬라이드를 모두** 갱신해야 한다. 정본은 `.claude/skills/generate-slides/assets/deck-template.html`이고, 나머지 복사본은 이걸로 찾는다:
 
-- `.claude/skills/generate-slides/assets/deck-template.html` (정본)
-- `contents/cloud/grafana-완벽-가이드-1-prometheus와-grafana-기초/slides.html`
-- `contents/go/go-fx-의존성-주입/slides.html`
+```bash
+find .claude/skills/generate-slides/assets contents -name "slides.html" -o -name "slides_en.html" -o -name "deck-template.html"
+```
+
+**영문 데크는 복사본을 두 배로 늘린다.** 이미 정본 1 + 데크 8벌이라 아래 임계를 넘겼다.
 
 복사본이 5벌을 넘어가면 `copy-assets.ts`가 빌드 시 엔진을 주입하는 구조로 바꾸는 걸 검토한다(테마 동기화 스크립트를 주입하는 것과 같은 방식). 다만 그렇게 하면 슬라이드 원본이 자기완결형이 아니게 되므로, 그 트레이드오프를 사용자와 상의할 것.
 
@@ -191,3 +285,5 @@ CSS나 JS 자체를 고쳐야 하는 상황이면 **템플릿과 기존 슬라�
 - 슬라이드 임베드 규약: `CLAUDE.md`의 "슬라이드 데크" 절
 - 설계 배경: `docs/superpowers/specs/2026-07-26-slides-embed-design.md`, `2026-07-26-slides-theme-sync-design.md`
 - 실제 사례: `contents/go/go-fx-의존성-주입/slides.html` (32장), `contents/cloud/grafana-완벽-가이드-1-.../slides.html` (38장)
+- 영문 데크 실제 사례: `contents/go/go-fx-의존성-주입/slides_en.html` (한국어판과 32장 동일)
+- 번역 규칙 원본: `translate-article-en` 스킬

--- a/contents/go/go-fx-의존성-주입/index_en.md
+++ b/contents/go/go-fx-의존성-주입/index_en.md
@@ -29,6 +29,8 @@ The scope of this article is as follows.
 - Module encapsulation: `fx.Private`
 - Testing strategies: `fxtest.New`, `fx.Replace`, `fx.Populate`
 
+<!-- slides -->
+
 # 2. fx Basics
 
 ## 2.1 Why DI Is Needed in Go

--- a/contents/go/go-fx-의존성-주입/slides_en.html
+++ b/contents/go/go-fx-의존성-주입/slides_en.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="ko">
+<html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>uber/fx로 시작하는 Go 의존성 주입</title>
+<title>Go Dependency Injection with uber/fx</title>
 <style>
 /* ─────────────────────────────────────────────────────────────
    계기판(instrument panel) — 차가운 슬레이트 바탕 위 따뜻한 표시등
@@ -780,14 +780,14 @@ code.inl {
   <div class="stage-wrap" id="stageWrap">
     <div class="stage" id="stage">
 
-    <!-- ═══════════ 01 표지 ═══════════ -->
+    <!-- ═══════════ 01 Cover ═══════════ -->
     <div class="holder" data-n="01">
       <section class="slide" data-kind="cover">
         <div class="cover">
           <div>
             <div class="eyebrow">Go · Dependency Injection</div>
-            <h1 class="cover-title">uber/fx로 시작하는<br />Go 의존성 주입</h1>
-            <p class="cover-sub">생성자를 등록하면 조립은 fx가 한다<br />— 타입으로 그래프를 만들고, 수명주기까지 관리하기</p>
+            <h1 class="cover-title">Go Dependency Injection<br />with uber/fx</h1>
+            <p class="cover-sub">Register the constructors — fx does the wiring<br />— building the graph from types, lifecycle included</p>
             <div class="cover-meta">
               <span class="chip on">fx.Provide</span>
               <span class="chip">fx.Invoke</span>
@@ -797,7 +797,7 @@ code.inl {
           </div>
           <div class="panel">
             <div class="panel-head">
-              <span><span class="dot"></span>fx가 자동으로 만드는 그래프</span>
+              <span><span class="dot"></span>The graph fx builds for you</span>
               <span>types only</span>
             </div>
             <div class="panel-body" style="display:block;padding:22px 20px;">
@@ -813,29 +813,29 @@ code.inl {
               </div>
             </div>
             <div class="panel-foot">
-              <span>등록 순서는 상관없다. fx는 매개변수·반환 타입만 본다.</span>
+              <span>Registration order is irrelevant. fx reads only parameter and return types.</span>
             </div>
           </div>
         </div>
-        <div class="notes-src">인사. 오늘은 uber/fx 한 바퀴. 오른쪽 트리가 fx가 자동으로 만들어주는 것이고, 우리는 생성자만 등록한다는 점을 먼저 각인시키고 시작한다.</div>
+        <div class="notes-src">Greeting. A full tour of uber/fx today. Point at the tree on the right — that is what fx builds on its own; all we do is register constructors. Land that framing before anything else.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 02 문제 제기 ═══════════ -->
+    <!-- ═══════════ 02 The problem ═══════════ -->
     <div class="holder" data-n="02">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">문제</span><span class="stamp">why DI</span></div>
-        <h2 class="slide-title"><code class="inl">main()</code>이 조립 설명서가 되어간다</h2>
+        <div class="slide-head"><span class="eyebrow">problem</span><span class="stamp">why DI</span></div>
+        <h2 class="slide-title"><code class="inl">main()</code> is turning into an assembly manual</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2a">
             <ul class="bul">
-              <li>생성자를 <b>순서대로</b> 직접 호출해야 한다</li>
-              <li>매개변수 순서를 손으로 맞춘다</li>
-              <li>새 서비스를 추가할 때마다 <code class="inl">main()</code>을 고친다</li>
-              <li>의존성이 늘수록 이 코드는 <b>급격히</b> 복잡해진다</li>
+              <li>You call every constructor <b>in order</b>, by hand</li>
+              <li>You line up parameter order yourself</li>
+              <li>Every new service means editing <code class="inl">main()</code></li>
+              <li>More dependencies, and this grows <b>fast</b></li>
             </ul>
-            <pre class="code sm"><span class="t-cm">// 수동 DI: main()에서 직접 조립</span>
+            <pre class="code sm"><span class="t-cm">// Manual DI: wiring by hand in main()</span>
 cfg, _ := config.<span class="t-fn">New</span>()
 db, _  := database.<span class="t-fn">New</span>(cfg)
 
@@ -851,25 +851,25 @@ article.<span class="t-fn">NewArticleHandler</span>(e, usecase)
 e.<span class="t-fn">Start</span>(cfg.Server.Address)</pre>
           </div>
           <div class="callout">
-            <span class="lbl">여기서 진짜 비용</span>
-            조립 <b>순서</b>라는 지식이 코드 여기저기에 흩어진다. 그 지식은 사실 <b>타입 안에 이미 들어 있다</b>.
+            <span class="lbl">the real cost</span>
+            Knowledge of the assembly <b>order</b> gets scattered across the code. That knowledge is <b>already inside the types</b>.
           </div>
         </div>
-        <div class="notes-src">"이 코드 익숙하시죠?"로 공감대부터. 순서를 틀리면 컴파일 에러가 나긴 하지만, 진짜 문제는 조립 지식이 main에 눌러앉는다는 점이라는 걸 짚는다.</div>
+        <div class="notes-src">Open with "you know this code, right?" to build rapport. Getting the order wrong is a compile error, sure — but the real problem is that assembly knowledge takes up permanent residence in main.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 03 fx의 해법 ═══════════ -->
+    <!-- ═══════════ 03 The fx answer ═══════════ -->
     <div class="holder" data-n="03">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">해법</span><span class="stamp">uber/fx</span></div>
-        <h2 class="slide-title">fx는 <b>타입</b>만 보고 순서를 정한다</h2>
+        <div class="slide-head"><span class="eyebrow">solution</span><span class="stamp">uber/fx</span></div>
+        <h2 class="slide-title">fx decides the order from <b>types</b> alone</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2">
             <div class="card">
-              <div class="card-t">우리가 하는 일</div>
-              <p>생성자 함수를 <b>등록</b>만 한다. 순서는 신경 쓰지 않는다.</p>
+              <div class="card-t">What we do</div>
+              <p>Just <b>register</b> constructor functions. Order is not our concern.</p>
               <pre class="code xs">fx.<span class="t-fn">Provide</span>(
     config.New,
     database.New,
@@ -877,43 +877,43 @@ e.<span class="t-fn">Start</span>(cfg.Server.Address)</pre>
 )</pre>
             </div>
             <div class="card">
-              <div class="card-t">fx가 하는 일</div>
-              <p>각 생성자의 <b>매개변수 타입</b>과 <b>반환 타입</b>을 읽어 그래프를 구성하고, 올바른 순서로 호출한다.</p>
+              <div class="card-t">What fx does</div>
+              <p>Reads each constructor's <b>parameter types</b> and <b>return types</b>, builds the graph, and calls them in the right order.</p>
               <pre class="code xs"><span class="t-fn">New</span>(cfg *config.Config) (*sql.DB, error)
-     <span class="t-cm">↑ 필요</span>            <span class="t-cm">↑ 제공</span></pre>
+     <span class="t-cm">↑ needs</span>            <span class="t-cm">↑ provides</span></pre>
             </div>
           </div>
           <div class="callout teal">
-            <span class="lbl">한 줄 요약</span>
-            <code class="inl">database.New</code>가 <code class="inl">*config.Config</code>를 요구하므로, 그 타입을 반환하는 <code class="inl">config.New</code>가 <b>먼저</b> 호출된다. 순환 의존성은 앱 시작 시점에 에러로 알려준다.
+            <span class="lbl">in one line</span>
+            <code class="inl">database.New</code> requires <code class="inl">*config.Config</code>, so <code class="inl">config.New</code> — which returns that type — runs <b>first</b>. Dependency cycles are reported as an error at startup.
           </div>
           <pre class="code plain sm">go get go.uber.org/fx</pre>
         </div>
-        <div class="notes-src">"리플렉션으로 타입을 본다"는 게 핵심. 컴파일 타임 안전성을 일부 내주는 대신 조립 지식을 타입에 위임하는 거래라는 프레임으로 설명하면 뒤의 트레이드오프 이야기(30번)와 연결된다.</div>
+        <div class="notes-src">"It reads types through reflection" is the core idea. Frame it as a trade — you give up some compile-time safety and hand assembly knowledge to the types. That framing pays off on slide 29.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 04 목차 ═══════════ -->
+    <!-- ═══════════ 04 Agenda ═══════════ -->
     <div class="holder" data-n="04">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">목차</span><span class="stamp">agenda</span></div>
-        <h2 class="slide-title">오늘 다루는 것</h2>
+        <div class="slide-head"><span class="eyebrow">agenda</span><span class="stamp">agenda</span></div>
+        <h2 class="slide-title">What we cover today</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="tbl-wrap">
             <table class="tbl">
-              <thead><tr><th>장</th><th>내용</th><th>핵심 메서드</th></tr></thead>
+              <thead><tr><th>Ch</th><th>Topic</th><th>Key methods</th></tr></thead>
               <tbody>
-                <tr class="on"><td>01</td><td>fx 기초 — 등록·실행·수명주기</td><td><code class="inl">Provide</code> <code class="inl">Invoke</code> <code class="inl">Supply</code> <code class="inl">Lifecycle</code></td></tr>
-                <tr><td>02</td><td>확장 패턴 — 커진 앱을 정리하는 도구들</td><td><code class="inl">Module</code> <code class="inl">Decorate</code> <code class="inl">Annotate</code> <code class="inl">Private</code></td></tr>
-                <tr><td>03</td><td>테스트 전략</td><td><code class="inl">fxtest</code> <code class="inl">Replace</code> <code class="inl">Populate</code></td></tr>
-                <tr><td>04</td><td>정리 — 언제 쓰고 언제 안 쓰나</td><td class="faint">선택 가이드</td></tr>
+                <tr class="on"><td>01</td><td>fx basics — register, run, lifecycle</td><td><code class="inl">Provide</code> <code class="inl">Invoke</code> <code class="inl">Supply</code> <code class="inl">Lifecycle</code></td></tr>
+                <tr><td>02</td><td>Scaling patterns — tools for a growing app</td><td><code class="inl">Module</code> <code class="inl">Decorate</code> <code class="inl">Annotate</code> <code class="inl">Private</code></td></tr>
+                <tr><td>03</td><td>Testing strategy</td><td><code class="inl">fxtest</code> <code class="inl">Replace</code> <code class="inl">Populate</code></td></tr>
+                <tr><td>04</td><td>Wrap-up — when to use it, when not to</td><td class="faint">decision guide</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="dim" style="margin:0;font-size:17px;">fx는 메서드가 많아 헷갈리기 쉽다. 다음 슬라이드의 <b>지도</b>를 먼저 펼쳐두고, 각 장에서 하나씩 실전 예제로 채워 나간다.</p>
+          <p class="dim" style="margin:0;font-size:17px;">fx has a lot of methods and they blur together. We open the <b>map</b> on the next slide first, then fill it in chapter by chapter with real examples.</p>
         </div>
-        <div class="notes-src">4장 구성. 시간이 모자라면 03(테스트)을 줄이고 01·02에 집중한다. 02의 group/Private은 실무에서 늦게 만나는 주제라 뒤로 밀어도 무방.</div>
+        <div class="notes-src">Four chapters. If time runs short, trim 03 (testing) and stay on 01 and 02. The group/Private material in 02 is something people meet late in practice, so it can slide.</div>
       </section>
     </div>
 
@@ -923,172 +923,172 @@ e.<span class="t-fn">Start</span>(cfg.Server.Address)</pre>
         <div class="chap">
           <div class="chap-n">01</div>
           <div class="chap-l">
-            <h2 class="chap-t">fx 기초</h2>
-            <p class="chap-d">등록하고, 실행하고, 수명주기를 맡긴다.
-            이 네 가지 — <code class="inl">Provide</code> · <code class="inl">Invoke</code> · <code class="inl">Supply</code> · <code class="inl">Lifecycle</code> — 만 알아도 실전 앱 하나는 굴러간다.</p>
+            <h2 class="chap-t">fx Basics</h2>
+            <p class="chap-d">Register, run, and hand off the lifecycle.
+            These four — <code class="inl">Provide</code> · <code class="inl">Invoke</code> · <code class="inl">Supply</code> · <code class="inl">Lifecycle</code> — are enough to run a real app.</p>
           </div>
         </div>
-        <div class="notes-src">여기가 오늘의 뿌리. 특히 Provide(lazy)와 Invoke(eager)의 차이는 뒤에서 계속 재등장하므로 시간을 아끼지 말 것.</div>
+        <div class="notes-src">This chapter is the root of everything today. The Provide (lazy) versus Invoke (eager) distinction keeps coming back, so do not rush it.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 06 메서드 지도 ═══════════ -->
+    <!-- ═══════════ 06 Method map ① ═══════════ -->
     <div class="holder" data-n="06">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">지도</span><span class="stamp">cheat sheet</span></div>
-        <h2 class="slide-title">fx 메서드 한눈에 ① 기초</h2>
+        <div class="slide-head"><span class="eyebrow">map</span><span class="stamp">cheat sheet</span></div>
+        <h2 class="slide-title">fx methods at a glance ① Basics</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="tbl-wrap">
             <table class="tbl">
-              <thead><tr><th>메서드</th><th>분류</th><th>역할</th></tr></thead>
+              <thead><tr><th>Method</th><th>Group</th><th>Role</th></tr></thead>
               <tbody>
-                <tr class="on"><td><code class="inl">fx.New</code></td><td>기초</td><td>앱 컨테이너 생성 — 모든 Option을 모아 그래프를 만든다</td></tr>
-                <tr class="on"><td><code class="inl">fx.Provide</code></td><td>기초</td><td>lazy 등록. 반환 타입 기준으로 그래프에 올린다</td></tr>
-                <tr class="on"><td><code class="inl">fx.Invoke</code></td><td>기초</td><td>eager 실행. 부수 효과의 시작점</td></tr>
-                <tr class="on"><td><code class="inl">fx.Supply</code></td><td>기초</td><td>생성자 없이 이미 만든 값을 등록</td></tr>
-                <tr class="on"><td><code class="inl">fx.Lifecycle</code></td><td>수명주기</td><td>OnStart / OnStop 훅</td></tr>
+                <tr class="on"><td><code class="inl">fx.New</code></td><td>basics</td><td>Creates the app container — collects Options into a graph</td></tr>
+                <tr class="on"><td><code class="inl">fx.Provide</code></td><td>basics</td><td>Lazy registration, keyed by return type</td></tr>
+                <tr class="on"><td><code class="inl">fx.Invoke</code></td><td>basics</td><td>Eager execution. The entry point for side effects</td></tr>
+                <tr class="on"><td><code class="inl">fx.Supply</code></td><td>basics</td><td>Registers a ready-made value, no constructor</td></tr>
+                <tr class="on"><td><code class="inl">fx.Lifecycle</code></td><td>lifecycle</td><td>OnStart / OnStop hooks</td></tr>
               </tbody>
             </table>
           </div>
           <div class="callout teal">
-            <span class="lbl">오늘의 8할</span>
-            이 다섯 개만 알아도 실전 앱 하나는 굴러간다. 다음 장의 확장·테스트 도구들은 <b>앱이 커진 뒤에</b> 필요해진다.
+            <span class="lbl">80% of today</span>
+            These five are enough to run a real app. The scaling and testing tools in the next chapters only matter <b>once the app grows</b>.
           </div>
         </div>
-        <div class="notes-src">읽어 내려가지 말 것. "지금은 이 다섯 개만" 하고 넘어간다. 뒤에서 하나씩 예제로 채운다.</div>
+        <div class="notes-src">Do not read the table out loud. Say "just these five for now" and move on. Each one gets filled in with an example later.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 07 메서드 지도 ② ═══════════ -->
+    <!-- ═══════════ 07 Method map ② ═══════════ -->
     <div class="holder" data-n="07">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">지도</span><span class="stamp">cheat sheet</span></div>
-        <h2 class="slide-title">fx 메서드 한눈에 ② 확장 · 테스트</h2>
+        <div class="slide-head"><span class="eyebrow">map</span><span class="stamp">cheat sheet</span></div>
+        <h2 class="slide-title">fx methods at a glance ② Scaling · Testing</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="tbl-wrap">
             <table class="tbl">
-              <thead><tr><th>메서드</th><th>분류</th><th>역할</th><th>도입</th></tr></thead>
+              <thead><tr><th>Method</th><th>Group</th><th>Role</th><th>Since</th></tr></thead>
               <tbody>
-                <tr><td><code class="inl">fx.Module</code></td><td>확장</td><td>도메인별 그룹화</td><td>v1.17+</td></tr>
-                <tr><td><code class="inl">fx.Decorate</code></td><td>확장</td><td>기존 의존성 래핑 (로깅·캐싱·메트릭)</td><td>v1.18+</td></tr>
-                <tr><td><code class="inl">fx.Annotate</code></td><td>확장</td><td>생성자에 name / group / As 부여</td><td class="faint">—</td></tr>
-                <tr><td><code class="inl">fx.In</code> / <code class="inl">fx.Out</code></td><td>확장</td><td>파라미터·반환값을 구조체로 묶어 태그 매칭</td><td class="faint">—</td></tr>
-                <tr><td><code class="inl">fx.Private</code></td><td>확장</td><td>Module 내부 의존성 캡슐화</td><td>v1.20+</td></tr>
-                <tr class="on"><td><code class="inl">fxtest.New</code></td><td>테스트</td><td>테스트 전용 앱</td><td class="faint">—</td></tr>
-                <tr class="on"><td><code class="inl">fx.Replace</code></td><td>테스트</td><td>기존 Provide를 Mock으로 교체</td><td class="faint">—</td></tr>
-                <tr class="on"><td><code class="inl">fx.Populate</code></td><td>테스트</td><td>내부 인스턴스를 외부 변수로 추출</td><td class="faint">—</td></tr>
+                <tr><td><code class="inl">fx.Module</code></td><td>scaling</td><td>Grouping by domain</td><td>v1.17+</td></tr>
+                <tr><td><code class="inl">fx.Decorate</code></td><td>scaling</td><td>Wrapping a dependency (logging · caching · metrics)</td><td>v1.18+</td></tr>
+                <tr><td><code class="inl">fx.Annotate</code></td><td>scaling</td><td>Attaches name / group / As to a constructor</td><td class="faint">—</td></tr>
+                <tr><td><code class="inl">fx.In</code> / <code class="inl">fx.Out</code></td><td>scaling</td><td>Bundles params or results into a struct for tag matching</td><td class="faint">—</td></tr>
+                <tr><td><code class="inl">fx.Private</code></td><td>scaling</td><td>Encapsulates dependencies inside a Module</td><td>v1.20+</td></tr>
+                <tr class="on"><td><code class="inl">fxtest.New</code></td><td>testing</td><td>A test-only app</td><td class="faint">—</td></tr>
+                <tr class="on"><td><code class="inl">fx.Replace</code></td><td>testing</td><td>Swaps an existing Provide for a mock</td><td class="faint">—</td></tr>
+                <tr class="on"><td><code class="inl">fx.Populate</code></td><td>testing</td><td>Extracts an internal instance into a variable</td><td class="faint">—</td></tr>
               </tbody>
             </table>
           </div>
         </div>
-        <div class="notes-src">버전 표기가 있는 셋(Module·Decorate·Private)은 실무에서 "왜 안 되지?" 하는 원인이 되곤 한다. go.mod 버전을 확인하라고 한마디 덧붙인다.</div>
+        <div class="notes-src">The three with version numbers (Module, Decorate, Private) are a common source of "why doesn't this work?" in the field. Add a line telling people to check their go.mod version.</div>
       </section>
     </div>
 
     <!-- ═══════════ 08 fx.Option ═══════════ -->
     <div class="holder" data-n="08">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">구조</span><span class="stamp">fx.Option</span></div>
-        <h2 class="slide-title">거의 모든 것이 <code class="inl">fx.Option</code>을 반환한다</h2>
+        <div class="slide-head"><span class="eyebrow">structure</span><span class="stamp">fx.Option</span></div>
+        <h2 class="slide-title">Almost everything returns an <code class="inl">fx.Option</code></h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2a">
-            <pre class="code sm">app := fx.<span class="t-fn">New</span>(          <span class="t-cm">// ← Option 들을 모아 앱을 만든다</span>
+            <pre class="code sm">app := fx.<span class="t-fn">New</span>(          <span class="t-cm">// ← collects Options into an app</span>
     fx.<span class="t-fn">Provide</span>(...),   <span class="t-cm">// fx.Option</span>
     fx.<span class="t-fn">Supply</span>(...),    <span class="t-cm">// fx.Option</span>
-    UserModule,        <span class="t-cm">// fx.Option (fx.Module 이 반환)</span>
+    UserModule,        <span class="t-cm">// fx.Option (returned by fx.Module)</span>
     fx.<span class="t-fn">Decorate</span>(...),  <span class="t-cm">// fx.Option</span>
     fx.<span class="t-fn">Invoke</span>(...),    <span class="t-cm">// fx.Option</span>
 )</pre>
             <div class="stack">
               <div class="card">
-                <div class="card-t">① Option을 반환하는 것들</div>
-                <p class="dim"><code class="inl">Provide</code> · <code class="inl">Invoke</code> · <code class="inl">Supply</code> · <code class="inl">Module</code> · <code class="inl">Decorate</code> · <code class="inl">Replace</code> · <code class="inl">Populate</code><br />→ <code class="inl">fx.New</code>의 인자로 들어간다</p>
+                <div class="card-t">① Things that return an Option</div>
+                <p class="dim"><code class="inl">Provide</code> · <code class="inl">Invoke</code> · <code class="inl">Supply</code> · <code class="inl">Module</code> · <code class="inl">Decorate</code> · <code class="inl">Replace</code> · <code class="inl">Populate</code><br />→ they go in as arguments to <code class="inl">fx.New</code></p>
               </div>
               <div class="card">
-                <div class="card-t">② Annotation을 반환하는 것들</div>
-                <p class="dim"><code class="inl">Annotate</code> · <code class="inl">ResultTags</code> · <code class="inl">ParamTags</code><br />→ <code class="inl">Provide</code> · <code class="inl">Supply</code> <b>안에서</b> 쓰인다</p>
+                <div class="card-t">② Things that return an Annotation</div>
+                <p class="dim"><code class="inl">Annotate</code> · <code class="inl">ResultTags</code> · <code class="inl">ParamTags</code><br />→ they are used <b>inside</b> <code class="inl">Provide</code> · <code class="inl">Supply</code></p>
               </div>
             </div>
           </div>
           <div class="callout teal">
-            <span class="lbl">이 둘만 구분하면</span>
-            fx API가 갑자기 단순해진다. 어디에 넣어야 할지 헷갈릴 일이 없다.
+            <span class="lbl">tell these two apart</span>
+            and the fx API turns simple all at once. You stop wondering where a thing is supposed to go.
           </div>
         </div>
-        <div class="notes-src">fx 문서를 처음 볼 때 가장 헷갈리는 지점. Option인지 Annotation인지만 구분되면 "이걸 어디에 넣지?" 하는 고민이 사라진다.</div>
+        <div class="notes-src">The single most confusing point when you first read the fx docs. Once Option versus Annotation is clear, "where do I put this?" stops being a question.</div>
       </section>
     </div>
 
     <!-- ═══════════ 09 fx.Provide ═══════════ -->
     <div class="holder" data-n="09">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">기초</span><span class="stamp">fx.Provide</span></div>
-        <h2 class="slide-title"><code class="inl">Provide</code>는 등록만 한다 — 실행은 미룬다</h2>
+        <div class="slide-head"><span class="eyebrow">basics</span><span class="stamp">fx.Provide</span></div>
+        <h2 class="slide-title"><code class="inl">Provide</code> only registers — it defers execution</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <pre class="code sm">app := fxtest.<span class="t-fn">New</span>(t,
-    <span class="t-cm">// Provide: 생성자를 등록만 한다. 즉시 실행되지 않는다.</span>
+    <span class="t-cm">// Provide: registers constructors only. Nothing runs yet.</span>
     fx.<span class="t-fn">Provide</span>(
-        NewLogger,        <span class="t-cm">// Logger 반환</span>
-        NewMysqlUserRepo, <span class="t-cm">// UserRepository 반환 (Logger 필요)</span>
-        NewUserService,   <span class="t-cm">// *UserService 반환 (UserRepository 필요)</span>
+        NewLogger,        <span class="t-cm">// returns Logger</span>
+        NewMysqlUserRepo, <span class="t-cm">// returns UserRepository (needs Logger)</span>
+        NewUserService,   <span class="t-cm">// returns *UserService (needs UserRepository)</span>
     ),
-    <span class="t-cm">// Invoke: 여기서 비로소 그래프가 조립된다</span>
+    <span class="t-cm">// Invoke: this is where the graph finally gets assembled</span>
     fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(s *UserService) { svc = s }),
 )</pre>
           <div class="cols c-2">
             <div class="callout">
-              <span class="lbl">lazy 라는 뜻</span>
-              등록된 생성자는 <b>그 타입을 요구하는 쪽이 생길 때</b> 비로소 호출된다. 아무도 안 찾으면 영영 호출되지 않는다.
+              <span class="lbl">what lazy means</span>
+              A registered constructor runs only <b>once something asks for its type</b>. If nothing asks, it never runs at all.
             </div>
             <div class="callout teal">
-              <span class="lbl">그래서 순서 무관</span>
-              위에서 <code class="inl">NewUserService</code>를 먼저 써도 결과는 같다. fx가 타입으로 정렬한다.
+              <span class="lbl">hence order-free</span>
+              Listing <code class="inl">NewUserService</code> first changes nothing. fx sorts by type.
             </div>
           </div>
         </div>
-        <div class="notes-src">"Provide만 잔뜩 써놓고 왜 아무것도 안 도나요?"가 fx 첫 입문자의 단골 질문. 다음 슬라이드로 바로 이어진다.</div>
+        <div class="notes-src">"I wrote a pile of Provides and nothing runs" is the classic beginner question. It leads straight into the next slide.</div>
       </section>
     </div>
 
     <!-- ═══════════ 10 fx.Invoke ═══════════ -->
     <div class="holder" data-n="10">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">기초</span><span class="stamp">fx.Invoke</span></div>
-        <h2 class="slide-title"><code class="inl">Invoke</code>가 없으면 아무 일도 일어나지 않는다</h2>
+        <div class="slide-head"><span class="eyebrow">basics</span><span class="stamp">fx.Invoke</span></div>
+        <h2 class="slide-title">Without <code class="inl">Invoke</code>, nothing happens at all</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2">
             <div class="card">
               <div class="card-t"><code class="inl">fx.Provide</code> — lazy</div>
-              <p>그래프에 <b>올려만</b> 둔다. 부수 효과 없음.</p>
-              <p class="dim">대부분의 <code class="inl">NewXxx</code> 생성자</p>
+              <p>Only <b>puts it on</b> the graph. No side effects.</p>
+              <p class="dim">Most <code class="inl">NewXxx</code> constructors</p>
             </div>
             <div class="card">
               <div class="card-t"><code class="inl">fx.Invoke</code> — eager</div>
-              <p>앱 시작 시 <b>반드시 실행</b>된다. 여기서 요구한 타입이 그래프 조립의 <b>출발점</b>이 된다.</p>
-              <p class="dim">서버 기동 · 라우터 등록 · 훅 등록</p>
+              <p><b>Always runs</b> at startup. The types it asks for become the <b>starting point</b> of graph assembly.</p>
+              <p class="dim">Booting the server · registering routes · registering hooks</p>
             </div>
           </div>
           <div class="callout">
-            <span class="lbl">기억법</span>
-            <b>부수 효과면 Invoke.</b> 값을 만들어 돌려주면 Provide.
+            <span class="lbl">rule of thumb</span>
+            <b>Side effect → Invoke.</b> Returns a value → Provide.
           </div>
-          <pre class="code xs plain"><span class="t-bad">// Provide만 있고 Invoke가 없는 앱</span>
-<span class="t-cm">→ 생성자는 단 하나도 호출되지 않는다. 앱은 조용히 뜨고 조용히 끝난다.</span></pre>
+          <pre class="code xs plain"><span class="t-bad">// An app with Provides but no Invoke</span>
+<span class="t-cm">→ not a single constructor runs. The app starts quietly and exits quietly.</span></pre>
         </div>
-        <div class="notes-src">여기서 손을 들게 해도 좋다 — "Provide 20개 등록하고 Invoke 없이 실행하면 몇 개가 호출될까요?" 답은 0개.</div>
+        <div class="notes-src">Good spot for a show of hands — "20 Provides, no Invoke, how many constructors run?" The answer is zero.</div>
       </section>
     </div>
 
     <!-- ═══════════ 11 fx.Supply ═══════════ -->
     <div class="holder" data-n="11">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">기초</span><span class="stamp">fx.Supply</span></div>
-        <h2 class="slide-title">만들 게 없는 값은 <code class="inl">Supply</code>로</h2>
+        <div class="slide-head"><span class="eyebrow">basics</span><span class="stamp">fx.Supply</span></div>
+        <h2 class="slide-title">Values with nothing to build go through <code class="inl">Supply</code></h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2a">
@@ -1100,67 +1100,67 @@ e.<span class="t-fn">Start</span>(cfg.Server.Address)</pre>
 cfg := &amp;Config{DBHost: <span class="t-str">"localhost"</span>, DBPort: <span class="t-num">3306</span>}
 
 app := fxtest.<span class="t-fn">New</span>(t,
-    fx.<span class="t-fn">Supply</span>(cfg),   <span class="t-cm">// 생성자 없이 값 그대로 등록</span>
+    fx.<span class="t-fn">Supply</span>(cfg),   <span class="t-cm">// register the value itself, no constructor</span>
     fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(c *Config) {
         <span class="t-cm">// c.DBHost == "localhost"</span>
     }),
 )</pre>
             <div class="stack">
               <div class="callout">
-                <span class="lbl">언제 쓰나</span>
-                설정 구조체, 상수처럼 <b>생성 로직이 없는</b> 값. <code class="inl">Provide</code>로 감싸면 <code class="inl">func() *Config { return cfg }</code> 같은 군더더기가 생긴다.
+                <span class="lbl">when to use it</span>
+                Config structs and constants — values with <b>no construction logic</b>. Wrapping them in <code class="inl">Provide</code> just adds noise like <code class="inl">func() *Config { return cfg }</code>.
               </div>
               <div class="callout teal">
-                <span class="lbl">차이 한 줄</span>
-                <code class="inl">Provide</code>는 <b>생성자 함수</b>를, <code class="inl">Supply</code>는 <b>이미 만든 값</b>을 등록한다.
+                <span class="lbl">the difference, in one line</span>
+                <code class="inl">Provide</code> registers a <b>constructor function</b>; <code class="inl">Supply</code> registers an <b>already-built value</b>.
               </div>
             </div>
           </div>
         </div>
-        <div class="notes-src">Supply는 테스트에서 특히 자주 쓴다. 실제 설정 파일을 읽는 대신 구조체를 손으로 만들어 넣는 식.</div>
+        <div class="notes-src">Supply shows up especially often in tests — build the struct by hand instead of reading a real config file.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 12 실전 적용 ═══════════ -->
+    <!-- ═══════════ 12 In practice ═══════════ -->
     <div class="holder" data-n="12">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">실전</span><span class="stamp">before → after</span></div>
-        <h2 class="slide-title">수동 조립을 fx로 옮기면</h2>
+        <div class="slide-head"><span class="eyebrow">in practice</span><span class="stamp">before → after</span></div>
+        <h2 class="slide-title">Manual wiring, moved over to fx</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <pre class="code sm"><span class="t-cm">// cmd/main.go</span>
 app := fx.<span class="t-fn">New</span>(
     fx.<span class="t-fn">Provide</span>(
         config.New,              <span class="t-cm">// *config.Config</span>
-        database.New,            <span class="t-cm">// *sql.DB          (*config.Config 필요)</span>
+        database.New,            <span class="t-cm">// *sql.DB          (needs *config.Config)</span>
         NewEcho,                 <span class="t-cm">// *echo.Echo</span>
 
-        <span class="t-cm">// 익명 함수도 그대로 생성자가 된다 — 타입만 맞으면 된다</span>
+        <span class="t-cm">// an anonymous function is a constructor too — only the types matter</span>
         <span class="t-key">func</span>(cfg *config.Config) time.Duration {
             <span class="t-key">return</span> time.<span class="t-fn">Duration</span>(cfg.Context.Timeout) * time.Second
         },
 
-        article.NewArticleHandler,         <span class="t-cm">// Echo, UseCase 필요</span>
-        article.NewArticleUsecase,         <span class="t-cm">// Repo, AuthorRepo, Duration 필요</span>
-        article.NewMysqlArticleRepository, <span class="t-cm">// DB 필요</span>
-        author.NewMysqlAuthorRepository,   <span class="t-cm">// DB 필요</span>
+        article.NewArticleHandler,         <span class="t-cm">// needs Echo, UseCase</span>
+        article.NewArticleUsecase,         <span class="t-cm">// needs Repo, AuthorRepo, Duration</span>
+        article.NewMysqlArticleRepository, <span class="t-cm">// needs DB</span>
+        author.NewMysqlAuthorRepository,   <span class="t-cm">// needs DB</span>
     ),
-    fx.<span class="t-fn">Invoke</span>(registerHooks),   <span class="t-cm">// 서버 시작</span>
+    fx.<span class="t-fn">Invoke</span>(registerHooks),   <span class="t-cm">// start the server</span>
 )</pre>
           <div class="callout teal">
-            <span class="lbl">달라진 것</span>
-            조립 <b>순서가 사라졌다.</b> 남은 건 "무엇이 있는가"의 목록뿐이고, "어떤 순서로"는 fx가 타입에서 읽어낸다.
+            <span class="lbl">what changed</span>
+            The assembly <b>order is gone.</b> What remains is a list of what exists; "in what order" is something fx reads out of the types.
           </div>
         </div>
-        <div class="notes-src">2번 슬라이드의 수동 코드와 나란히 놓고 보면 효과가 크다. 필요하면 2번으로 잠깐 돌아갔다 와도 좋다.</div>
+        <div class="notes-src">Powerful when placed side by side with the manual code on slide 02. Jumping back to 02 for a moment is fine.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 13 의존성 그래프 ═══════════ -->
+    <!-- ═══════════ 13 Dependency graph ═══════════ -->
     <div class="holder" data-n="13">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">원리</span><span class="stamp">graph</span></div>
-        <h2 class="slide-title">그래프는 시그니처에서 나온다</h2>
+        <div class="slide-head"><span class="eyebrow">how it works</span><span class="stamp">graph</span></div>
+        <h2 class="slide-title">The graph comes out of the signatures</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="arch">
@@ -1181,18 +1181,18 @@ app := fx.<span class="t-fn">New</span>(
               <div class="node mute"><span class="n-t">registerHooks</span><span class="n-p">lifecycle, echo, cfg</span></div>
             </div>
           </div>
-          <p class="cap">화살표는 <b>의존 방향</b>이다. fx는 이 그래프를 <b>선언 없이</b> 매개변수·반환 타입만으로 만든다.
-          순환이 생기면 앱 시작 시점에 어디가 물렸는지 알려준다.</p>
+          <p class="cap">Arrows are the <b>direction of dependency</b>. fx builds this graph with <b>no declaration at all</b> — parameter and return types are the whole input.
+          If a cycle appears, it tells you at startup exactly where things are tangled.</p>
         </div>
-        <div class="notes-src">"이 그림을 우리가 그린 적이 없다"는 게 포인트. 코드 어디에도 이 순서를 적어두지 않았는데 fx가 만들어낸다.</div>
+        <div class="notes-src">The point is that we never drew this picture. Nowhere in the code did we write this order down, and fx produced it anyway.</div>
       </section>
     </div>
 
     <!-- ═══════════ 14 Lifecycle ═══════════ -->
     <div class="holder" data-n="14">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">수명주기</span><span class="stamp">fx.Lifecycle</span></div>
-        <h2 class="slide-title">시작과 종료를 짝으로 묶는다</h2>
+        <div class="slide-head"><span class="eyebrow">lifecycle</span><span class="stamp">fx.Lifecycle</span></div>
+        <h2 class="slide-title">Bind startup and shutdown as a pair</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">registerHooks</span>(lifecycle fx.Lifecycle, e *echo.Echo, cfg *config.Config) {
@@ -1209,32 +1209,32 @@ app := fx.<span class="t-fn">New</span>(
     })
 }</pre>
           <div class="callout">
-            <span class="lbl">쓰는 곳</span>
-            서버 기동/종료, DB 커넥션 open/close처럼 <b>시작과 정리가 짝을 이루는</b> 리소스. <code class="inl">fx.Invoke(registerHooks)</code>로 등록한다.
+            <span class="lbl">where it belongs</span>
+            Resources whose <b>setup and teardown come in pairs</b> — booting and stopping a server, opening and closing a DB connection. Register it with <code class="inl">fx.Invoke(registerHooks)</code>.
           </div>
         </div>
-        <div class="notes-src">Graceful Shutdown이 공짜로 따라온다는 점을 강조. OnStop은 등록의 역순으로 호출된다.</div>
+        <div class="notes-src">Stress that graceful shutdown comes for free. OnStop hooks run in reverse registration order.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 15 실행 시점 ═══════════ -->
+    <!-- ═══════════ 15 Timing ═══════════ -->
     <div class="holder" data-n="15">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">주의</span><span class="stamp">타이밍</span></div>
-        <h2 class="slide-title">서버는 정확히 <b>언제</b> 뜨는가</h2>
+        <div class="slide-head"><span class="eyebrow">careful</span><span class="stamp">timing</span></div>
+        <h2 class="slide-title"><b>When</b> exactly does the server come up?</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="steps">
-            <div class="step"><span class="s-n">1</span><div><div class="s-c">fx.New() / fxtest.New()</div><div class="s-d"><code class="inl">fx.Invoke</code> 함수 <b>본문</b>이 즉시 실행된다. 여기서 하는 일은 Lifecycle에 훅을 <b>등록</b>하는 것뿐. (<code class="inl">fx.Populate</code>도 이 시점에 채워진다)</div></div></div>
-            <div class="step"><span class="s-n">2</span><div><div class="s-c">app.Start(ctx)</div><div class="s-d">등록된 <code class="inl">OnStart</code> 훅이 실행된다 — <b>실제 서버 기동</b>은 여기서 일어난다</div></div></div>
-            <div class="step"><span class="s-n">3</span><div><div class="s-c">app.Stop(ctx)</div><div class="s-d">등록된 <code class="inl">OnStop</code> 훅이 실행된다 — Graceful Shutdown</div></div></div>
+            <div class="step"><span class="s-n">1</span><div><div class="s-c">fx.New() / fxtest.New()</div><div class="s-d">The <b>body</b> of each <code class="inl">fx.Invoke</code> function runs right away. All it does here is <b>register</b> hooks on the Lifecycle. (<code class="inl">fx.Populate</code> is filled in at this point too)</div></div></div>
+            <div class="step"><span class="s-n">2</span><div><div class="s-c">app.Start(ctx)</div><div class="s-d">The registered <code class="inl">OnStart</code> hooks run — <b>the server actually boots</b> here</div></div></div>
+            <div class="step"><span class="s-n">3</span><div><div class="s-c">app.Stop(ctx)</div><div class="s-d">The registered <code class="inl">OnStop</code> hooks run — graceful shutdown</div></div></div>
           </div>
           <div class="callout teal">
-            <span class="lbl">Lifecycle이 2단계인 이유</span>
-            Invoke로 훅을 <b>일찍 등록</b>해두고, 훅 <b>본문 실행</b>은 <code class="inl">Start</code>까지 미루기 위해서다.
+            <span class="lbl">why Lifecycle has two stages</span>
+            So hooks can be <b>registered early</b> through Invoke while the hook <b>body</b> waits until <code class="inl">Start</code>.
           </div>
         </div>
-        <div class="notes-src">여기가 실무에서 제일 많이 헷갈리는 지점. "Invoke에 넣었는데 왜 벌써 실행되죠?" / "왜 아직 안 뜨죠?" 둘 다 이 표로 설명된다.</div>
+        <div class="notes-src">The most commonly confused point in real work. "I put it in Invoke, why did it run already?" and "why hasn't it started yet?" are both answered by this table.</div>
       </section>
     </div>
 
@@ -1244,20 +1244,20 @@ app := fx.<span class="t-fn">New</span>(
         <div class="chap">
           <div class="chap-n">02</div>
           <div class="chap-l">
-            <h2 class="chap-t">확장 패턴</h2>
-            <p class="chap-d">앱이 커지면 <code class="inl">Provide</code> 목록이 수십 줄이 된다.
-            묶고(<code class="inl">Module</code>), 덧씌우고(<code class="inl">Decorate</code>), 구분하고(<code class="inl">name</code>/<code class="inl">group</code>), 감추는(<code class="inl">Private</code>) 도구들.</p>
+            <h2 class="chap-t">Scaling Patterns</h2>
+            <p class="chap-d">Once an app grows, the <code class="inl">Provide</code> list runs to dozens of lines.
+            Tools to group (<code class="inl">Module</code>), wrap (<code class="inl">Decorate</code>), distinguish (<code class="inl">name</code>/<code class="inl">group</code>), and hide (<code class="inl">Private</code>).</p>
           </div>
         </div>
-        <div class="notes-src">여기부터는 "당장 필요하진 않지만 언젠가 반드시 만나는" 것들. 지금 다 외우지 말고 이런 게 있다는 것만 기억하라고 안내한다.</div>
+        <div class="notes-src">From here on these are things you do not need today but will certainly meet someday. Tell people not to memorize — just remember that these exist.</div>
       </section>
     </div>
 
     <!-- ═══════════ 17 fx.Module ═══════════ -->
     <div class="holder" data-n="17">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Module · v1.17+</span></div>
-        <h2 class="slide-title">도메인별로 묶는다</h2>
+        <div class="slide-head"><span class="eyebrow">scaling</span><span class="stamp">fx.Module · v1.17+</span></div>
+        <h2 class="slide-title">Group things by domain</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2">
@@ -1274,35 +1274,35 @@ app := fx.<span class="t-fn">New</span>(
         NewOrderService,
     ),
 )</pre>
-            <pre class="code sm"><span class="t-cm">// 실전: 각 도메인 패키지가 Module 을 노출하고</span>
-<span class="t-cm">// main 에서 조합한다</span>
+            <pre class="code sm"><span class="t-cm">// In practice: each domain package exposes a Module</span>
+<span class="t-cm">// and main composes them</span>
 app := fx.<span class="t-fn">New</span>(
     fx.<span class="t-fn">Provide</span>(config.New, database.New, NewEcho),
 
-    article.Module,   <span class="t-cm">// article 도메인</span>
-    author.Module,    <span class="t-cm">// author 도메인</span>
-    payment.Module,   <span class="t-cm">// payment 도메인</span>
+    article.Module,   <span class="t-cm">// article domain</span>
+    author.Module,    <span class="t-cm">// author domain</span>
+    payment.Module,   <span class="t-cm">// payment domain</span>
 
     fx.<span class="t-fn">Invoke</span>(registerHooks),
 )</pre>
           </div>
           <div class="callout">
-            <span class="lbl">주의</span>
-            <code class="inl">Module</code>은 <b>이름을 붙여 묶어줄 뿐</b>이다. 안의 <code class="inl">Provide</code>는 여전히 <b>전역 그래프에 노출</b>된다. 감추려면 22번의 <code class="inl">fx.Private</code>이 필요하다.
+            <span class="lbl">careful</span>
+            <code class="inl">Module</code> only <b>groups things under a name</b>. The <code class="inl">Provide</code>s inside are still <b>exposed to the global graph</b>. Hiding them takes <code class="inl">fx.Private</code>, on slide 22.
           </div>
         </div>
-        <div class="notes-src">"Module = 캡슐화"라고 오해하기 쉬운데 아니다. 이 오해가 22번 슬라이드의 출발점이므로 여기서 미리 심어둔다.</div>
+        <div class="notes-src">"Module = encapsulation" is an easy misreading, and it is wrong. That misreading is the starting point of slide 22, so plant it here on purpose.</div>
       </section>
     </div>
 
     <!-- ═══════════ 18 fx.Decorate ═══════════ -->
     <div class="holder" data-n="18">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Decorate · v1.18+</span></div>
-        <h2 class="slide-title">원본을 안 건드리고 덧씌운다</h2>
+        <div class="slide-head"><span class="eyebrow">scaling</span><span class="stamp">fx.Decorate · v1.18+</span></div>
+        <h2 class="slide-title">Wrap it without touching the original</h2>
         <div class="rule"></div>
         <div class="slide-body">
-          <pre class="code sm"><span class="t-cm">// 로깅 데코레이터: 기존 UserRepository 를 래핑</span>
+          <pre class="code sm"><span class="t-cm">// Logging decorator: wraps the existing UserRepository</span>
 <span class="t-key">type</span> loggingUserRepo <span class="t-key">struct</span> {
     inner  UserRepository
     logger Logger
@@ -1310,7 +1310,7 @@ app := fx.<span class="t-fn">New</span>(
 
 <span class="t-key">func</span> (r *loggingUserRepo) <span class="t-fn">FindByID</span>(id <span class="t-key">int</span>) <span class="t-key">string</span> {
     r.calls = <span class="t-fn">append</span>(r.calls, fmt.<span class="t-fn">Sprintf</span>(<span class="t-str">"FindByID(%d)"</span>, id))
-    <span class="t-key">return</span> r.inner.<span class="t-fn">FindByID</span>(id)   <span class="t-cm">// 원본 호출</span>
+    <span class="t-key">return</span> r.inner.<span class="t-fn">FindByID</span>(id)   <span class="t-cm">// call the original</span>
 }
 
 app := fxtest.<span class="t-fn">New</span>(t,
@@ -1320,25 +1320,25 @@ app := fxtest.<span class="t-fn">New</span>(t,
     }),
 )</pre>
           <div class="callout teal">
-            <span class="lbl">핵심</span>
-            원본을 매개변수로 받아 <b>같은 타입</b>을 반환하면 fx가 그래프의 그 노드를 교체한다.
-            <code class="inl">UserService</code>는 <b>코드 한 줄 안 고치고</b> 래퍼를 주입받는다.
+            <span class="lbl">the key</span>
+            Take the original as a parameter and return the <b>same type</b>, and fx swaps that node in the graph.
+            <code class="inl">UserService</code> receives the wrapper <b>without a single line changed</b>.
           </div>
         </div>
-        <div class="notes-src">로깅·캐싱·메트릭 같은 횡단 관심사에 쓴다. Java의 AOP를 떠올리면 이해가 빠른 청중도 있다.</div>
+        <div class="notes-src">Used for cross-cutting concerns — logging, caching, metrics. For some audiences, "think Java AOP" lands quickly.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 19 name 태그 ═══════════ -->
+    <!-- ═══════════ 19 name tag ═══════════ -->
     <div class="holder" data-n="19">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Annotate + name:</span></div>
-        <h2 class="slide-title">같은 타입이 둘일 때 — read / write DB</h2>
+        <div class="slide-head"><span class="eyebrow">scaling</span><span class="stamp">fx.Annotate + name:</span></div>
+        <h2 class="slide-title">Two values of the same type — read / write DB</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2">
             <div class="stack tight">
-              <div class="card-t">① 등록: 생성자에 이름을 붙인다</div>
+              <div class="card-t">① Register: name the constructors</div>
               <pre class="code xs">fx.<span class="t-fn">Provide</span>(
     fx.<span class="t-fn">Annotate</span>(NewReadDB,
         fx.<span class="t-fn">ResultTags</span>(<span class="t-str">`name:"readDB"`</span>)),
@@ -1348,7 +1348,7 @@ app := fxtest.<span class="t-fn">New</span>(t,
 )</pre>
             </div>
             <div class="stack tight">
-              <div class="card-t">② 수신: <code class="inl">fx.In</code> 구조체로 매칭</div>
+              <div class="card-t">② Receive: match with an <code class="inl">fx.In</code> struct</div>
               <pre class="code xs"><span class="t-key">type</span> DBParams <span class="t-key">struct</span> {
     fx.In
     ReadDB  *DBConnection <span class="t-str">`name:"readDB"`</span>
@@ -1364,19 +1364,19 @@ app := fxtest.<span class="t-fn">New</span>(t,
             </div>
           </div>
           <div class="callout">
-            <span class="lbl">fx.In 이란</span>
-            여러 의존성을 <b>하나의 파라미터 구조체</b>로 묶어 받게 해주는 임베디드 마커. 필드마다 태그로 특정 인스턴스를 지목할 수 있다. (반환값을 묶을 땐 <code class="inl">fx.Out</code>)
+            <span class="lbl">what fx.In is</span>
+            An embedded marker that lets you receive several dependencies as <b>a single parameter struct</b>. Each field can point at a specific instance through a tag. (Use <code class="inl">fx.Out</code> to bundle return values.)
           </div>
         </div>
-        <div class="notes-src">타입이 같으면 fx가 구분할 방법이 없다는 게 출발점. 이름표를 붙여주는 것뿐이라고 설명하면 직관적이다.</div>
+        <div class="notes-src">Start from the fact that fx has no way to tell identical types apart. Explaining it as "we are just adding name tags" is intuitive.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 20 group 태그 ═══════════ -->
+    <!-- ═══════════ 20 group tag ═══════════ -->
     <div class="holder" data-n="20">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">group:</span></div>
-        <h2 class="slide-title">같은 인터페이스 구현체를 <b>모아서</b> 받는다</h2>
+        <div class="slide-head"><span class="eyebrow">scaling</span><span class="stamp">group:</span></div>
+        <h2 class="slide-title">Receive implementations of one interface <b>as a set</b></h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2">
@@ -1399,82 +1399,82 @@ app := fxtest.<span class="t-fn">New</span>(t,
 }</pre>
           </div>
           <div class="callout teal">
-            <span class="lbl">이게 좋은 이유</span>
-            새 구현체를 추가해도 <b>수신 측 코드는 그대로</b>다. 플러그인·핸들러·외부 클라이언트를 모을 때의 정석.
+            <span class="lbl">why this is good</span>
+            Adding a new implementation leaves the <b>receiving code untouched</b>. The standard move for collecting plugins, handlers, and external clients.
           </div>
         </div>
-        <div class="notes-src">"Notifier 하나 더 추가하려면 어디를 고쳐야 하나?" → Provide 한 줄만. 수신 측은 안 건드린다는 게 핵심 가치.</div>
+        <div class="notes-src">"To add one more Notifier, what do you edit?" — one Provide line. The value is that the receiving side stays put.</div>
       </section>
     </div>
 
     <!-- ═══════════ 21 name vs group ═══════════ -->
     <div class="holder" data-n="21">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">비교</span><span class="stamp">name vs group</span></div>
-        <h2 class="slide-title">개별로 지목할까, 모아서 받을까</h2>
+        <div class="slide-head"><span class="eyebrow">compare</span><span class="stamp">name vs group</span></div>
+        <h2 class="slide-title">Point at one, or take them all?</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="tbl-wrap">
             <table class="tbl">
-              <thead><tr><th>패턴</th><th>용도</th><th>수신 측</th><th>구현체가 늘면</th></tr></thead>
+              <thead><tr><th>Pattern</th><th>Use for</th><th>Receiving side</th><th>As implementations grow</th></tr></thead>
               <tbody>
-                <tr><td><code class="inl">name:"X"</code></td><td>동일 타입을 <b>개별</b> 식별</td><td>단일 필드</td><td class="faint">수신 코드도 고쳐야 한다</td></tr>
-                <tr class="on"><td><code class="inl">group:"Y"</code></td><td>동일 타입·인터페이스를 <b>모음</b></td><td>슬라이스 필드</td><td>수신 코드는 그대로</td></tr>
+                <tr><td><code class="inl">name:"X"</code></td><td>Identifying one type <b>individually</b></td><td>single field</td><td class="faint">receiving code changes too</td></tr>
+                <tr class="on"><td><code class="inl">group:"Y"</code></td><td><b>Collecting</b> one type or interface</td><td>slice field</td><td>receiving code stays put</td></tr>
               </tbody>
             </table>
           </div>
           <div class="cols c-2">
             <div class="callout">
-              <span class="lbl">name: 이 맞는 상황</span>
-              read/write DB처럼 <b>역할이 다른</b> 소수의 인스턴스. 각각을 정확히 지목해야 한다.
+              <span class="lbl">when name: fits</span>
+              A few instances with <b>different roles</b>, like read/write DBs. You need to point at each one precisely.
             </div>
             <div class="callout teal">
-              <span class="lbl">group: 이 맞는 상황</span>
-              Notifier·Handler처럼 <b>같은 취급</b>을 받는 구현체 묶음. 하나씩 이름 붙이면 확장할 때마다 아프다.
+              <span class="lbl">when group: fits</span>
+              A set of implementations <b>treated identically</b>, like Notifiers or Handlers. Naming them one by one hurts on every extension.
             </div>
           </div>
         </div>
-        <div class="notes-src">이 슬라이드 하나만 기억해도 실무에서 헷갈릴 일이 없다. "개별 지목이면 name, 한꺼번에면 group".</div>
+        <div class="notes-src">Remember this one slide and you will not get confused in practice: point at one → name, take them all → group.</div>
       </section>
     </div>
 
     <!-- ═══════════ 22 fx.Private ═══════════ -->
     <div class="holder" data-n="22">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">확장</span><span class="stamp">fx.Private · v1.20+</span></div>
-        <h2 class="slide-title">Module 내부 의존성을 감춘다</h2>
+        <div class="slide-head"><span class="eyebrow">scaling</span><span class="stamp">fx.Private · v1.20+</span></div>
+        <h2 class="slide-title">Hide a Module's internal dependencies</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2a">
             <pre class="code sm">PrivateModule := fx.<span class="t-fn">Module</span>(<span class="t-str">"private"</span>,
     fx.<span class="t-fn">Provide</span>(
         newInternalDB,
-        fx.Private,    <span class="t-cm">// ← 이 Provide 그룹 전체를</span>
-                       <span class="t-cm">//   Module 내부 전용으로</span>
+        fx.Private,    <span class="t-cm">// ← makes this whole Provide group</span>
+                       <span class="t-cm">//   Module-internal only</span>
     ),
-    fx.<span class="t-fn">Provide</span>(newModuleService),  <span class="t-cm">// 이건 외부 노출</span>
+    fx.<span class="t-fn">Provide</span>(newModuleService),  <span class="t-cm">// this one is exposed</span>
 )
 
-<span class="t-cm">// 외부에서 *internalDB 를 요청하면?</span>
+<span class="t-cm">// What if something outside asks for *internalDB?</span>
 leakApp := fx.<span class="t-fn">New</span>(
     PrivateModule,
     fx.<span class="t-fn">Populate</span>(&amp;leaked),
     fx.NopLogger,
 )
-<span class="t-cm">// leakApp.Err() != nil  →</span> <span class="t-bad">그래프 구성 단계에서 에러</span></pre>
+<span class="t-cm">// leakApp.Err() != nil  →</span> <span class="t-bad">error while building the graph</span></pre>
             <div class="stack">
               <div class="callout">
-                <span class="lbl">해결하는 문제</span>
-                DB 핸들·외부 API 클라이언트 같은 <b>인프라 의존성</b>을 다른 Module이 <b>우연히 공유</b>하는 것을 막는다.
+                <span class="lbl">the problem it solves</span>
+                Stops other Modules from <b>accidentally sharing</b> <b>infrastructure dependencies</b> like DB handles and external API clients.
               </div>
               <div class="callout teal">
-                <span class="lbl">범위</span>
-                <code class="inl">*internalDB</code>는 같은 Module 안의 <code class="inl">newModuleService</code>만 주입받을 수 있다.
+                <span class="lbl">scope</span>
+                <code class="inl">*internalDB</code> can only be injected into <code class="inl">newModuleService</code>, inside the same Module.
               </div>
             </div>
           </div>
         </div>
-        <div class="notes-src">17번에서 심어둔 "Module은 캡슐화가 아니다"의 답. 실무에서 DB 커넥션 풀이 의도치 않게 공유되는 사고를 막아준다.</div>
+        <div class="notes-src">The answer to "Module is not encapsulation," planted back on slide 17. In practice it prevents accidents where a DB connection pool gets shared unintentionally.</div>
       </section>
     </div>
 
@@ -1484,20 +1484,20 @@ leakApp := fx.<span class="t-fn">New</span>(
         <div class="chap">
           <div class="chap-n">03</div>
           <div class="chap-l">
-            <h2 class="chap-t">테스트 전략</h2>
-            <p class="chap-d">fx로 조립한 앱을 테스트에서 어떻게 띄우고,
-            어떻게 Mock을 끼워 넣고, 조립된 인스턴스를 어떻게 꺼내는가.</p>
+            <h2 class="chap-t">Testing Strategy</h2>
+            <p class="chap-d">How to boot an fx-wired app inside a test,
+            how to slot mocks in, and how to pull assembled instances back out.</p>
           </div>
         </div>
-        <div class="notes-src">DI 프레임워크의 실질적 이점이 드러나는 부분. 조립 지점이 한 곳이라 갈아끼우기가 쉽다.</div>
+        <div class="notes-src">Where the practical payoff of a DI framework shows up. There is one assembly point, so swapping things out is easy.</div>
       </section>
     </div>
 
     <!-- ═══════════ 24 fxtest ═══════════ -->
     <div class="holder" data-n="24">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">테스트</span><span class="stamp">fxtest.New</span></div>
-        <h2 class="slide-title">테스트 전용 앱 컨테이너</h2>
+        <div class="slide-head"><span class="eyebrow">testing</span><span class="stamp">fxtest.New</span></div>
+        <h2 class="slide-title">A test-only app container</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <pre class="code sm">app := fxtest.<span class="t-fn">New</span>(t,
@@ -1508,30 +1508,30 @@ leakApp := fx.<span class="t-fn">New</span>(
 app.<span class="t-fn">RequireStart</span>()</pre>
           <div class="cols c-2">
             <div class="callout">
-              <span class="lbl">fx.New 대신 쓰는 이유</span>
-              실패를 <code class="inl">t</code>로 리포트하고, 정리를 도와주며, fx 로그가 테스트 출력에 포함된다.
+              <span class="lbl">why not fx.New</span>
+              It reports failures through <code class="inl">t</code>, helps with cleanup, and folds fx logs into the test output.
             </div>
             <div class="callout teal">
-              <span class="lbl">Require 접두사</span>
-              <code class="inl">RequireStart</code>/<code class="inl">RequireStop</code>은 실패하면 테스트를 즉시 중단시킨다.
+              <span class="lbl">the Require prefix</span>
+              <code class="inl">RequireStart</code>/<code class="inl">RequireStop</code> abort the test immediately on failure.
             </div>
           </div>
         </div>
-        <div class="notes-src">앞 슬라이드들의 예제가 전부 fxtest였다는 점을 여기서 밝히면 자연스럽게 이어진다.</div>
+        <div class="notes-src">Revealing here that every example so far was fxtest makes the transition natural.</div>
       </section>
     </div>
 
     <!-- ═══════════ 25 fx.Replace ═══════════ -->
     <div class="holder" data-n="25">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">테스트</span><span class="stamp">fx.Replace + fx.As</span></div>
-        <h2 class="slide-title">Mock으로 갈아끼우기</h2>
+        <div class="slide-head"><span class="eyebrow">testing</span><span class="stamp">fx.Replace + fx.As</span></div>
+        <h2 class="slide-title">Swapping in a mock</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <pre class="code sm">app := fxtest.<span class="t-fn">New</span>(t,
     fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
 
-    <span class="t-cm">// 실제 UserRepository 를 Mock 으로 교체</span>
+    <span class="t-cm">// replace the real UserRepository with a mock</span>
     fx.<span class="t-fn">Replace</span>(fx.<span class="t-fn">Annotate</span>(&amp;mockUserRepo{}, fx.<span class="t-fn">As</span>(<span class="t-fn">new</span>(UserRepository)))),
 
     fx.<span class="t-fn">Invoke</span>(<span class="t-key">func</span>(svc *UserService) {
@@ -1540,24 +1540,24 @@ app.<span class="t-fn">RequireStart</span>()</pre>
     }),
 )</pre>
           <div class="callout">
-            <span class="lbl"><code class="inl">fx.As</code>가 왜 필요한가</span>
-            fx는 <b>타입으로 매칭</b>한다. <code class="inl">&amp;mockUserRepo{}</code>의 타입은 <code class="inl">*mockUserRepo</code>이지 <code class="inl">UserRepository</code>가 아니다.
-            <code class="inl">fx.As(new(UserRepository))</code>로 <b>인터페이스 타입으로 등록</b>해야 기존 Provide를 교체한다.
+            <span class="lbl">why <code class="inl">fx.As</code> is needed</span>
+            fx <b>matches by type</b>. The type of <code class="inl">&amp;mockUserRepo{}</code> is <code class="inl">*mockUserRepo</code>, not <code class="inl">UserRepository</code>.
+            You have to <b>register it as the interface type</b> with <code class="inl">fx.As(new(UserRepository))</code> for it to replace the existing Provide.
           </div>
         </div>
-        <div class="notes-src">fx 입문자가 가장 자주 넘어지는 함정. Replace만 쓰고 As를 빼면 "교체가 안 되는데요?"가 된다.</div>
+        <div class="notes-src">The trap fx newcomers hit most often. Use Replace without As and you get "why isn't it being replaced?"</div>
       </section>
     </div>
 
     <!-- ═══════════ 26 Populate vs Invoke ═══════════ -->
     <div class="holder" data-n="26">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">테스트</span><span class="stamp">Populate vs Invoke</span></div>
-        <h2 class="slide-title">조립된 인스턴스 꺼내기</h2>
+        <div class="slide-head"><span class="eyebrow">testing</span><span class="stamp">Populate vs Invoke</span></div>
+        <h2 class="slide-title">Pulling assembled instances out</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2">
-            <pre class="code xs"><span class="t-cm">// 방식 1: Invoke 클로저로 캡처</span>
+            <pre class="code xs"><span class="t-cm">// Option 1: capture with an Invoke closure</span>
 <span class="t-key">var</span> svc1 *UserService
 app1 := fxtest.<span class="t-fn">New</span>(t,
     fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
@@ -1565,28 +1565,28 @@ app1 := fxtest.<span class="t-fn">New</span>(t,
         svc1 = s
     }),
 )</pre>
-            <pre class="code xs"><span class="t-cm">// 방식 2: Populate 로 직접 추출</span>
+            <pre class="code xs"><span class="t-cm">// Option 2: extract directly with Populate</span>
 <span class="t-key">var</span> svc2 *UserService
 app2 := fxtest.<span class="t-fn">New</span>(t,
     fx.<span class="t-fn">Provide</span>(NewLogger, NewMysqlUserRepo, NewUserService),
     fx.<span class="t-fn">Populate</span>(&amp;svc2),
 )
 
-<span class="t-cm">// 여러 개도 한 번에</span>
+<span class="t-cm">// several at once works too</span>
 fx.<span class="t-fn">Populate</span>(&amp;svc, &amp;logger)</pre>
           </div>
           <div class="tbl-wrap">
             <table class="tbl">
-              <thead><tr><th>구분</th><th><code class="inl">fx.Invoke</code></th><th><code class="inl">fx.Populate</code></th></tr></thead>
+              <thead><tr><th>Aspect</th><th><code class="inl">fx.Invoke</code></th><th><code class="inl">fx.Populate</code></th></tr></thead>
               <tbody>
-                <tr><td>본질</td><td>함수를 <b>실행</b>한다</td><td>변수에 값을 <b>채운다</b></td></tr>
-                <tr><td>넘기는 것</td><td>함수(클로저)</td><td>포인터</td></tr>
-                <tr><td>고르는 기준</td><td>꺼낸 뒤 <b>호출·검증까지</b> 할 때</td><td>꺼내는 것 <b>자체가 목적</b>일 때</td></tr>
+                <tr><td>Nature</td><td><b>Runs</b> a function</td><td><b>Fills</b> a variable</td></tr>
+                <tr><td>What you pass</td><td>a function (closure)</td><td>a pointer</td></tr>
+                <tr><td>Pick it when</td><td>you'll <b>call and assert</b> afterwards</td><td>pulling it out <b>is the point</b></td></tr>
               </tbody>
             </table>
           </div>
         </div>
-        <div class="notes-src">Populate는 내부적으로 Invoke로 구현된 편의 함수다. 본질이 같고 목적만 다르다는 걸 알면 선택이 쉬워진다.</div>
+        <div class="notes-src">Populate is a convenience function implemented on top of Invoke. Once you know they are the same underneath and differ only in intent, the choice is easy.</div>
       </section>
     </div>
 
@@ -1596,167 +1596,167 @@ fx.<span class="t-fn">Populate</span>(&amp;svc, &amp;logger)</pre>
         <div class="chap">
           <div class="chap-n">04</div>
           <div class="chap-l">
-            <h2 class="chap-t">정리</h2>
-            <p class="chap-d">무엇을 언제 고를지, 그리고 — 어디까지 fx에 맡기지 <b>않을</b> 것인지.</p>
+            <h2 class="chap-t">Wrap-up</h2>
+            <p class="chap-d">What to reach for when — and how much you should <b>not</b> hand over to fx.</p>
           </div>
         </div>
-        <div class="notes-src">마지막 장. 선택 가이드 표는 자료로 남겨두고, 마지막 메시지(30번)에 시간을 더 쓴다.</div>
+        <div class="notes-src">Final chapter. Leave the decision table as a takeaway and spend the time on the closing message instead.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 28 선택 가이드 ═══════════ -->
+    <!-- ═══════════ 28 Decision guide ═══════════ -->
     <div class="holder" data-n="28">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">정리</span><span class="stamp">선택 가이드</span></div>
-        <h2 class="slide-title">하고 싶은 일 → 쓸 메서드</h2>
+        <div class="slide-head"><span class="eyebrow">wrap-up</span><span class="stamp">decision guide</span></div>
+        <h2 class="slide-title">What you want → the method to reach for</h2>
         <div class="rule"></div>
         <div class="slide-body top">
           <div class="tbl-wrap">
             <table class="tbl">
-              <thead><tr><th>하고 싶은 일</th><th>메서드</th><th>기억법</th></tr></thead>
+              <thead><tr><th>What you want</th><th>Method</th><th>Remember</th></tr></thead>
               <tbody>
-                <tr><td>의존성을 그래프에 등록 (lazy)</td><td><code class="inl">fx.Provide</code></td><td class="faint">즉시 실행 아님</td></tr>
-                <tr><td>앱 시작 시 즉시 실행 (서버 기동)</td><td><code class="inl">fx.Invoke</code></td><td>부수 효과면 Invoke</td></tr>
-                <tr><td>이미 만든 값·설정을 주입</td><td><code class="inl">fx.Supply</code></td><td class="faint">상수·구성값</td></tr>
-                <tr><td>시작/종료 훅 (Graceful Shutdown)</td><td><code class="inl">fx.Lifecycle</code></td><td>Invoke 안에서 Append</td></tr>
-                <tr><td>도메인별로 의존성 묶기</td><td><code class="inl">fx.Module</code></td><td class="faint">커진 Provide 분리</td></tr>
-                <tr><td>기존 의존성에 로깅·캐싱 덧입히기</td><td><code class="inl">fx.Decorate</code></td><td>원본 수정 없이 래핑</td></tr>
-                <tr><td>동일 타입을 <b>개별</b> 식별 (read/write)</td><td><code class="inl">Annotate</code> + <code class="inl">name:</code></td><td class="faint">수신 측 단일 필드</td></tr>
-                <tr><td>동일 인터페이스를 <b>모아서</b> 주입</td><td><code class="inl">group:</code></td><td>수신 측 슬라이스</td></tr>
-                <tr><td>Module 내부 의존성 숨기기</td><td><code class="inl">fx.Private</code></td><td class="faint">인프라 핸들 격리</td></tr>
-                <tr><td>테스트에서 Mock 주입</td><td><code class="inl">fx.Replace</code></td><td><code class="inl">fx.As</code>로 인터페이스 매칭</td></tr>
-                <tr><td>테스트에서 인스턴스 꺼내기</td><td><code class="inl">fx.Populate</code></td><td class="faint">검증까지면 Invoke</td></tr>
+                <tr><td>Register a dependency (lazy)</td><td><code class="inl">fx.Provide</code></td><td class="faint">does not run yet</td></tr>
+                <tr><td>Run at startup (boot the server)</td><td><code class="inl">fx.Invoke</code></td><td>side effect → Invoke</td></tr>
+                <tr><td>Inject a ready-made value or config</td><td><code class="inl">fx.Supply</code></td><td class="faint">constants · config</td></tr>
+                <tr><td>Start/stop hooks (graceful shutdown)</td><td><code class="inl">fx.Lifecycle</code></td><td>Append inside Invoke</td></tr>
+                <tr><td>Group dependencies by domain</td><td><code class="inl">fx.Module</code></td><td class="faint">split a bloated Provide</td></tr>
+                <tr><td>Add logging or caching to a dependency</td><td><code class="inl">fx.Decorate</code></td><td>wrap, no edits</td></tr>
+                <tr><td>Identify one type <b>individually</b> (read/write)</td><td><code class="inl">Annotate</code> + <code class="inl">name:</code></td><td class="faint">single field</td></tr>
+                <tr><td>Inject one interface's set of impls</td><td><code class="inl">group:</code></td><td>slice on the receiver</td></tr>
+                <tr><td>Hide a Module's internals</td><td><code class="inl">fx.Private</code></td><td class="faint">isolate infra handles</td></tr>
+                <tr><td>Inject a mock in a test</td><td><code class="inl">fx.Replace</code></td><td>match iface via <code class="inl">fx.As</code></td></tr>
+                <tr><td>Pull an instance out in a test</td><td><code class="inl">fx.Populate</code></td><td class="faint">Invoke if asserting</td></tr>
               </tbody>
             </table>
           </div>
         </div>
-        <div class="notes-src">읽어 내려가지 말고 "자료로 가져가시라"고 안내. 대신 앞에서 다룬 것 중 두어 개만 짚어 복습한다.</div>
+        <div class="notes-src">Do not read it down the list — tell people to take it away as a reference. Instead pick two items already covered and recap those.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 29 마지막 메시지 ═══════════ -->
+    <!-- ═══════════ 29 Closing message ═══════════ -->
     <div class="holder" data-n="29">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">마무리</span><span class="stamp">trade-off</span></div>
-        <h2 class="slide-title">모든 것을 fx로 관리할 필요는 없다</h2>
+        <div class="slide-head"><span class="eyebrow">closing</span><span class="stamp">trade-off</span></div>
+        <h2 class="slide-title">You don't have to manage everything with fx</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="cols c-2">
             <div class="card">
-              <div class="card-t">fx가 빛나는 곳</div>
-              <p><b>수명주기 관리가 필요한 컴포넌트</b></p>
-              <p class="dim">DB 연결 · HTTP 서버 · 외부 클라이언트 — 시작과 정리가 짝을 이루고, 여러 곳에서 공유되는 것들</p>
+              <div class="card-t">Where fx shines</div>
+              <p><b>Components that need lifecycle management</b></p>
+              <p class="dim">DB connections · HTTP servers · external clients — things whose startup and teardown pair up and that are shared in many places</p>
             </div>
             <div class="card">
-              <div class="card-t">직접 만드는 게 나은 곳</div>
-              <p><b>단순한 값 객체와 유틸리티</b></p>
-              <p class="dim">생성 비용이 없고 수명주기도 없는 것을 그래프에 올리면 얻는 것 없이 간접성만 늘어난다</p>
+              <div class="card-t">Where hand-wiring is better</div>
+              <p><b>Plain value objects and utilities</b></p>
+              <p class="dim">Putting something with no construction cost and no lifecycle on the graph buys nothing and only adds indirection</p>
             </div>
           </div>
           <div class="callout">
-            <span class="lbl">치르는 대가</span>
-            리플렉션 기반이라 <b>컴파일 타임 타입 안전성을 일부 포기</b>한다. 대신 상세한 런타임 에러 메시지와 실전 생산성을 얻는다 — 이 거래가 맞는지는 앱 규모가 답한다.
+            <span class="lbl">the price you pay</span>
+            Because it is reflection-based, you <b>give up some compile-time type safety</b>. In exchange you get detailed runtime errors and real productivity — whether that trade is worth it is answered by the size of your app.
           </div>
         </div>
-        <div class="notes-src">"DI 프레임워크를 쓰면 다 좋아진다"는 인상으로 끝내지 않는 게 중요. 작은 앱에서는 수동 조립이 더 명확하다는 말을 꼭 덧붙인다.</div>
+        <div class="notes-src">Important not to end on "DI frameworks make everything better." Always add that manual wiring is clearer in a small app.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 30 퀴즈 1 ═══════════ -->
+    <!-- ═══════════ 30 Quiz 1 ═══════════ -->
     <div class="holder" data-n="30">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">확인</span><span class="stamp">클릭하면 답이 열립니다</span></div>
-        <h2 class="slide-title">스스로 답해보기 ①</h2>
+        <div class="slide-head"><span class="eyebrow">check</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Check yourself ①</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="quiz">
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q1</span><span><code class="inl">fx.Provide</code>에 생성자를 잔뜩 등록했는데 앱을 띄워도 아무것도 실행되지 않는다. 왜일까?</span></button>
-              <div class="q-a"><code class="inl">Provide</code>는 등록만 하고 실행은 미루는 lazy 등록이기 때문이다. 그래프가 조립되려면 그 타입을 요구하는 쪽이 있어야 하고, 그 시작점이 <code class="inl">fx.Invoke</code>다. <span class="ref">→ 슬라이드 09 · 10</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>I registered a pile of constructors with <code class="inl">fx.Provide</code>, but nothing runs at startup. Why?</span></button>
+              <div class="q-a">Because <code class="inl">Provide</code> is lazy — it registers and defers execution. The graph is assembled only when something asks for a type, and <code class="inl">fx.Invoke</code> is that starting point. <span class="ref">→ Slide 09 · 10</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q2</span><span><code class="inl">fx.Provide</code>와 <code class="inl">fx.Supply</code>는 무엇이 다른가?</span></button>
-              <div class="q-a"><code class="inl">Provide</code>는 <b>생성자 함수</b>를 등록하고 fx가 반환 타입으로 그래프에 연결한다. <code class="inl">Supply</code>는 <b>이미 만들어진 값</b>을 그대로 등록한다. 설정 구조체·상수처럼 생성 로직이 없는 값에 맞다. <span class="ref">→ 슬라이드 11</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>What is the difference between <code class="inl">fx.Provide</code> and <code class="inl">fx.Supply</code>?</span></button>
+              <div class="q-a"><code class="inl">Provide</code> registers a <b>constructor function</b> and fx wires it in by return type. <code class="inl">Supply</code> registers an <b>already-built value</b> as is — right for config structs and constants with no construction logic. <span class="ref">→ Slide 11</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>fx는 생성자를 어떤 순서로 호출할지 어떻게 결정하나?</span></button>
-              <div class="q-a">각 생성자의 <b>매개변수 타입과 반환 타입</b>만 본다. 등록 순서는 상관없고, 순환 의존성이 있으면 앱 시작 시점에 에러로 알려준다. <span class="ref">→ 슬라이드 03 · 13</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>How does fx decide the order in which to call constructors?</span></button>
+              <div class="q-a">It looks only at each constructor's <b>parameter and return types</b>. Registration order is irrelevant, and a dependency cycle is reported as an error at startup. <span class="ref">→ Slide 03 · 13</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q4</span><span><code class="inl">registerHooks</code>를 <code class="inl">fx.Invoke</code>로 등록했다. 서버는 정확히 언제 뜨나?</span></button>
-              <div class="q-a">두 시점으로 나뉜다. <code class="inl">Invoke</code> 본문은 <code class="inl">fx.New()</code> 때 즉시 실행되지만 거기서 하는 일은 훅 <b>등록</b>뿐이고, <code class="inl">OnStart</code> 본문은 <code class="inl">app.Start(ctx)</code>에서 실행된다. <span class="ref">→ 슬라이드 15</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>I registered <code class="inl">registerHooks</code> via <code class="inl">fx.Invoke</code>. When exactly does the server boot?</span></button>
+              <div class="q-a">In two stages. The <code class="inl">Invoke</code> body runs immediately at <code class="inl">fx.New()</code>, but all it does there is <b>register</b> hooks; the <code class="inl">OnStart</code> body runs at <code class="inl">app.Start(ctx)</code>. <span class="ref">→ Slide 15</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>도메인별로 <code class="inl">fx.Module</code>을 나눴는데 다른 Module이 같은 DB 핸들을 주입받아 버렸다. 무엇을 빠뜨렸나?</span></button>
-              <div class="q-a"><code class="inl">fx.Private</code>이다. <code class="inl">Module</code>은 이름을 붙여 묶어줄 뿐, 안의 <code class="inl">Provide</code>는 전역 그래프에 노출된다. 같은 <code class="inl">Provide</code> 그룹에 <code class="inl">fx.Private</code>을 넣어야 감춰진다. <span class="ref">→ 슬라이드 17 · 22</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>I split things into <code class="inl">fx.Module</code>s by domain, yet another Module got the same DB handle injected. What did I miss?</span></button>
+              <div class="q-a"><code class="inl">fx.Private</code>. <code class="inl">Module</code> only groups under a name — the <code class="inl">Provide</code>s inside stay exposed to the global graph. Put <code class="inl">fx.Private</code> in that same <code class="inl">Provide</code> group to hide them. <span class="ref">→ Slide 17 · 22</span></div>
             </div>
           </div>
         </div>
-        <div class="notes-src">한 문제씩 열기 전에 3초쯤 기다린다. Q4는 오답이 많이 나오는 문제라 특히 천천히.</div>
+        <div class="notes-src">Wait about three seconds before opening each answer. Q4 draws the most wrong answers, so take that one especially slowly.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 31 퀴즈 2 ═══════════ -->
+    <!-- ═══════════ 31 Quiz 2 ═══════════ -->
     <div class="holder" data-n="31">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">확인</span><span class="stamp">클릭하면 답이 열립니다</span></div>
-        <h2 class="slide-title">스스로 답해보기 ②</h2>
+        <div class="slide-head"><span class="eyebrow">check</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Check yourself ②</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <div class="quiz">
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q6</span><span>기존 Repository 코드를 한 줄도 건드리지 않고 로깅을 붙이고 싶다.</span></button>
-              <div class="q-a"><code class="inl">fx.Decorate</code>다. 원본을 매개변수로 받아 래핑한 <b>같은 타입</b>을 반환하면 fx가 그래프의 해당 노드를 교체한다. 주입받는 쪽은 코드 변경 없이 래퍼를 받는다. <span class="ref">→ 슬라이드 18</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q6</span><span>I want to add logging without touching a line of the existing Repository code.</span></button>
+              <div class="q-a"><code class="inl">fx.Decorate</code>. Take the original as a parameter and return a wrapped value of the <b>same type</b>, and fx swaps that node in the graph. Whatever injects it receives the wrapper with no code change. <span class="ref">→ Slide 18</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q7</span><span>같은 <code class="inl">*DBConnection</code> 타입인 read용·write용 커넥션을 각각 주입받으려면?</span></button>
-              <div class="q-a"><code class="inl">fx.Annotate</code> + <code class="inl">fx.ResultTags</code>로 생성자마다 <code class="inl">name:"readDB"</code> 같은 이름을 붙이고, 수신 측은 <code class="inl">fx.In</code>을 임베드한 구조체 필드에 같은 태그를 단다. <span class="ref">→ 슬라이드 19</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q7</span><span>How do I inject a read and a write connection that are both <code class="inl">*DBConnection</code>?</span></button>
+              <div class="q-a">Tag each constructor with something like <code class="inl">name:"readDB"</code> using <code class="inl">fx.Annotate</code> + <code class="inl">fx.ResultTags</code>, then put the same tags on the fields of a receiving struct that embeds <code class="inl">fx.In</code>. <span class="ref">→ Slide 19</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q8</span><span><code class="inl">Notifier</code> 구현체가 셋인데 전부 한꺼번에 주입받고 싶다. <code class="inl">name:</code> 태그로 되나?</span></button>
-              <div class="q-a">되긴 하지만 나쁜 방법이다. 구현체가 늘 때마다 수신 코드를 고쳐야 한다. <code class="inl">group:"notifiers"</code>로 등록하고 <code class="inl">[]Notifier</code> 슬라이스로 받으면 수신 코드는 그대로다. <span class="ref">→ 슬라이드 20 · 21</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q8</span><span>I have three <code class="inl">Notifier</code> impls and want all of them injected at once. Will <code class="inl">name:</code> tags do?</span></button>
+              <div class="q-a">They will, but it is the wrong tool — you would edit the receiving code every time an implementation is added. Register with <code class="inl">group:"notifiers"</code> and receive a <code class="inl">[]Notifier</code> slice; the receiving code stays put. <span class="ref">→ Slide 20 · 21</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q9</span><span>테스트에서 <code class="inl">fx.Replace(&amp;mockUserRepo{})</code>만으로는 왜 부족한가?</span></button>
-              <div class="q-a">fx는 타입으로 매칭하는데 <code class="inl">&amp;mockUserRepo{}</code>의 타입은 <code class="inl">*mockUserRepo</code>이지 인터페이스가 아니기 때문이다. <code class="inl">fx.Annotate(..., fx.As(new(UserRepository)))</code>로 감싸야 교체된다. <span class="ref">→ 슬라이드 25</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q9</span><span>Why is <code class="inl">fx.Replace(&amp;mockUserRepo{})</code> alone not enough in a test?</span></button>
+              <div class="q-a">fx matches by type, and the type of <code class="inl">&amp;mockUserRepo{}</code> is <code class="inl">*mockUserRepo</code>, not the interface. Wrap it in <code class="inl">fx.Annotate(..., fx.As(new(UserRepository)))</code> for the replacement to take. <span class="ref">→ Slide 25</span></div>
             </div>
             <div class="q">
-              <button class="q-btn" type="button"><span class="q-n">Q10</span><span>조립된 인스턴스를 테스트로 꺼낼 때 <code class="inl">fx.Invoke</code>와 <code class="inl">fx.Populate</code> 중 무엇을 쓰나?</span></button>
-              <div class="q-a">본질은 같다 — <code class="inl">Populate</code>는 내부적으로 <code class="inl">Invoke</code>로 구현된 편의 함수다. 차이는 목적이다. 담는 것만이 목적이면 <code class="inl">Populate</code>, 꺼낸 뒤 호출·검증까지 하면 <code class="inl">Invoke</code>. <span class="ref">→ 슬라이드 26</span></div>
+              <button class="q-btn" type="button"><span class="q-n">Q10</span><span>To pull an assembled instance into a test, do I use <code class="inl">fx.Invoke</code> or <code class="inl">fx.Populate</code>?</span></button>
+              <div class="q-a">They are the same underneath — <code class="inl">Populate</code> is a convenience function built on <code class="inl">Invoke</code>. The difference is intent: if capturing is the whole goal use <code class="inl">Populate</code>; if you will call and assert afterwards use <code class="inl">Invoke</code>. <span class="ref">→ Slide 26</span></div>
             </div>
           </div>
         </div>
-        <div class="notes-src">Q9는 실제로 많이 겪는 함정이라 "당해보신 분?" 하고 물어보면 반응이 온다.</div>
+        <div class="notes-src">Q9 is a trap people really do hit, so asking "anyone been burned by this?" usually gets a reaction.</div>
       </section>
     </div>
 
-    <!-- ═══════════ 32 마무리 ═══════════ -->
+    <!-- ═══════════ 32 Closing ═══════════ -->
     <div class="holder" data-n="32">
       <section class="slide">
-        <div class="slide-head"><span class="eyebrow">끝</span><span class="stamp">thank you</span></div>
-        <h2 class="slide-title">오늘 정리</h2>
+        <div class="slide-head"><span class="eyebrow">end</span><span class="stamp">thank you</span></div>
+        <h2 class="slide-title">Today in summary</h2>
         <div class="rule"></div>
         <div class="slide-body">
           <ul class="bul">
-            <li>fx는 생성자의 <b>매개변수·반환 타입</b>만으로 의존성 그래프를 만든다 — 조립 순서를 코드에서 지운다</li>
-            <li><code class="inl">Provide</code>는 lazy 등록, <code class="inl">Invoke</code>는 eager 실행. <b>Invoke가 없으면 아무 일도 일어나지 않는다</b></li>
-            <li><code class="inl">Lifecycle</code>은 2단계다 — <code class="inl">New</code>에서 훅을 등록하고, <code class="inl">Start</code>에서 본문을 실행한다</li>
-            <li>앱이 커지면 <code class="inl">Module</code>로 묶고, <code class="inl">Decorate</code>로 덧씌우고, <code class="inl">name</code>/<code class="inl">group</code>으로 구분하고, <code class="inl">Private</code>으로 감춘다</li>
-            <li>테스트는 <code class="inl">fxtest</code> + <code class="inl">Replace</code>(<code class="inl">fx.As</code> 잊지 말 것) + <code class="inl">Populate</code></li>
-            <li>모든 것을 fx로 관리하지 않는다. <b>수명주기가 있는 컴포넌트</b>에 집중할 때 가장 빛난다</li>
+            <li>fx builds the dependency graph from nothing but constructors' <b>parameter and return types</b> — assembly order disappears from the code</li>
+            <li><code class="inl">Provide</code> is lazy registration, <code class="inl">Invoke</code> is eager execution. <b>Without Invoke, nothing happens</b></li>
+            <li><code class="inl">Lifecycle</code> has two stages — <code class="inl">New</code> registers the hooks, <code class="inl">Start</code> runs their bodies</li>
+            <li>As the app grows: group with <code class="inl">Module</code>, wrap with <code class="inl">Decorate</code>, distinguish with <code class="inl">name</code>/<code class="inl">group</code>, hide with <code class="inl">Private</code></li>
+            <li>Testing is <code class="inl">fxtest</code> + <code class="inl">Replace</code> (don't forget <code class="inl">fx.As</code>) + <code class="inl">Populate</code></li>
+            <li>Don't manage everything with fx. It shines brightest on <b>components that have a lifecycle</b></li>
           </ul>
           <div class="cols c-2">
             <div class="callout">
-              <span class="lbl">메서드별 학습 예제</span>
+              <span class="lbl">per-method examples</span>
               github.com/kenshin579/tutorials-go<br /><span class="dim">golang/third-party/fx</span>
             </div>
             <div class="callout teal">
-              <span class="lbl">실전 적용 (Clean Architecture)</span>
+              <span class="lbl">real-world use (Clean Architecture)</span>
               github.com/kenshin579/tutorials-go<br /><span class="dim">project-layout/go-clean-arch-v2</span>
             </div>
           </div>
         </div>
-        <div class="notes-src">저장소 주소를 띄워둔 채로 Q&amp;A를 받는다. 시간이 남으면 6번 지도 슬라이드로 돌아가 못 다룬 메서드를 짚어줘도 좋다.</div>
+        <div class="notes-src">Take Q&amp;A with the repository addresses left on screen. If time remains, go back to the map on slide 06 and touch on the methods you could not cover.</div>
       </section>
     </div>
 
@@ -1764,34 +1764,34 @@ fx.<span class="t-fn">Populate</span>(&amp;svc, &amp;logger)</pre>
   </div><!-- /stage-wrap -->
 
   <div class="notes" id="notes" aria-live="polite">
-    <div class="n-h">발표자 노트</div>
+    <div class="n-h">Speaker notes</div>
     <div id="notesBody"></div>
   </div>
 
   <div class="chrome">
-    <span class="deck-id">uber/fx 의존성 주입</span>
+    <span class="deck-id">uber/fx · Go DI</span>
     <div class="rail" id="rail"></div>
     <span class="counter" id="counter"><span class="cur">01</span> / 32</span>
     <div class="keys">
-      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="개요 (O)">개요</button>
-      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="발표자 노트 (N)">노트</button>
-      <button class="kbtn" id="btnTheme" type="button" title="테마 전환 (T)">테마</button>
-      <button class="kbtn" id="btnHelp" type="button" title="단축키 (?)">?</button>
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="Overview (O)">Overview</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="Speaker notes (N)">Notes</button>
+      <button class="kbtn" id="btnTheme" type="button" title="Toggle theme (T)">Theme</button>
+      <button class="kbtn" id="btnHelp" type="button" title="Shortcuts (?)">?</button>
     </div>
   </div>
 
   <div class="help" id="help">
     <div class="help-box">
-      <h3>단축키</h3>
+      <h3>Shortcuts</h3>
       <dl>
-        <dt>→ · Space · PgDn</dt><dd>다음 슬라이드</dd>
-        <dt>← · PgUp</dt><dd>이전 슬라이드</dd>
-        <dt>Home · End</dt><dd>처음 · 마지막</dd>
-        <dt>O</dt><dd>전체 슬라이드 개요</dd>
-        <dt>N</dt><dd>발표자 노트</dd>
-        <dt>T</dt><dd>밝은 테마 / 어두운 테마</dd>
-        <dt>F</dt><dd>전체 화면</dd>
-        <dt>Esc</dt><dd>닫기</dd>
+        <dt>→ · Space · PgDn</dt><dd>Next slide</dd>
+        <dt>← · PgUp</dt><dd>Previous slide</dd>
+        <dt>Home · End</dt><dd>First · Last</dd>
+        <dt>O</dt><dd>Slide overview</dd>
+        <dt>N</dt><dd>Speaker notes</dd>
+        <dt>T</dt><dd>Light / dark theme</dd>
+        <dt>F</dt><dd>Fullscreen</dd>
+        <dt>Esc</dt><dd>Close</dd>
       </dl>
     </div>
   </div>
@@ -1819,7 +1819,7 @@ fx.<span class="t-fn">Populate</span>(&amp;svc, &amp;logger)</pre>
   var ticks = holders.map(function (h, i) {
     var t = document.createElement("span");
     t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
-    t.title = "슬라이드 " + (i + 1);
+    t.title = "Slide " + (i + 1);
     t.addEventListener("click", function () { go(i); });
     rail.appendChild(t);
     return t;


### PR DESCRIPTION
## Summary

슬라이드가 있는 글에 **영문 데크(`slides_en.html`)** 를 만들 수 있게 `generate-slides` 스킬을 확장하고, `go/go-fx-의존성-주입` 에 시범 적용했다.

빌드 파이프라인은 이미 `slides_en.html` 을 지원하고 있었지만(`scripts/copy-assets.ts:43`, `scripts/generate-content-manifest.ts:91`) 이를 만드는 절차가 없어서 실제 파일이 0개였고, 그래서 `/en/slides` 목록이 빈 상태였다.

### 왜 새 스킬이 아니라 기존 스킬 확장인가

절차의 대부분(엔진 템플릿, 번호 검증, 넘침 검사, 빌드 확인)이 그대로 재사용된다. 달라지는 건 **소스가 글이 아니라 기존 `slides.html`** 이라는 점, 번역 규칙이 `translate-article-en` 을 따른다는 점, 마커가 `index_en.md` 로 간다는 점 셋뿐이다.

## 스킬 변경 (`.claude/skills/generate-slides/SKILL.md`)

「영문 데크 (slides_en.html)」 절을 신설했다. 핵심 원칙은 **글에서 새로 설계하지 않고 기존 한국어 데크를 번역한다** — 구조·장수·번호·액센트를 그대로 두고 텍스트만 바꾼다. 그래야 두 데크가 같은 발표로 남는다.

1. 세 조각으로 분리 (head=CSS / 본문 / tail=chrome·JS) — 엔진을 손으로 옮기면 반드시 어긋난다
2. 본문만 번역 — `data-n`·class·하이라이팅 `<span>` 은 그대로, 발표자 노트도 전부
3. head·tail 의 정해진 자리 치환 — `lang`, `<title>`, `deck-id`, 버튼 4개, 도움말 `<dd>` 8개, JS 의 `"슬라이드 "` → `"Slide "`
4. 병합 후 검증 — 번호·카운터·퀴즈 참조(`→ Slide NN`), 주석 밖 한글 잔여 검사
5. `index_en.md` 에 마커 — 데크를 만든 뒤에만
6. **넘침 재검사** — 영어가 길어 새로 넘치는 장이 생긴다. 하단 크롬 가로 넘침도 함께

부수 갱신: `description`, When to Use, Common Mistakes 4항목 추가. 「엔진을 고쳐야 할 때」의 복사본 목록이 실제와 어긋나 있어(2벌로 기재, 실제 8벌) `find` 명령으로 대체하고 임계 초과 사실을 명시했다.

### 설계 판단: 엔진 주석은 번역하지 않는다

엔진의 한국어 CSS/JS 주석은 그대로 뒀다. 화면에 노출되지 않고, 엔진이 두 데크 간 바이트 동일해야 나중에 엔진을 고칠 때 diff 가 깨끗하다. 근거를 스킬에 적어뒀다.

## 시범 적용 (`go/go-fx-의존성-주입`)

- `slides_en.html` 신규 (32장, 한국어판과 동일 구조)
- `index_en.md` 에 `<!-- slides -->` 마커 삽입

### 딸려온 수정

번역하면서 원본 한국어 데크의 슬라이드 오참조를 발견해 함께 고쳤다.

| 위치 | 잘못된 참조 | 실제 |
|---|---|---|
| 17번 본문 callout | `23번의 fx.Private` | 22번 |
| 22번 발표자 노트 | `16번에서 심어둔` | 17번 |

## Test plan

전부 실측 완료.

- [x] 넘침 검사 — 영문 32장 `overflowing: []`
- [x] 넘침 검사 — 한국어 32장 회귀 `overflowing: []`
- [x] 번호 연속성 01–32, 카운터 `/ 32` 일치
- [x] 크롬 가로 넘침 0, `deck-id` 잘림 없음
- [x] `npm run build` → `Slides copied: 8` (기존 7 + 영문 1)
- [x] `out/en/go-fx-의존성-주입/slides/index.html` 생성, 돌아가기 링크 `← Article`
- [x] 영문 글 임베드 `src=/en/go-fx-의존성-주입/slides/`, 위치는 `1. Introduction` 뒤 · `2. fx Basics` 앞
- [x] `/en/slides` 에 카드 1개 (`1 slide deck`, 32 slides)
- [x] 전 파일 UTF-8

## 별건 (이 PR 범위 밖)

`/en/slides` 의 날짜가 한국어 형식으로 나온다(`2026년 5월 24일`). `lib/utils.ts:11` 의 `formatDate` 가 하드코딩이고 영문 홈·시리즈 페이지도 전부 같은 상태다. 사이트 전역의 기존 동작이라 이번 변경과 무관해서 손대지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)