### PR TITLE
feat: 나머지 6개 글에 영문 슬라이드 데크 추가

### DIFF
--- a/contents/cloud/grafana-완벽-가이드-1-prometheus와-grafana-기초/index_en.md
+++ b/contents/cloud/grafana-완벽-가이드-1-prometheus와-grafana-기초/index_en.md
@@ -53,6 +53,8 @@ Here is what this article covers.
 
 > The full code used in this article is available on [GitHub](https://github.com/kenshin579/tutorials-go/tree/master/monitoring/grafana-metrics).
 
+<!-- slides -->
+
 # 2. Prometheus Core Concepts
 
 ## 2.1 Architecture — Pull-based Metric Collection

--- a/contents/cloud/grafana-완벽-가이드-1-prometheus와-grafana-기초/slides_en.html
+++ b/contents/cloud/grafana-완벽-가이드-1-prometheus와-grafana-기초/slides_en.html
@@ -1,0 +1,2357 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Prometheus and Grafana Basics — Complete Grafana Guide Part 1</title>
+<style>
+/* ─────────────────────────────────────────────────────────────
+   계기판(instrument panel) — 차가운 슬레이트 바탕 위 따뜻한 표시등
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #C24A12;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(194, 74, 18, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+
+  --f-display: "Avenir Next", "Apple SD Gothic Neo", "Helvetica Neue", system-ui, sans-serif;
+  --f-body:    "Apple SD Gothic Neo", -apple-system, "Helvetica Neue", "Noto Sans KR", sans-serif;
+  --f-mono:    "MesloLGS NF", "SF Mono", ui-monospace, Menlo, "D2Coding", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0E1117;
+    --surface:   #161B23;
+    --surface-2: #1B212A;
+    --ink:       #E6E9EE;
+    --ink-dim:   #98A2B0;
+    --ink-faint: #6B7688;
+    --line:      #272F3A;
+    --line-soft: #1E252E;
+    --grid:      rgba(255, 255, 255, .038);
+    --accent:    #FF7A45;
+    --accent-ink:#170A03;
+    --accent-soft: rgba(255, 122, 69, .14);
+    --teal:      #46C7B0;
+    --teal-soft: rgba(70, 199, 176, .13);
+    --amber:     #E8B84B;
+    --red:       #F0625E;
+    --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg:        #0E1117;
+  --surface:   #161B23;
+  --surface-2: #1B212A;
+  --ink:       #E6E9EE;
+  --ink-dim:   #98A2B0;
+  --ink-faint: #6B7688;
+  --line:      #272F3A;
+  --line-soft: #1E252E;
+  --grid:      rgba(255, 255, 255, .038);
+  --accent:    #FF7A45;
+  --accent-ink:#170A03;
+  --accent-soft: rgba(255, 122, 69, .14);
+  --teal:      #46C7B0;
+  --teal-soft: rgba(70, 199, 176, .13);
+  --amber:     #E8B84B;
+  --red:       #F0625E;
+  --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+}
+
+:root[data-theme="light"] {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #C24A12;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(194, 74, 18, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ── 무대: 1280×720 고정, 뷰포트에 맞춰 축소 ───────────────── */
+.stage-wrap {
+  position: fixed;
+  inset: 0 0 52px 0;
+  display: grid;
+  /* 가운데 정렬은 fit() 이 translate 로 직접 한다. grid 중앙 정렬에 맡기면
+     무대가 뷰포트보다 클 때 safe alignment 로 좌상단에 고정되어 계산이 어긋난다. */
+  place-items: start;
+  overflow: hidden;
+}
+.stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  transform-origin: 0 0;
+  flex: none;
+}
+.holder {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .22s ease;
+}
+.holder.is-active { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .holder { transition: none; } }
+
+.slide {
+  width: 1280px;
+  height: 720px;
+  padding: 52px 68px 56px;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 40px,
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px) 0 0 / 40px 100%,
+    var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.slide::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0 34%, var(--line) 34% 100%);
+  opacity: .55;
+}
+
+/* ── 슬라이드 머리 ─────────────────────────────────────────── */
+.slide-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  flex: none;
+}
+.eyebrow {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+}
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+}
+.slide-title {
+  font-family: var(--f-display);
+  font-size: 42px;
+  line-height: 1.16;
+  font-weight: 700;
+  letter-spacing: -.022em;
+  margin: 0 0 6px;
+  text-wrap: balance;
+}
+.slide-title .em { color: var(--accent); }
+.slide-lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0 0 4px;
+  max-width: 72ch;
+}
+.rule {
+  height: 1px;
+  background: var(--line);
+  margin: 18px 0 22px;
+  flex: none;
+}
+.slide-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  font-size: 19px;
+  line-height: 1.6;
+}
+.slide-body.top { justify-content: flex-start; }
+
+/* ── 공용 조판 ─────────────────────────────────────────────── */
+.cols { display: grid; gap: 30px; align-items: start; }
+.c-2  { grid-template-columns: 1fr 1fr; }
+.c-2a { grid-template-columns: 1.15fr .85fr; }
+.c-2b { grid-template-columns: .82fr 1.18fr; }
+.c-3  { grid-template-columns: repeat(3, 1fr); }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.stack.tight { gap: 10px; }
+.grow { flex: 1; min-height: 0; }
+/* 높이를 채우는 2단 조판에서는 각 열이 늘어나고, 내용은 열 안에서 세로 중앙에 놓인다 */
+.cols.grow { align-items: stretch; }
+.cols.grow > .stack { justify-content: center; }
+
+ul.bul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 13px; }
+ul.bul > li { position: relative; padding-left: 26px; }
+ul.bul > li::before {
+  content: "";
+  position: absolute;
+  left: 4px; top: .62em;
+  width: 9px; height: 2px;
+  background: var(--accent);
+}
+ul.bul.teal > li::before { background: var(--teal); }
+.dim { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.hl { color: var(--accent); font-weight: 600; }
+.hl-teal { color: var(--teal); font-weight: 600; }
+b, strong { font-weight: 700; }
+
+/* ── 표 ────────────────────────────────────────────────────── */
+.tbl-wrap { overflow-x: auto; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink-faint);
+  padding: 0 14px 9px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: 11px 14px 11px 0;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  line-height: 1.45;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td:first-child { font-weight: 600; white-space: nowrap; }
+table.tbl.sm { font-size: 15.5px; }
+table.tbl.sm td { padding: 8px 12px 8px 0; }
+table.tbl tr.on td { background: var(--accent-soft); }
+table.tbl tr.on td:first-child { color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); padding-left: 12px; }
+.num-col { font-family: var(--f-mono); }
+
+/* ── 코드 ──────────────────────────────────────────────────── */
+.code {
+  font-family: var(--f-mono);
+  font-size: 15.5px;
+  line-height: 1.72;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+  padding: 14px 18px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+  tab-size: 2;
+}
+.code.sm { font-size: 14px; line-height: 1.66; padding: 12px 15px; }
+.code.xs { font-size: 12.6px; line-height: 1.6; padding: 11px 14px; }
+.code.plain { border-left-color: var(--line); }
+.code.teal { border-left-color: var(--teal); }
+.t-fn  { color: var(--accent); }
+.t-str { color: var(--teal); }
+.t-cm  { color: var(--ink-faint); }
+.t-num { color: var(--ink); font-weight: 600; }
+.t-key { color: var(--accent); font-weight: 600; }
+.t-bad { color: var(--red); }
+code.inl {
+  font-family: var(--f-mono);
+  font-size: .88em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  white-space: nowrap;
+}
+
+/* ── 카드 / 콜아웃 ─────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.card-t {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+.callout {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 14px 20px;
+  border-radius: 0 3px 3px 0;
+  font-size: 18px;
+  line-height: 1.55;
+}
+.callout.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+.callout .lbl {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.callout.teal .lbl { color: var(--teal); }
+
+/* ── 그림 ──────────────────────────────────────────────────── */
+.figure { display: flex; flex-direction: column; justify-content: center; gap: 10px; min-height: 0; }
+.figure img {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: var(--shadow);
+  background: var(--surface-2);
+}
+.figure figcaption, .cap {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.fit img { max-height: 100%; }
+
+/* ── 아키텍처 다이어그램 ───────────────────────────────────── */
+.arch {
+  display: grid;
+  grid-template-columns: 1fr 104px 1.02fr 104px 1fr;
+  align-items: center;
+  gap: 0;
+}
+.arch-col { display: flex; flex-direction: column; gap: 11px; }
+.node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 4px;
+  padding: 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.node .n-t { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.node .n-p { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-faint); }
+.node.hero {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  padding: 20px 18px;
+}
+.node.hero .n-t { font-size: 22px; color: var(--accent); }
+.node.hero .n-p { color: var(--ink-dim); }
+.node.mute { border-style: dashed; background: transparent; }
+.arch-link { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.arch-link .l-lbl {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.arch-link .l-line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  position: relative;
+}
+.arch-link .l-line::after {
+  content: "";
+  position: absolute;
+  right: 8px; top: -4px;
+  border: 4.5px solid transparent;
+  border-left-color: var(--accent);
+}
+
+/* ── 트리 ──────────────────────────────────────────────────── */
+.tree { font-family: var(--f-mono); font-size: 15px; line-height: 2.05; }
+.tree .lv { display: block; white-space: pre; }
+.tree .k { color: var(--accent); font-weight: 600; }
+.tree .v { color: var(--ink-dim); }
+
+/* ── 쿼리 해부도 ───────────────────────────────────────────── */
+.anat { display: flex; flex-direction: column; gap: 14px; }
+.anat-q {
+  font-family: var(--f-mono);
+  font-size: 24px;
+  letter-spacing: -.01em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.anat-q .p { padding: 3px 2px; border-bottom: 2px solid transparent; }
+.anat-q .p1 { border-bottom-color: var(--accent); }
+.anat-q .p2 { border-bottom-color: var(--teal); }
+.anat-q .p3 { border-bottom-color: var(--amber); }
+.anat-q .p4 { border-bottom-color: var(--ink-faint); }
+.legend { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.legend .lg-i { display: flex; flex-direction: column; gap: 4px; }
+.legend .lg-b { height: 3px; width: 34px; }
+.legend .lg-n { font-size: 15px; font-weight: 700; }
+.legend .lg-d { font-size: 14px; color: var(--ink-dim); line-height: 1.42; }
+
+/* ── 카디널리티 계산기 ─────────────────────────────────────── */
+.odo-row { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.odo {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 62px;
+  font-weight: 700;
+  letter-spacing: -.03em;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.odo.sm { font-size: 34px; color: var(--ink); }
+.odo-cap { font-size: 15px; color: var(--ink-dim); }
+.factor {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-family: var(--f-mono);
+  font-size: 19px;
+  color: var(--ink-dim);
+}
+.factor b { color: var(--ink); font-size: 22px; }
+
+/* ── 단계 목록 ─────────────────────────────────────────────── */
+.steps { display: flex; flex-direction: column; gap: 0; }
+.step {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.step:last-child { border-bottom: none; }
+.step .s-n {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 600;
+  padding-top: 3px;
+}
+.step .s-c { font-family: var(--f-mono); font-size: 14.5px; color: var(--ink); }
+.step .s-d { font-size: 15.5px; color: var(--ink-dim); line-height: 1.45; margin-top: 3px; }
+
+/* ── 표지 ──────────────────────────────────────────────────── */
+.cover { display: grid; grid-template-columns: 1.06fr .94fr; gap: 46px; align-items: center; height: 100%; }
+.cover-title {
+  font-family: var(--f-display);
+  font-size: 62px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -.032em;
+  margin: 14px 0 18px;
+  text-wrap: balance;
+}
+.cover-sub { font-size: 21px; color: var(--ink-dim); line-height: 1.5; margin: 0 0 30px; }
+.cover-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .06em;
+}
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+.panel-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+.panel-body { padding: 12px 8px 8px; }
+.panel canvas { display: block; width: 100%; height: 232px; }
+.panel-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 9px 15px 13px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 챕터 구분 ─────────────────────────────────────────────── */
+.slide[data-kind="chapter"] { justify-content: center; }
+.chap { display: grid; grid-template-columns: auto 1fr; gap: 46px; align-items: center; }
+.chap-n {
+  font-family: var(--f-mono);
+  font-size: 168px;
+  font-weight: 700;
+  line-height: .82;
+  letter-spacing: -.06em;
+  color: var(--accent);
+}
+.chap-t {
+  font-family: var(--f-display);
+  font-size: 50px;
+  font-weight: 700;
+  letter-spacing: -.028em;
+  line-height: 1.12;
+  margin: 0 0 14px;
+}
+.chap-d { font-size: 19px; color: var(--ink-dim); line-height: 1.55; margin: 0; max-width: 56ch; }
+.chap-l { border-left: 1px solid var(--line); padding-left: 46px; }
+
+/* ── 퀴즈 ──────────────────────────────────────────────────── */
+.quiz { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 20px; }
+.q {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.q-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 16.5px;
+  line-height: 1.42;
+  font-weight: 600;
+}
+.q-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+.q-btn .q-n { font-family: var(--f-mono); font-size: 12.5px; color: var(--accent); flex: none; }
+.q-a {
+  display: none;
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line-soft);
+  padding-top: 9px;
+}
+.q.is-open .q-a { display: block; }
+.q-a .ref { font-family: var(--f-mono); font-size: 12px; color: var(--ink-faint); }
+
+/* ── 토글 (Counter 슬라이드) ───────────────────────────────── */
+.toggle { display: flex; gap: 8px; }
+.tg {
+  all: unset;
+  cursor: pointer;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.tg[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.tg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.swap > .swap-i { display: none; }
+.swap > .swap-i.on { display: flex; }
+.swap > img.swap-i.on { display: block; }
+
+/* ── 하단 크롬 ─────────────────────────────────────────────── */
+.chrome {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  background: var(--bg);
+  border-top: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.chrome .deck-id { text-transform: uppercase; white-space: nowrap; }
+.rail { flex: 1; display: flex; gap: 2px; align-items: center; height: 22px; min-width: 0; }
+.tick { flex: 1; height: 4px; background: var(--line); border-radius: 1px; transition: background .18s ease, height .18s ease; }
+.tick.done { background: var(--ink-faint); }
+.tick.now  { background: var(--accent); height: 14px; }
+.tick.chap { height: 10px; }
+.counter { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--ink-dim); }
+.counter .cur { color: var(--accent); font-weight: 600; }
+.keys { display: flex; gap: 6px; }
+.kbtn {
+  all: unset;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 4px 8px;
+  color: var(--ink-dim);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+}
+.kbtn:hover { border-color: var(--accent); color: var(--accent); }
+.kbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.kbtn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+/* ── 발표자 노트 ───────────────────────────────────────────── */
+.notes-src { display: none; }
+.notes {
+  position: fixed;
+  left: 0; right: 0; bottom: 52px;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 16px 22px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  display: none;
+  z-index: 19;
+}
+.notes.on { display: block; }
+.notes .n-h {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+/* ── 개요(썸네일) 모드 ─────────────────────────────────────── */
+.deck.is-overview .stage-wrap { place-items: start center; overflow: auto; padding: 24px 18px; }
+.deck.is-overview .stage {
+  width: 100%; height: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 256px);
+  gap: 16px;
+  justify-content: center;
+}
+.deck.is-overview .holder {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  visibility: visible;
+  width: 256px;
+  height: 144px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deck.is-overview .holder.is-active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.deck.is-overview .holder::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 5px; bottom: 4px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  color: var(--ink-faint);
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.deck.is-overview .slide {
+  position: absolute;
+  top: 0; left: 0;
+  transform: scale(.2);
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+/* ── 도움말 ────────────────────────────────────────────────── */
+.help {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  display: none;
+  place-items: center;
+  z-index: 40;
+  padding: 24px;
+}
+.help.on { display: grid; }
+.help-box {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  padding: 26px 30px;
+  min-width: 360px;
+}
+.help-box h3 {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.help-box dl { display: grid; grid-template-columns: auto 1fr; gap: 9px 20px; margin: 0; font-size: 15px; }
+.help-box dt { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.help-box dd { margin: 0; color: var(--ink-dim); }
+
+/* ── 인쇄 ──────────────────────────────────────────────────── */
+@media print {
+  @page { size: 1280px 720px; margin: 0; }
+  body { overflow: visible; background: #fff; }
+  .chrome, .notes, .help { display: none !important; }
+  .stage-wrap { position: static; display: block; inset: auto; overflow: visible; }
+  .stage { width: auto; height: auto; transform: none !important; display: block; }
+  .holder { position: static; opacity: 1; visibility: visible; break-after: page; }
+  .slide { box-shadow: none; }
+}
+</style>
+</head>
+<body>
+
+<div class="deck" id="deck">
+  <div class="stage-wrap" id="stageWrap">
+    <div class="stage" id="stage">
+    <!-- ═══════════ 01 cover ═══════════ -->
+    <div class="holder" data-n="01">
+      <section class="slide" data-kind="cover">
+        <div class="cover">
+          <div>
+            <div class="eyebrow">Complete Grafana Guide · Part 1 / 4</div>
+            <h1 class="cover-title">Prometheus and<br />Grafana Basics</h1>
+            <p class="cover-sub">Collect the numbers, ask questions, draw them<br />— one lap around a minimal metrics setup</p>
+            <div class="cover-meta">
+              <span class="chip on">Metrics</span>
+              <span class="chip">PromQL</span>
+              <span class="chip">Grafana Dashboard</span>
+              <span class="chip">docker-compose</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-head">
+              <span><span class="dot"></span>CPU usage</span>
+              <span>last 30m</span>
+            </div>
+            <div class="panel-body"><canvas id="heroCanvas" width="1000" height="464"></canvas></div>
+            <div class="panel-foot">
+              <span>100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Greet the room and note this is part 1 of 4. Say up front that the panel on the right is what they will build themselves by the end of today.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 02 problem ═══════════ -->
+    <div class="holder" data-n="02">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">problem</span><span class="stamp">why monitoring</span></div>
+        <h2 class="slide-title">By the time you type <code class="inl">top</code>, it's too late</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>You hear the service got slow and ssh into the box</li>
+              <li>You can see what the CPU is doing <b>right now</b></li>
+              <li>There is no way to know what it looked like <b>30 minutes ago</b></li>
+              <li>Finding the cause needs past numbers, and they were never kept anywhere</li>
+            </ul>
+            <pre class="code sm plain"><span class="t-cm">$</span> top
+<span class="t-cm">Processes: 612 total, 3 running</span>
+<span class="t-cm">CPU usage: </span><span class="t-num">78.4%</span><span class="t-cm"> user, 9.1% sys</span>
+
+<span class="t-cm"># so what about 30 minutes ago?</span>
+<span class="t-bad">…no record</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">What monitoring does</span>
+            <b>Keep piling up</b> the numbers so you can <b>rewind</b> them later.
+          </div>
+        </div>
+        <div class="notes-src">A slide that builds rapport through shared experience. Asking “who here has run top after an incident?” for a show of hands works well. The point is history, not the live value.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 03 Observability ═══════════ -->
+    <div class="holder" data-n="03">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">background</span><span class="stamp">observability</span></div>
+        <h2 class="slide-title">Observability splits into three kinds of data</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Pillar</th><th>What it is</th><th>Typical tools</th><th>Today</th></tr></thead>
+              <tbody>
+                <tr class="on"><td>Metrics</td><td>Numbers over time — CPU, memory, request counts</td><td>Prometheus, Datadog</td><td>covered</td></tr>
+                <tr><td>Logs</td><td>Event records — error messages, request logs</td><td>Loki, ELK Stack</td><td class="faint">not covered</td></tr>
+                <tr><td>Traces</td><td>Request paths — calls between services</td><td>Tempo, Jaeger</td><td class="faint">Part 3</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Today's scope</span>
+            <b>Metrics</b> only. Collecting numbers with Prometheus and drawing them with Grafana.
+          </div>
+        </div>
+        <div class="notes-src">Do not try to explain all three. Draw the line — “logs and traces belong to other parts” — and move on. Just remember logs come back in the cardinality slide (15).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 04 series roadmap ═══════════ -->
+    <div class="holder" data-n="04">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">series</span><span class="stamp">4 parts</span></div>
+        <h2 class="slide-title">Where today sits in the series</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Part</th><th>Title</th><th>Area</th></tr></thead>
+              <tbody>
+                <tr class="on"><td>Part 1</td><td>Prometheus and Grafana Basics</td><td>Metrics basics</td></tr>
+                <tr><td>Part 2</td><td>Custom Metrics in a Go Application</td><td>Metrics in depth</td></tr>
+                <tr><td>Part 3</td><td>Distributed Tracing with Grafana Tempo</td><td>Traces</td></tr>
+                <tr><td>Part 4</td><td>Continuous Profiling with Grafana Pyroscope</td><td>Profiles</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="dim" style="margin:0;font-size:17px;">Some screens today borrow metrics from the sample app built in part 2.
+          The environment we set up today shows <code class="inl">node-exporter</code> and Prometheus' own metrics.</p>
+        </div>
+        <div class="notes-src">Saying up front that the Counter/Histogram/Summary screenshots come from the Go sample app in part 2 prevents “why can't I see this?” questions later.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 05 agenda ═══════════ -->
+    <div class="holder" data-n="05">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">contents</span><span class="stamp">agenda</span></div>
+        <h2 class="slide-title">What we cover today</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <p class="card-t">01 — Prometheus core concepts</p>
+              <ul class="bul" style="font-size:17px;">
+                <li>Pull-based architecture</li>
+                <li>The four metric types</li>
+                <li>Labels, time series, cardinality</li>
+              </ul>
+            </div>
+            <div class="card">
+              <p class="card-t">02 — PromQL</p>
+              <ul class="bul" style="font-size:17px;">
+                <li>The four pieces of a query</li>
+                <li>instant vector vs range vector</li>
+                <li>Three real queries, dissected</li>
+              </ul>
+            </div>
+            <div class="card">
+              <p class="card-t">03 — Grafana</p>
+              <ul class="bul" style="font-size:17px;">
+                <li>Connecting a Data Source</li>
+                <li>Dashboard · Row · Panel · Query</li>
+                <li>Reusing dashboards with Variables</li>
+              </ul>
+            </div>
+            <div class="card">
+              <p class="card-t">04 — Hands-on setup</p>
+              <ul class="bul" style="font-size:17px;">
+                <li>One docker-compose file to run it all</li>
+                <li>Scraping node-exporter metrics</li>
+                <li>A four-panel system dashboard</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Chapters 1 and 2 are concepts, 3 and 4 are hands-on. If time runs short, trim the real-world queries (24–26) and protect chapter 4.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 06 chapter 1 ═══════════ -->
+    <div class="holder" data-n="06" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">01</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Prometheus core concepts</h2>
+            <p class="chap-d">How metrics come in, and what shape they are stored in.
+            Get this and PromQL and dashboards are just stories told on top of it.</p>
+          </div>
+        </div>
+        <div class="notes-src">This chapter is the root of the talk. Do not rush the definition of “one time series” (14) and cardinality (15) — they are what prevent accidents later.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 07 architecture ═══════════ -->
+    <div class="holder" data-n="07">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Prometheus</span><span class="stamp">architecture</span></div>
+        <h2 class="slide-title">It <span class="em">fetches</span> metrics itself — the Pull model</h2>
+        <p class="slide-lede">As long as a target exposes a <code class="inl">/metrics</code> HTTP endpoint, Prometheus calls that address on a schedule (scrape) and pulls the values. The target never has to know where to send anything.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Node Exporter</span><span class="n-p">:9100/metrics</span></div>
+              <div class="node"><span class="n-t">Go Application</span><span class="n-p">:8080/metrics</span></div>
+              <div class="node"><span class="n-t">MySQL Exporter</span><span class="n-p">:9104/metrics</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">scrape</span><span class="l-line"></span><span class="l-lbl">every 15s</span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">Prometheus</span><span class="n-p">:9090 · TSDB · PromQL engine</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">query</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Grafana</span><span class="n-p">:3000 · dashboards</span></div>
+              <div class="node"><span class="n-t">Alertmanager</span><span class="n-p">:9093 · alert rules</span></div>
+              <div class="node mute"><span class="n-t">Slack / Email</span><span class="n-p">notify</span></div>
+            </div>
+          </div>
+          <p class="cap">The arrows show <b>which way the data flows</b>. The calls go the other way — Prometheus calls each target's <code class="inl">/metrics</code>.</p>
+        </div>
+        <div class="notes-src">Calling an exporter a “translator” lands well: it turns a system's state into text Prometheus can read. Today's lab runs only node-exporter.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 08 Pull vs Push ═══════════ -->
+    <div class="holder" data-n="08">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Prometheus</span><span class="stamp">pull vs push</span></div>
+        <h2 class="slide-title">What Pull and Push trade away</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Aspect</th><th>Pull — Prometheus</th><th>Push — Datadog, InfluxDB</th></tr></thead>
+              <tbody>
+                <tr><td>Data flow</td><td>Server fetches from targets</td><td>Targets send to the server</td></tr>
+                <tr><td>Service discovery</td><td>Needed — must know what to scrape</td><td>Not needed — targets send directly</td></tr>
+                <tr><td>Network</td><td>Server → target reachability</td><td>Target → server reachability</td></tr>
+                <tr><td>Upside</td><td class="hl">Target health for free — failed scrape = down</td><td>Works behind a firewall</td></tr>
+                <tr><td>Downside</td><td>Hard to scrape targets behind firewalls</td><td>Missing data from a dead target is hard to spot</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">One line to remember</span>
+            With Push, when a target goes quiet you cannot tell <b>an outage from no traffic</b>. With Pull, the failed call is itself the signal.
+          </div>
+        </div>
+        <div class="notes-src">Directly tied to quiz Q1. You can also mention the exception: short-lived workloads such as Kubernetes CronJobs suit Pull poorly, and that is what Pushgateway is for.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 09 metric types overview ═══════════ -->
+    <div class="holder" data-n="09">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Prometheus</span><span class="stamp">metric types</span></div>
+        <h2 class="slide-title">There are only four metric types</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Type</th><th>Behavior</th><th>Example use</th><th>Key functions</th></tr></thead>
+              <tbody>
+                <tr><td>Counter</td><td>Only goes up (back to 0 on restart)</td><td>HTTP request count, error count</td><td class="num-col">rate(), increase()</td></tr>
+                <tr><td>Gauge</td><td>Goes up and down</td><td>CPU usage, memory, active connections</td><td class="num-col">read directly, avg_over_time()</td></tr>
+                <tr><td>Histogram</td><td>Spreads values across buckets</td><td>Response time, request size</td><td class="num-col">histogram_quantile()</td></tr>
+                <tr><td>Summary</td><td>Stores pre-computed quantiles</td><td>Response time (client-side)</td><td class="num-col">read directly</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">In practice</span>
+            You will not use all four. The two you actually reach for are <b>Counter</b> and <b>Histogram</b>.
+          </div>
+        </div>
+        <div class="notes-src">Just skim the table here. Announce that the next five slides show each type on a real graph.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 10 Counter (toggle) ═══════════ -->
+    <div class="holder" data-n="10">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · metric types</span><span class="stamp">counter</span></div>
+        <h2 class="slide-title">Counter — the answer is the <span class="em">slope</span>, not the value</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <div class="toggle">
+                <button class="tg" type="button" data-swap="cnt" data-target="raw" aria-pressed="true">raw cumulative</button>
+                <button class="tg" type="button" data-swap="cnt" data-target="rate" aria-pressed="false">with rate()</button>
+              </div>
+              <div class="swap" data-swap-group="cnt">
+                <div class="swap-i on stack tight" data-swap-item="raw">
+                  <pre class="code sm">http_requests_total</pre>
+                  <p class="dim" style="margin:0;font-size:16.5px;line-height:1.5;">All you can read is “it keeps going up”.
+                  The drop to the floor at 14:11 is an <b>application restart</b>.</p>
+                </div>
+                <div class="swap-i stack tight" data-swap-item="rate">
+                  <pre class="code sm"><span class="t-fn">rate</span>(http_requests_total[<span class="t-num">5m</span>])</pre>
+                  <p class="dim" style="margin:0;font-size:16.5px;line-height:1.5;">5–10 per second — the real traffic shows.
+                  The line stays smooth across the restart — <b>counter resets are corrected automatically</b>.</p>
+                </div>
+              </div>
+              <div class="callout">
+                <span class="lbl">Rule</span>
+                See a Counter, think <code class="inl">rate()</code> first.
+              </div>
+            </div>
+            <div class="figure fit swap" data-swap-group="cnt">
+              <img class="swap-i on" data-swap-item="raw" src="counter-cumulative.png" alt="Grafana panel plotting the raw cumulative http_requests_total" />
+              <img class="swap-i" data-swap-item="rate" src="counter-rate.png" alt="Grafana panel showing the per-second rate computed with rate()" />
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Click both buttons to compare two faces of the same data. Asking the audience “can you read the current request rate off the cumulative graph?” before switching to rate() lands hard. Ties to quiz Q2.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 11 Gauge ═══════════ -->
+    <div class="holder" data-n="11">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · metric types</span><span class="stamp">gauge</span></div>
+        <h2 class="slide-title">Gauge — the value itself is the answer</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <ul class="bul">
+                <li>It is the value at this instant, so it <b>goes up and down</b></li>
+                <li>CPU usage, memory used, active connections</li>
+                <li>Unlike a Counter, there is no reason to wrap it in <code class="inl">rate()</code></li>
+              </ul>
+              <pre class="code sm"><span class="t-cm"># in-flight requests right now</span>
+http_requests_in_flight
+
+<span class="t-cm"># 5-minute average</span>
+<span class="t-fn">avg_over_time</span>(node_cpu_seconds_total{<span class="t-str">mode="idle"</span>}[<span class="t-num">5m</span>])</pre>
+              <p class="cap">Here too you can see memory dip at the 14:11 restart and fill back up.</p>
+            </div>
+            <div class="figure fit">
+              <img src="gauge-memory.png" alt="Gauge panel showing memory in use" />
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The most intuitive type, so move fast. But slide 23 has the trap that rate() on a Gauge raises no error, so drive “no reason to use it” home here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 12 Histogram ═══════════ -->
+    <div class="holder" data-n="12">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · metric types</span><span class="stamp">histogram</span></div>
+        <h2 class="slide-title">Histogram — buckets are <span class="em">cumulative</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <ul class="bul">
+                <li>Stores only <b>counts per bucket</b>; percentiles are computed at query time</li>
+                <li><code class="inl">le="0.5"</code> means <b>everything under 0.5s</b>, not the 0.25–0.5s slice</li>
+                <li>For the distribution, set the panel format to <code class="inl">Heatmap</code></li>
+              </ul>
+              <pre class="code sm"><span class="t-cm"># P99 response time</span>
+<span class="t-fn">histogram_quantile</span>(<span class="t-num">0.99</span>,
+  <span class="t-fn">rate</span>(http_request_duration_seconds_bucket[<span class="t-num">5m</span>]))</pre>
+              <div class="callout">
+                <span class="lbl">How to read it</span>
+                Dark bands are where requests pile up: <b>10–25ms</b> (read API) and <b>250–500ms</b> (order-create).
+                An average would smear both into one number near 100ms.
+              </div>
+            </div>
+            <div class="figure fit">
+              <img src="histogram-heatmap.png" alt="Heatmap panel showing the response time distribution" />
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The “trap of averages” slide. A bimodal distribution smeared into one mean resonates everywhere. Ties to quiz Q3.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 13 Summary ═══════════ -->
+    <div class="holder" data-n="13">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · metric types</span><span class="stamp">summary</span></div>
+        <h2 class="slide-title">Summary — already computed, so it <span class="em">cannot be merged</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <div class="tbl-wrap">
+                <table class="tbl sm">
+                  <thead><tr><th>Aspect</th><th>Histogram</th><th>Summary</th></tr></thead>
+                  <tbody>
+                    <tr><td>Quantile computed</td><td>Server (at query time)</td><td>Client (at collection)</td></tr>
+                    <tr><td>Merge across instances</td><td class="hl-teal">Possible</td><td class="hl">Impossible</td></tr>
+                    <tr><td>Change buckets/quantiles</td><td>Edit config, restart</td><td>Code change required</td></tr>
+                    <tr><td>Recommended for</td><td>Most cases</td><td>When exact quantiles are a must</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="callout">
+                <span class="lbl">Rule of thumb</span>
+                Averaging the p99 of three servers <b>does not give you a p99.</b>
+                With more than one server, use a Histogram.
+              </div>
+            </div>
+            <div class="figure fit">
+              <img src="summary-quantile.png" alt="Summary panel plotting go_gc_duration_seconds per quantile label" />
+              <figcaption>GC pause times the Go runtime exports by default. The median sits near 100µs while the max swings past 500µs.</figcaption>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">It is fine to sum Summary up as “you will rarely use it”. Still, Go runtime metrics expose one, so they should recognize it. Ties to quiz Q4.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 14 Label and time series ═══════════ -->
+    <div class="holder" data-n="14">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Prometheus</span><span class="stamp">time series</span></div>
+        <h2 class="slide-title">The unit of storage is <span class="em">one time series</span></h2>
+        <p class="slide-lede">A time series = one name tag with <code class="inl">(timestamp, value)</code> pairs appended forever. Every dot on a graph is one row.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <pre class="code xs plain">time       value
+14:30:00   1,204
+14:30:15   1,251     <span class="t-cm">← one row every 15s (scrape interval)</span>
+14:30:30   1,298
+14:30:45   1,344</pre>
+              <p class="dim" style="margin:0;font-size:16.5px;line-height:1.5;">One name tag only tells you “requests went up” — not which API,
+              or how many failed. So we attach <b>labels</b>.</p>
+              <pre class="code xs">http_requests_total{<span class="t-str">method="GET" , path="/api/orders", status="200"</span>}
+http_requests_total{<span class="t-str">method="POST", path="/api/orders", status="201"</span>}
+http_requests_total{<span class="t-str">method="POST", path="/api/orders", status="500"</span>}</pre>
+              <div class="callout teal">
+                <span class="lbl">The point</span>
+                Same name, but Prometheus stores these as <b>three separate time series</b>. Labels are what make splitting and merging possible.
+              </div>
+            </div>
+            <div class="figure fit">
+              <img src="promql-label-series.png" alt="Prometheus Table tab showing one metric split out by label combination" />
+              <figcaption>One metric name, but as many time series as there are label combinations.</figcaption>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">This is the most important concept in the talk. Using PromQL while believing “metric name = time series” guarantees getting stuck on aggregation (22) and division (25).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 15 cardinality ═══════════ -->
+    <div class="holder" data-n="15">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Prometheus</span><span class="stamp">cardinality</span></div>
+        <h2 class="slide-title">The shadow of labels — series grow by <span class="em">multiplication</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2" style="align-items:center;">
+            <div class="stack">
+              <div class="factor"><span>method</span><b>5</b><span>×</span><span>path</span><b>20</b><span>×</span><span>status</span><b>6</b></div>
+              <div class="odo-row">
+                <span class="odo sm" data-odo="600">0</span>
+                <span class="odo-cap">time series — that much is fine</span>
+              </div>
+              <div class="rule" style="margin:6px 0;"></div>
+              <div class="factor"><span>+ user_id</span><b>100,000</b><span>and you get</span></div>
+              <div class="odo-row">
+                <span class="odo" data-odo="60000000">0</span>
+              </div>
+              <p class="dim" style="margin:0;font-size:16.5px;">Every single series costs memory. Prometheus simply falls over.
+              This is called a <b>cardinality explosion</b>.</p>
+            </div>
+            <div class="stack">
+              <div class="callout">
+                <span class="lbl">One test decides it</span>
+                Can you <b>count this label's possible values in advance?</b>
+              </div>
+              <div class="cols c-2" style="gap:16px;">
+                <div class="card">
+                  <p class="card-t" style="color:var(--teal);">Fine as a label</p>
+                  <ul class="bul teal" style="font-size:16px;">
+                    <li><code class="inl">method</code></li>
+                    <li><code class="inl">status</code></li>
+                    <li><code class="inl">path</code></li>
+                  </ul>
+                </div>
+                <div class="card">
+                  <p class="card-t" style="color:var(--accent);">Send it to logs</p>
+                  <ul class="bul" style="font-size:16px;">
+                    <li><code class="inl">user_id</code></li>
+                    <li><code class="inl">session_id</code></li>
+                    <li>email · IP address</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Pause while the number climbs so the audience reads the digits. Stress that this is the number one cause of dead Prometheus servers in the field. Ties to quiz Q5.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 16 metric names ═══════════ -->
+    <div class="holder" data-n="16">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Prometheus</span><span class="stamp">naming</span></div>
+        <h2 class="slide-title">Where do those names come from?</h2>
+        <p class="slide-lede"><code class="inl">http_requests_total</code> is not built into Prometheus. Every one of these names was typed into someone's code.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack">
+              <pre class="code sm"><span class="t-key">var</span> HttpRequestsTotal = prometheus.NewCounterVec(
+    prometheus.CounterOpts{
+        Name: <span class="t-str">"http_requests_total"</span>,
+        Help: <span class="t-str">"Total number of HTTP requests"</span>,
+    },
+    []<span class="t-key">string</span>{<span class="t-str">"method", "path", "status"</span>},
+)</pre>
+              <p class="cap">The third argument lists the label names this metric will use. To Prometheus a name is just a string, so
+              <code class="inl">my_stuff_counter</code> would have worked identically.</p>
+            </div>
+            <div class="stack">
+              <div class="tbl-wrap">
+                <table class="tbl sm">
+                  <thead><tr><th>Official naming rules</th><th>Example</th></tr></thead>
+                  <tbody>
+                    <tr><td>One domain word up front</td><td class="num-col">node_ · process_ · prometheus_</td></tr>
+                    <tr><td>Plural unit at the end</td><td class="num-col">_seconds · _bytes</td></tr>
+                    <tr><td>Cumulative counts end in _total</td><td class="num-col">http_requests_total</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="tbl-wrap">
+                <table class="tbl sm">
+                  <thead><tr><th>Where a name comes from</th><th>Who picks it</th></tr></thead>
+                  <tbody>
+                    <tr><td class="num-col">node_cpu_seconds_total</td><td>exporter author</td></tr>
+                    <tr><td class="num-col">go_gc_duration_seconds</td><td>registered by the library</td></tr>
+                    <tr><td class="num-col">http_requests_total</td><td>application developer</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <p class="cap">No need to memorize names. Ask with <code class="inl">curl -s :9090/api/v1/metadata</code>, or use the autocomplete in the Prometheus UI.</p>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">“Nobody declared them, so why do go_ metrics exist?” comes up a lot. The answer: attaching the Go client library brings the runtime metrics along with it.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 17 /metrics raw ═══════════ -->
+    <div class="holder" data-n="17">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Prometheus</span><span class="stamp">exposition format</span></div>
+        <h2 class="slide-title">What Prometheus actually scrapes</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a grow" style="min-height:0;">
+            <pre class="code xs" style="overflow:auto;"><span class="t-cm"># TYPE http_requests_total counter</span>
+http_requests_total{<span class="t-str">method="GET",path="/api/orders",status="200"</span>} <span class="t-num">272</span>
+http_requests_total{<span class="t-str">method="POST",path="/api/orders",status="201"</span>} <span class="t-num">64</span>
+http_requests_total{<span class="t-str">method="POST",path="/api/orders",status="500"</span>} <span class="t-num">8</span>
+
+<span class="t-cm"># TYPE http_requests_in_flight gauge</span>
+http_requests_in_flight <span class="t-num">0</span>
+
+<span class="t-cm"># TYPE http_request_duration_seconds histogram</span>
+..._bucket{<span class="t-str">le="0.1"</span>}   <span class="t-num">7</span>
+..._bucket{<span class="t-str">le="0.25"</span>}  <span class="t-num">32</span>
+..._bucket{<span class="t-str">le="0.5"</span>}   <span class="t-num">72</span>
+..._bucket{<span class="t-str">le="+Inf"</span>}  <span class="t-num">72</span>
+..._sum   <span class="t-num">19.577</span>
+..._count <span class="t-num">72</span>
+
+<span class="t-cm"># TYPE go_gc_duration_seconds summary</span>
+go_gc_duration_seconds{<span class="t-str">quantile="0.5"</span>} <span class="t-num">4.82e-05</span>
+go_gc_duration_seconds_sum   <span class="t-num">8.74e-05</span>
+go_gc_duration_seconds_count <span class="t-num">2</span></pre>
+            <ul class="bul" style="font-size:17px;">
+              <li><b>The <code class="inl"># TYPE</code> line is where the type comes from.</b> It starts with <code class="inl">#</code> but it is metadata, not a comment</li>
+              <li><b>A Counter gets one line per label combination.</b> Three lines here, so three series</li>
+              <li><b>A Histogram fans one name out over many lines.</b> Buckets climbing <code class="inl">7 → 32 → 72</code> and then holding is what <b>cumulative</b> means — all 72 finished within 0.5s</li>
+              <li><b>A Summary has no buckets.</b> Only finished numbers, so there is no raw material to merge</li>
+              <li><b>A Gauge is one current value and that is it</b></li>
+            </ul>
+          </div>
+        </div>
+        <div class="notes-src">Showing the raw text after all the concepts pulls the whole story together at once. If the lab is up, curling it live here is the best option.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 18 chapter 2 ═══════════ -->
+    <div class="holder" data-n="18" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">02</div>
+          <div class="chap-l">
+            <h2 class="chap-t">PromQL</h2>
+            <p class="chap-d">A Grafana panel is, in the end, one line of PromQL.
+            There is no building a dashboard without it.</p>
+          </div>
+        </div>
+        <div class="notes-src">Open with “it looks like a cipher, but the structure is simple”. Breaking it into four pieces on the next slide is the spine of this chapter.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 19 query anatomy ═══════════ -->
+    <div class="holder" data-n="19">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · PromQL</span><span class="stamp">anatomy</span></div>
+        <h2 class="slide-title">Every query is four pieces put together</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="anat">
+            <div class="anat-q"><span class="p p4">sum by(path)</span> (<span class="p p4">rate</span>(<span class="p p1">http_requests_total</span><span class="p p2">{status="500"}</span><span class="p p3">[5m]</span>))</div>
+            <div class="legend">
+              <div class="lg-i"><span class="lg-b" style="background:var(--accent)"></span><span class="lg-n">metric name</span><span class="lg-d">what to look at</span></div>
+              <div class="lg-i"><span class="lg-b" style="background:var(--teal)"></span><span class="lg-n">label filter</span><span class="lg-d">which series of those</span></div>
+              <div class="lg-i"><span class="lg-b" style="background:var(--amber)"></span><span class="lg-n">time range</span><span class="lg-d">over what window</span></div>
+              <div class="lg-i"><span class="lg-b" style="background:var(--ink-faint)"></span><span class="lg-n">function · aggregation</span><span class="lg-d">how to compute them</span></div>
+            </div>
+            <div class="callout teal" style="margin-top:8px;">
+              <span class="lbl">Read it from the inside out</span>
+              Out of <code class="inl">http_requests_total</code> → keep only <code class="inl">status="500"</code> → take the last 5 minutes → turn it into a per-second rate → sum it by <code class="inl">path</code>.
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Use this slide as the anchor for the chapter. Saying that the following slides each zoom into one piece keeps the flow clear.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 20 label filters ═══════════ -->
+    <div class="holder" data-n="20">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · PromQL</span><span class="stamp">selector</span></div>
+        <h2 class="slide-title">Pieces 1 · 2 — the conditions inside the braces</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="tbl-wrap">
+              <table class="tbl">
+                <thead><tr><th>Operator</th><th>Meaning</th><th>Example</th></tr></thead>
+                <tbody>
+                  <tr><td class="num-col">=</td><td>value is equal</td><td class="num-col">{method="GET"}</td></tr>
+                  <tr><td class="num-col">!=</td><td>value differs</td><td class="num-col">{device!="lo"}</td></tr>
+                  <tr><td class="num-col">=~</td><td>matches the regex</td><td class="num-col">{status=~"5.."}</td></tr>
+                  <tr><td class="num-col">!~</td><td>does not match it</td><td class="num-col">{path!~"/health.*"}</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="stack">
+              <div class="callout">
+                <span class="lbl">A common idiom</span>
+                In <code class="inl">{status=~"5.."}</code>, <code class="inl">.</code> is any single character. 500, 502 and 503 all match — that is, <b>“all 5xx”</b>.
+              </div>
+              <pre class="code sm"><span class="t-cm"># comma-separated conditions must all match</span>
+http_requests_total{<span class="t-str">method="GET"</span>, <span class="t-str">status=~"5.."</span>}</pre>
+              <p class="dim" style="margin:0;font-size:16.5px;">Dropping loopback with <code class="inl">device!="lo"</code> on a network panel,
+              or picking one filesystem with <code class="inl">mountpoint="/"</code> on a disk panel — it all happens right here.</p>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Ties to quiz Q7. Adding that regexes are fully anchored rather than partial matches makes it precise.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 21 range vector ═══════════ -->
+    <div class="holder" data-n="21">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · PromQL</span><span class="stamp">instant vs range</span></div>
+        <h2 class="slide-title">Piece 3 — what changes when <code class="inl">[5m]</code> is attached</h2>
+        <p class="slide-lede">The most confusing spot in PromQL, because every function demands a different <b>shape of input</b>.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <p class="card-t">instant vector — one value, right now</p>
+              <pre class="code sm plain" style="margin-bottom:10px;">http_requests_total
+<span class="t-cm"># 1 value per series (e.g. 1,344)</span></pre>
+              <p class="dim" style="margin:0;font-size:16px;">Enough when you just want to look at a Gauge.</p>
+            </div>
+            <div class="card">
+              <p class="card-t">range vector — every value in the window</p>
+              <pre class="code sm" style="margin-bottom:10px;">http_requests_total[<span class="t-num">5m</span>]
+<span class="t-cm"># 20 values per series (15s × 5m)</span></pre>
+              <p class="dim" style="margin:0;font-size:16px;"><code class="inl">rate()</code> is “increase ÷ elapsed time”, so it needs at least two values.</p>
+            </div>
+          </div>
+          <div class="cols c-2">
+            <pre class="code sm"><span class="t-fn">rate</span>(http_requests_total[<span class="t-num">5m</span>])   <span class="t-cm">✓ works</span>
+<span class="t-fn">rate</span>(http_requests_total)       <span class="t-bad">✗ error</span></pre>
+            <div class="callout">
+              <span class="lbl">How wide should the window be</span>
+              It needs at least two samples, so keep it <b>comfortably longer than the scrape interval</b>. At 15s, a minute or more; <b>5m</b> by convention.
+              Too short and it twitches, too long and change blurs out.
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Ties to quiz Q6. “Why is [5m] there?” always comes up. Settle it here before moving on.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 22 aggregation ═══════════ -->
+    <div class="holder" data-n="22">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · PromQL</span><span class="stamp">aggregation</span></div>
+        <h2 class="slide-title">Piece 4 — putting the split series back together</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b">
+            <div class="tbl-wrap">
+              <table class="tbl">
+                <thead><tr><th>Function</th><th>Meaning</th></tr></thead>
+                <tbody>
+                  <tr><td class="num-col">sum()</td><td>adds them all up</td></tr>
+                  <tr><td class="num-col">avg()</td><td>takes the average</td></tr>
+                  <tr><td class="num-col">max() / min()</td><td>largest / smallest</td></tr>
+                  <tr><td class="num-col">count()</td><td>counts how many series</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="stack">
+              <pre class="code sm"><span class="t-fn">sum</span>(<span class="t-fn">rate</span>(http_requests_total[<span class="t-num">5m</span>]))
+<span class="t-cm">→ total traffic · 1 line</span>
+
+<span class="t-fn">sum</span> <span class="t-key">by</span>(path) (<span class="t-fn">rate</span>(http_requests_total[<span class="t-num">5m</span>]))
+<span class="t-cm">→ traffic per path · one line per path</span>
+
+<span class="t-fn">sum</span> <span class="t-key">by</span>(path, status) (...)
+<span class="t-cm">→ per path × status combination</span></pre>
+              <div class="callout teal">
+                <span class="lbl">by and without</span>
+                <code class="inl">by</code> = <b>keep</b> only these labels. <code class="inl">without</code> = <b>drop</b> these labels and keep the rest.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Ties to quiz Q8. That a bare sum(...) throws away every label and collapses to a single value foreshadows the error-rate slide (25).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 23 functions + type trap ═══════════ -->
+    <div class="holder" data-n="23">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · PromQL</span><span class="stamp">functions · trap</span></div>
+        <h2 class="slide-title">Four functions cover most of it — and one trap</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl sm">
+              <thead><tr><th>Function</th><th>What it does</th><th>Metric type</th><th>Example</th></tr></thead>
+              <tbody>
+                <tr><td class="num-col">rate()</td><td>per-second average rate</td><td>Counter</td><td class="num-col">rate(http_requests_total[5m])</td></tr>
+                <tr><td class="num-col">increase()</td><td>total increase over a window</td><td>Counter</td><td class="num-col">increase(http_requests_total[1h])</td></tr>
+                <tr><td class="num-col">histogram_quantile()</td><td>computes a percentile</td><td>Histogram</td><td class="num-col">histogram_quantile(0.99, rate(...))</td></tr>
+                <tr><td class="num-col">avg_over_time()</td><td>average over a window</td><td>Gauge</td><td class="num-col">avg_over_time(metric[5m])</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="cols c-2" style="align-items:start;">
+            <div class="callout">
+              <span class="lbl">The trap — that “metric type” column is never checked</span>
+              The Prometheus server <b>does not know</b> whether a metric is a Counter or a Gauge.
+              It flattens every type into untyped floating-point time series.
+            </div>
+            <pre class="code sm"><span class="t-fn">rate</span>(node_memory_MemAvailable_bytes[<span class="t-num">5m</span>])
+<span class="t-cm">→ no error. Computes on a Gauge (result is nonsense)</span>
+
+<span class="t-fn">rate</span>(http_requests_total)
+<span class="t-bad">→ error. not a range vector</span></pre>
+          </div>
+          <p class="cap"><b>Errors catch the vector type only; matching the metric type is on you.</b>
+          The name is a decent guess — <code class="inl">_total</code> means Counter, a <code class="inl">_bucket/_sum/_count</code> set means Histogram, a <code class="inl">quantile</code> label means Summary.</p>
+        </div>
+        <div class="notes-src">This is the classic path to a quietly wrong dashboard. Worth adding that rate() on a Gauge reads every dip as a counter reset and “corrects” it away.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 24 real-world CPU ═══════════ -->
+    <div class="holder" data-n="24">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · query 1</span><span class="stamp">cpu %</span></div>
+        <h2 class="slide-title">CPU usage — one layer at a time from the inside</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code"><span class="t-num">100</span> - (<span class="t-fn">avg</span> <span class="t-key">by</span>(instance) (<span class="t-fn">rate</span>(node_cpu_seconds_total{<span class="t-str">mode="idle"</span>}[<span class="t-num">5m</span>])) * <span class="t-num">100</span>)</pre>
+          <div class="cols c-2a grow" style="min-height:0;">
+            <div class="steps">
+              <div class="step"><span class="s-n">1</span><div><div class="s-c">node_cpu_seconds_total{mode="idle"}</div><div class="s-d">Out of cumulative CPU time, pick only the idle mode</div></div></div>
+              <div class="step"><span class="s-n">2</span><div><div class="s-c">[5m] + rate(...)</div><div class="s-d">Slope over 5 minutes = idle seconds per second. With 8 cores you get one series per core</div></div></div>
+              <div class="step"><span class="s-n">3</span><div><div class="s-c">avg by(instance)</div><div class="s-d">Average the per-core values per host. Result is 0–1; 1 means completely idle</div></div></div>
+              <div class="step"><span class="s-n">4</span><div><div class="s-c">* 100</div><div class="s-d">Turn it into a percentage</div></div></div>
+              <div class="step"><span class="s-n">5</span><div><div class="s-c">100 - (...)</div><div class="s-d">Flip “percent idle” into “percent busy”</div></div></div>
+            </div>
+            <div class="figure fit">
+              <img src="prometheus-query-cpu.png" alt="Running the CPU usage query in the Prometheus Graph tab" />
+              <figcaption>It is faster to check in the Prometheus UI that a query returns what you want before building the dashboard.</figcaption>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The point is that no metric measures CPU usage directly, so we invert idle. It looks odd at first, but explaining that Linux reports it that way settles it.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 25 real-world error rate ═══════════ -->
+    <div class="holder" data-n="25">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · query 2</span><span class="stamp">error rate · trap</span></div>
+        <h2 class="slide-title">Error rate — without <code class="inl">sum()</code> you <span class="em">always get 1</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code"><span class="t-fn">sum</span>(<span class="t-fn">rate</span>(http_requests_total{<span class="t-str">status=~"5.."</span>}[<span class="t-num">5m</span>]))
+  / <span class="t-fn">sum</span>(<span class="t-fn">rate</span>(http_requests_total[<span class="t-num">5m</span>])) * <span class="t-num">100</span></pre>
+          <div class="cols c-2">
+            <div class="stack">
+              <div class="callout">
+                <span class="lbl">Why sum() is needed</span>
+                Division in PromQL pairs series whose <b>label sets match exactly</b>.
+                Without <code class="inl">sum()</code>, the left <code class="inl">{status="500"}</code> pairs with the right <code class="inl">{status="500"}</code> — dividing something by itself, so <b>always 1</b>.
+              </div>
+              <pre class="code sm plain"><span class="t-cm"># without sum — always 1</span>
+{method="POST", path="/api/orders", status="500"}  <span class="t-bad">1</span>
+
+<span class="t-cm"># after sum strips the labels — the real rate</span>
+{}  <span class="t-num">5.5</span></pre>
+            </div>
+            <div class="stack">
+              <p class="dim" style="margin:0;font-size:17px;">The point is removing <code class="inl">status</code> from the labels,
+              so instead of <code class="inl">sum()</code> you can name what to keep with <code class="inl">by</code>. For a per-path error rate:</p>
+              <pre class="code sm"><span class="t-fn">sum</span> <span class="t-key">by</span>(path) (<span class="t-fn">rate</span>(http_requests_total{<span class="t-str">status=~"5.."</span>}[<span class="t-num">5m</span>]))
+  / <span class="t-fn">sum</span> <span class="t-key">by</span>(path) (<span class="t-fn">rate</span>(http_requests_total[<span class="t-num">5m</span>])) * <span class="t-num">100</span></pre>
+              <div class="callout teal">
+                <span class="lbl">Generalized</span>
+                Before dividing two queries, ask first — <b>do both sides carry the same label set?</b>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">This is 90% of the “my error rate is stuck at 100%” reports. Tell them a graph pinned flat at 1.0 should raise this suspicion.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 26 real-world memory/disk ═══════════ -->
+    <div class="holder" data-n="26">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · query 3</span><span class="stamp">memory · disk</span></div>
+        <h2 class="slide-title">Memory and disk — half the job is picking the metric</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack">
+              <pre class="code sm">(<span class="t-num">1</span> - node_memory_MemAvailable_bytes
+     / node_memory_MemTotal_bytes) * <span class="t-num">100</span></pre>
+              <ul class="bul" style="font-size:16.5px;">
+                <li>No <code class="inl">rate()</code> — both are Gauges, so the current value is the answer</li>
+                <li>Both sides carry the same <code class="inl">instance</code>, <code class="inl">job</code> labels, so <b>they pair up by themselves</b>. That is where this parts ways with the error-rate query</li>
+                <li><b>MemAvailable, not MemFree</b> — Linux spends spare memory on file cache, and that cache is reclaimed the moment it is needed. Compute with MemFree and a well-cached server always looks out of memory</li>
+              </ul>
+            </div>
+            <div class="stack">
+              <pre class="code sm">(<span class="t-num">1</span> - node_filesystem_avail_bytes{<span class="t-str">mountpoint="/"</span>}
+     / node_filesystem_size_bytes{<span class="t-str">mountpoint="/"</span>}) * <span class="t-num">100</span></pre>
+              <ul class="bul" style="font-size:16.5px;">
+                <li>Same shape of calculation as memory</li>
+                <li>Filesystem metrics get <b>a separate series per mount point</b>, so pin one with <code class="inl">mountpoint</code>. Skip it and you get <code class="inl">/</code>, <code class="inl">/boot</code> and Docker overlays too</li>
+                <li><b>avail, not free</b> — Linux reserves some blocks for root only. What an ordinary process can really use is avail</li>
+              </ul>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">Lab note</span>
+            The node-exporter started by docker-compose is boxed in its container and sees only its own filesystem. If the disk query is empty,
+            check the real mount points with <code class="inl">curl -s :9100/metrics | grep "^node_filesystem_size_bytes"</code>.
+          </div>
+        </div>
+        <div class="notes-src">MemAvailable vs MemFree trips up even long-time Linux users, so it gets a good reaction. Mentioning that Docker Desktop on macOS/Windows cannot see the host disk cuts questions during the lab.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 27 chapter 3 ═══════════ -->
+    <div class="holder" data-n="27" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">03</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Grafana</h2>
+            <p class="chap-d">An open-source dashboard tool that plugs into many data sources and visualizes them.
+            Besides Prometheus it can talk to Loki, Tempo, MySQL and Elasticsearch.</p>
+          </div>
+        </div>
+        <div class="notes-src">Point out that Grafana stores nothing. Prometheus stores, Grafana draws.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 28 Data Source ═══════════ -->
+    <div class="holder" data-n="28">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · Grafana</span><span class="stamp">data source</span></div>
+        <h2 class="slide-title">Data Source — register it first</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <div class="card">
+                <p class="card-t">Option 1 — from the UI</p>
+                <div class="tree">
+                  <span class="lv"><span class="k">Connections</span> → Data sources → Add</span>
+                  <span class="lv">Pick Prometheus</span>
+                  <span class="lv">URL: <span class="k">http://prometheus:9090</span></span>
+                  <span class="lv">Save &amp; Test</span>
+                </div>
+              </div>
+              <div class="callout">
+                <span class="lbl">The point</span>
+                <code class="inl">prometheus:9090</code>, not <code class="inl">localhost:9090</code> — Grafana runs in a container too, so it must reach it by <b>container name</b>.
+              </div>
+              <pre class="code xs"><span class="t-cm"># Option 2 — auto-register via provisioning</span>
+<span class="t-key">apiVersion</span>: 1
+<span class="t-key">datasources</span>:
+  - name: <span class="t-str">Prometheus</span>
+    type: <span class="t-str">prometheus</span>
+    access: <span class="t-str">proxy</span>
+    url: <span class="t-str">http://prometheus:9090</span>
+    isDefault: <span class="t-num">true</span></pre>
+            </div>
+            <div class="figure fit">
+              <img src="grafana-datasource-setup.png" alt="The Prometheus Data Source settings screen in Grafana" />
+              <figcaption>Save &amp; Test → “Successfully queried the Prometheus API”.</figcaption>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Ties to quiz Q9. If anyone in the room is new to container networking, add the line: on a docker-compose network the service name is the hostname.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 29 Dashboard structure + Panel ═══════════ -->
+    <div class="holder" data-n="29">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · Grafana</span><span class="stamp">dashboard · panel</span></div>
+        <h2 class="slide-title">Dashboard → Row → Panel → Query</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack">
+              <div class="tree">
+                <span class="lv"><span class="k">Dashboard</span>  <span class="v">can be exported/imported as JSON</span></span>
+                <span class="lv">├─ <span class="k">Row</span>  <span class="v">collapsible group of panels</span></span>
+                <span class="lv">│   ├─ <span class="k">Panel</span>  <span class="v">one unit of visualization</span></span>
+                <span class="lv">│   │   └─ <span class="k">Query</span>  <span class="v">one line of PromQL</span></span>
+                <span class="lv">│   └─ <span class="k">Panel</span></span>
+                <span class="lv">└─ <span class="k">Row</span></span>
+              </div>
+              <div class="callout teal">
+                <span class="lbl">One line to remember</span>
+                One panel = <b>one PromQL query</b>. Building a dashboard is really writing queries.
+              </div>
+            </div>
+            <div class="tbl-wrap">
+              <table class="tbl sm">
+                <thead><tr><th>Panel type</th><th>Good for</th></tr></thead>
+                <tbody>
+                  <tr><td>Time series</td><td>CPU usage, request rate, response time</td></tr>
+                  <tr><td>Stat</td><td>Current uptime, total requests</td></tr>
+                  <tr><td>Gauge</td><td>Disk usage, memory usage</td></tr>
+                  <tr><td>Table</td><td>Per-instance status, Top N lists</td></tr>
+                  <tr><td>Bar chart</td><td>Errors per service, requests per endpoint</td></tr>
+                  <tr><td>Heatmap</td><td>Response time distribution, Histogram buckets</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Exporting a dashboard as JSON matters a lot in practice — mention managing them as code and shipping them via provisioning.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 30 Variables ═══════════ -->
+    <div class="holder" data-n="30">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · Grafana</span><span class="stamp">variables</span></div>
+        <h2 class="slide-title">Variables — one dashboard for twenty servers</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <div class="tbl-wrap">
+                <table class="tbl sm">
+                  <thead><tr><th>Field</th><th>Value</th></tr></thead>
+                  <tbody>
+                    <tr><td>Name</td><td class="num-col">instance</td></tr>
+                    <tr><td>Type</td><td>Query</td></tr>
+                    <tr><td>Data source</td><td>Prometheus</td></tr>
+                    <tr><td>Query</td><td class="num-col">label_values(node_cpu_seconds_total, instance)</td></tr>
+                    <tr><td>Multi-value</td><td>enabled</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <pre class="code xs"><span class="t-num">100</span> - (<span class="t-fn">avg</span> <span class="t-key">by</span>(instance) (<span class="t-fn">rate</span>(node_cpu_seconds_total{
+    <span class="t-str">mode="idle"</span>, <span class="t-str">instance=~"$instance"</span>}[<span class="t-num">5m</span>])) * <span class="t-num">100</span>)</pre>
+              <p class="cap">Pick an instance from the dropdown and only that instance's metrics remain.
+              Add servers and the list grows with whatever <code class="inl">label_values()</code> finds.</p>
+            </div>
+            <div class="figure fit">
+              <img src="grafana-variables-dropdown.png" alt="The instance variable dropdown at the top of the dashboard" />
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">With one server nobody feels the need, but by the time you are cloning a dashboard per server it is already too late.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 31 chapter 4 ═══════════ -->
+    <div class="holder" data-n="31" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">04</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Hands-on — a local setup</h2>
+            <p class="chap-d">Bring up Prometheus · Grafana · node-exporter with a single docker-compose file,
+            then build a four-panel system monitoring dashboard.</p>
+          </div>
+        </div>
+        <div class="notes-src">Live demo from here if at all possible. Pull the images beforehand, and be ready to fall back on the screenshots in the following slides.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 32 docker-compose ═══════════ -->
+    <div class="holder" data-n="32">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · hands-on</span><span class="stamp">docker-compose.yml</span></div>
+        <h2 class="slide-title">Three services and you are done</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a grow" style="min-height:0;">
+            <pre class="code xs" style="overflow:auto;"><span class="t-key">services</span>:
+  <span class="t-key">prometheus</span>:
+    image: <span class="t-str">prom/prometheus:v2.51.0</span>
+    ports: [<span class="t-str">"9090:9090"</span>]
+    volumes:
+      - <span class="t-str">./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml</span>
+    command:
+      - <span class="t-str">'--config.file=/etc/prometheus/prometheus.yml'</span>
+      - <span class="t-str">'--storage.tsdb.retention.time=7d'</span>
+
+  <span class="t-key">grafana</span>:
+    image: <span class="t-str">grafana/grafana:11.4.0</span>
+    ports: [<span class="t-str">"3000:3000"</span>]
+    environment:
+      - <span class="t-str">GF_SECURITY_ADMIN_PASSWORD=admin</span>
+    volumes:
+      - <span class="t-str">./provisioning:/etc/grafana/provisioning</span>
+
+  <span class="t-key">node-exporter</span>:
+    image: <span class="t-str">prom/node-exporter:v1.8.1</span>
+    ports: [<span class="t-str">"9100:9100"</span>]</pre>
+            <div class="stack">
+              <pre class="code sm"><span class="t-cm">></span> docker compose up -d</pre>
+              <div class="tbl-wrap">
+                <table class="tbl sm">
+                  <thead><tr><th>Service</th><th>Address</th></tr></thead>
+                  <tbody>
+                    <tr><td>Prometheus</td><td class="num-col">localhost:9090</td></tr>
+                    <tr><td>Grafana</td><td class="num-col">localhost:3000 · admin/admin</td></tr>
+                    <tr><td>node-exporter</td><td class="num-col">localhost:9100/metrics</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="callout teal">
+                <span class="lbl">Retention</span>
+                <code class="inl">--storage.tsdb.retention.time=7d</code> — 7 days for a local lab. In production this is traded against disk.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Point out that the image tags are pinned. Leave them on latest and yesterday's working lab breaks today.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 33 prometheus.yml ═══════════ -->
+    <div class="holder" data-n="33">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · hands-on</span><span class="stamp">prometheus.yml</span></div>
+        <h2 class="slide-title"><code class="inl">scrape_configs</code> decides what gets scraped</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <pre class="code sm"><span class="t-key">global</span>:
+  scrape_interval: <span class="t-num">15s</span>      <span class="t-cm"># scrape period</span>
+  evaluation_interval: <span class="t-num">15s</span>  <span class="t-cm"># rule evaluation period</span>
+
+<span class="t-key">scrape_configs</span>:
+  <span class="t-cm"># Prometheus' own metrics</span>
+  - job_name: <span class="t-str">'prometheus'</span>
+    static_configs:
+      - targets: [<span class="t-str">'localhost:9090'</span>]
+
+  <span class="t-cm"># node-exporter system metrics</span>
+  - job_name: <span class="t-str">'node-exporter'</span>
+    static_configs:
+      - targets: [<span class="t-str">'node-exporter:9100'</span>]</pre>
+            <div class="stack">
+              <ul class="bul">
+                <li><code class="inl">scrape_interval: 15s</code> — this becomes the <b>spacing between points</b> in a time series</li>
+                <li><code class="inl">job_name</code> becomes the <code class="inl">job</code> label attached to every series</li>
+                <li>This uses <code class="inl">static_configs</code>, but real operations wire in <b>service discovery</b> such as Kubernetes or Consul</li>
+              </ul>
+              <div class="callout">
+                <span class="lbl">The price of Pull</span>
+                The server has to know “where to scrape” — that is this file. Push setups have no such file.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Connecting “service discovery needed” from the Pull vs Push table (8) to this concrete file is what makes it click.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 34 Targets ═══════════ -->
+    <div class="holder" data-n="34">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · hands-on</span><span class="stamp">status → targets</span></div>
+        <h2 class="slide-title">When something breaks, look <span class="em">here first</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack">
+              <ul class="bul">
+                <li>Prometheus web UI → <b>Status → Targets</b></li>
+                <li>Endpoint, last scrape time and how long it took are all here</li>
+                <li>If this says <code class="inl">DOWN</code>, no amount of dashboard tweaking gives you anything but <b>empty graphs</b></li>
+              </ul>
+              <div class="callout">
+                <span class="lbl">Debugging order</span>
+                ① Are the targets UP → ② does the query return values in the Prometheus UI → ③ only then the Grafana panel settings.
+                Skip the order and you burn time.
+              </div>
+            </div>
+            <div class="figure fit">
+              <img src="prometheus-targets.png" alt="Two targets showing UP on the Prometheus Targets page" />
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Ties to quiz Q10. “My graph is empty” is the most common question during the lab, and the answer is almost always on this screen.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 35 4-panel dashboard ═══════════ -->
+    <div class="holder" data-n="35">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · hands-on</span><span class="stamp">first dashboard</span></div>
+        <h2 class="slide-title">The minimum setup for watching one server</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b grow" style="min-height:0;">
+            <div class="stack tight">
+              <pre class="code xs"><span class="t-cm"># 1. CPU usage (%)  · Unit: Percent (0-100)</span>
+<span class="t-num">100</span> - (<span class="t-fn">avg</span> <span class="t-key">by</span>(instance) (<span class="t-fn">rate</span>(node_cpu_seconds_total{<span class="t-str">mode="idle"</span>}[<span class="t-num">5m</span>])) * <span class="t-num">100</span>)
+
+<span class="t-cm"># 2. Memory usage (%)</span>
+(<span class="t-num">1</span> - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * <span class="t-num">100</span>
+
+<span class="t-cm"># 3. Disk I/O  · Unit: Bytes/sec (IEC)</span>
+<span class="t-fn">rate</span>(node_disk_read_bytes_total[<span class="t-num">5m</span>])
+<span class="t-fn">rate</span>(node_disk_written_bytes_total[<span class="t-num">5m</span>])
+
+<span class="t-cm"># 4. Network traffic  · Unit: Bytes/sec (IEC)</span>
+<span class="t-fn">rate</span>(node_network_receive_bytes_total{<span class="t-str">device!="lo"</span>}[<span class="t-num">5m</span>])
+<span class="t-fn">rate</span>(node_network_transmit_bytes_total{<span class="t-str">device!="lo"</span>}[<span class="t-num">5m</span>])</pre>
+              <div class="callout">
+                <span class="lbl">If the legend looks messy</span>
+                Disk and network produce one series per device. Keep only real devices with <code class="inl">device=~"nvme.*|sd.*"</code>, or turn the legend off.
+              </div>
+            </div>
+            <div class="figure fit">
+              <img src="grafana-system-dashboard.png" alt="System monitoring dashboard with four panels: CPU, memory, disk and network" />
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Stress that skipping Unit leaves the y-axis as bare numbers that are hard to read. Setting a Unit per panel changes dashboard quality dramatically.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 36 recap ═══════════ -->
+    <div class="holder" data-n="36">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">wrap-up</span><span class="stamp">recap</span></div>
+        <h2 class="slide-title">What to take away today</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <ul class="bul" style="font-size:20px;gap:16px;">
+            <li>Prometheus is <b>Pull</b>-based — it scrapes the <code class="inl">/metrics</code> endpoints exporters expose</li>
+            <li>There are four metric types, but the ones you actually reach for are <b>Counter and Histogram</b></li>
+            <li>PromQL is mostly covered by four functions: <code class="inl">rate()</code> · <code class="inl">increase()</code> · <code class="inl">histogram_quantile()</code> · <code class="inl">avg_over_time()</code></li>
+            <li>Labels slice a metric into dimensions, but <b>a unique identifier blows cardinality up</b></li>
+            <li>A Grafana dashboard is <b>Data Source → Dashboard → Row → Panel → Query</b></li>
+            <li>Prometheus + Grafana + node-exporter come up from <b>a single docker-compose file</b></li>
+          </ul>
+        </div>
+        <div class="notes-src">Reading the six lines aloud is enough of a recap on its own. It is fine to start taking questions here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 37 quiz ═══════════ -->
+    <div class="holder" data-n="37">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Answer these yourself</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>A cumulative Counter graph drops to the floor at some point. What happened?</span></button>
+              <div class="q-a">The application restarted and the counter began again at 0. <code class="inl">rate()</code> corrects for that break, so the line does not jump there. <span class="ref">→ Slide 10</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>Which requests land in a Histogram's <code class="inl">le="0.5"</code> bucket?</span></button>
+              <div class="q-a">Every request of 0.5s <b>or less</b>, not just the 0.25–0.5s slice. Buckets are cumulative, so values keep growing to the right. <span class="ref">→ Slide 12</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>You need the p99 across three servers. Histogram or Summary?</span></button>
+              <div class="q-a">Histogram. A Summary only hands over quantiles each server already computed, so they cannot be merged — averaging three p99s is not the overall p99. <span class="ref">→ Slide 13</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>Someone wants <code class="inl">user_id</code> as a Label to see requests per user. Why stop them?</span></button>
+              <div class="q-a">Series count grows as the product of label value counts. 600 series times 100,000 users is 60 million. Values you cannot count belong in logs. <span class="ref">→ Slide 15</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>Why does <code class="inl">rate(http_requests_total)</code> fail?</span></button>
+              <div class="q-a">Without a range, each series yields one current value (an instant vector). “Increase ÷ elapsed time” needs at least two, so add <code class="inl">[5m]</code> to make it a range vector. <span class="ref">→ Slide 21</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q6</span><span>The dashboard is built but every panel is empty. Where do you look first?</span></button>
+              <div class="q-a"><b>Status → Targets</b> in the Prometheus web UI. If a target is <code class="inl">DOWN</code> there is no data at all, so touching queries or panel settings is pointless. <span class="ref">→ Slide 34</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Let the audience answer first, then click to open. If time is short, Q4 and Q6 alone are enough.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 38 next part ═══════════ -->
+    <div class="holder" data-n="38">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">next</span><span class="stamp">part 2</span></div>
+        <h2 class="slide-title">Next — Custom Metrics in a Go Application</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack">
+              <p class="dim" style="margin:0;font-size:18px;line-height:1.6;">One step past the system metrics node-exporter gives you,
+              <b>we instrument a Go application directly.</b> HTTP request counts and response times, of course,
+              plus <b>business metrics</b> like order volume, all the way up into Grafana.</p>
+              <div class="callout">
+                <span class="lbl">Among today's screens</span>
+                The Counter · Histogram · Summary screenshots came from that very sample app.
+              </div>
+            </div>
+            <div class="card">
+              <p class="card-t">References</p>
+              <ul class="bul" style="font-size:16.5px;gap:9px;">
+                <li>Full code — <code class="inl">github.com/kenshin579/tutorials-go</code> <span class="faint">/monitoring/grafana-metrics</span></li>
+                <li>Prometheus docs — <code class="inl">prometheus.io/docs</code></li>
+                <li>PromQL querying guide — <code class="inl">prometheus.io/docs/prometheus/latest/querying/basics</code></li>
+                <li>Grafana docs — <code class="inl">grafana.com/docs/grafana/latest</code></li>
+                <li>node-exporter — <code class="inl">github.com/prometheus/node_exporter</code></li>
+                <li>Dashboard Best Practices — <code class="inl">grafana.com/docs/grafana/latest/dashboards/build-dashboards/best-practices</code></li>
+              </ul>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Thank you</span>
+            Questions welcome — <code class="inl">advenoh.pe.kr</code>
+          </div>
+        </div>
+        <div class="notes-src">Take Q&amp;A with the GitHub repo URL up on the screen.</div>
+      </section>
+    </div>
+    </div><!-- /stage -->
+  </div><!-- /stage-wrap -->
+
+  <div class="notes" id="notes" aria-live="polite">
+    <div class="n-h">Speaker notes</div>
+    <div id="notesBody"></div>
+  </div>
+
+  <div class="chrome">
+    <span class="deck-id">Prometheus &amp; Grafana Basics</span>
+    <div class="rail" id="rail"></div>
+    <span class="counter" id="counter"><span class="cur">01</span> / 38</span>
+    <div class="keys">
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="Overview (O)">Overview</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="Speaker notes (N)">Notes</button>
+      <button class="kbtn" id="btnTheme" type="button" title="Toggle theme (T)">Theme</button>
+      <button class="kbtn" id="btnHelp" type="button" title="Shortcuts (?)">?</button>
+    </div>
+  </div>
+
+  <div class="help" id="help">
+    <div class="help-box">
+      <h3>Shortcuts</h3>
+      <dl>
+        <dt>→ · Space · PgDn</dt><dd>Next slide</dd>
+        <dt>← · PgUp</dt><dd>Previous slide</dd>
+        <dt>Home · End</dt><dd>First · Last</dd>
+        <dt>O</dt><dd>Slide overview</dd>
+        <dt>N</dt><dd>Speaker notes</dd>
+        <dt>T</dt><dd>Light / dark theme</dd>
+        <dt>F</dt><dd>Fullscreen</dd>
+        <dt>Esc</dt><dd>Close</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var deck     = document.getElementById("deck");
+  var stage    = document.getElementById("stage");
+  var wrap     = document.getElementById("stageWrap");
+  var rail     = document.getElementById("rail");
+  var counter  = document.getElementById("counter");
+  var notesEl  = document.getElementById("notes");
+  var notesBody= document.getElementById("notesBody");
+  var helpEl   = document.getElementById("help");
+  var holders  = Array.prototype.slice.call(stage.querySelectorAll(".holder"));
+  var total    = holders.length;
+  var idx      = 0;
+  var overview = false;
+  var reduce   = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ── 눈금 레일 ─────────────────────────────────── */
+  var ticks = holders.map(function (h, i) {
+    var t = document.createElement("span");
+    t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
+    t.title = "Slide " + (i + 1);
+    t.addEventListener("click", function () { go(i); });
+    rail.appendChild(t);
+    return t;
+  });
+
+  function pad(n) { return (n < 10 ? "0" : "") + n; }
+
+  /* ── 무대 스케일 ───────────────────────────────── */
+  /* 무대는 stage-wrap 의 좌상단에 고정(place-items:start)해 두고,
+     축소한 뒤 남는 여백만큼 직접 translate 해서 가운데로 옮긴다.
+     transform-origin 을 center 로 두고 grid 중앙 정렬에 맡기면,
+     뷰포트가 1280x720 보다 작을 때 브라우저가 넘치는 항목을
+     좌상단에 고정(safe alignment)해 버려서 축소 결과가 오른쪽 아래로 쏠린다. */
+  function fit() {
+    if (overview) { stage.style.transform = ""; return; }
+    var k = Math.min(wrap.clientWidth / 1280, wrap.clientHeight / 720);
+    var tx = (wrap.clientWidth - 1280 * k) / 2;
+    var ty = (wrap.clientHeight - 720 * k) / 2;
+    stage.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + k + ")";
+  }
+
+  /* ── 이동 ──────────────────────────────────────── */
+  function go(n, silent) {
+    n = Math.max(0, Math.min(total - 1, n));
+    idx = n;
+    holders.forEach(function (h, i) { h.classList.toggle("is-active", i === n); });
+    ticks.forEach(function (t, i) {
+      t.classList.toggle("done", i < n);
+      t.classList.toggle("now", i === n);
+    });
+    counter.innerHTML = '<span class="cur">' + pad(n + 1) + "</span> / " + total;
+    var src = holders[n].querySelector(".notes-src");
+    notesBody.textContent = src ? src.textContent.trim() : "—";
+    if (!silent) { history.replaceState(null, "", "#" + (n + 1)); }
+    runOdometers(holders[n]);
+    if (overview) {
+      holders[n].scrollIntoView({ block: "nearest", behavior: reduce ? "auto" : "smooth" });
+    }
+  }
+
+  /* ── 카디널리티 카운터 ─────────────────────────── */
+  function runOdometers(holder) {
+    var list = holder.querySelectorAll("[data-odo]");
+    Array.prototype.forEach.call(list, function (el, i) {
+      var to = parseInt(el.getAttribute("data-odo"), 10);
+      if (reduce) { el.textContent = to.toLocaleString("en-US"); return; }
+      var dur = 900, delay = i * 420, t0 = null;
+      el.textContent = "0";
+      function frame(ts) {
+        if (t0 === null) { t0 = ts; }
+        var p = (ts - t0 - delay) / dur;
+        if (p < 0) { requestAnimationFrame(frame); return; }
+        if (p > 1) { p = 1; }
+        var e = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(to * e).toLocaleString("en-US");
+        if (p < 1) { requestAnimationFrame(frame); }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
+  /* ── 개요 모드 ─────────────────────────────────── */
+  function setOverview(on) {
+    overview = on;
+    deck.classList.toggle("is-overview", on);
+    document.getElementById("btnOverview").setAttribute("aria-pressed", String(on));
+    fit();
+    if (on) { holders[idx].scrollIntoView({ block: "center" }); }
+  }
+
+  holders.forEach(function (h, i) {
+    h.addEventListener("click", function () { if (overview) { setOverview(false); go(i); } });
+  });
+
+  /* ── 노트 · 테마 · 도움말 ──────────────────────── */
+  function setNotes(on) {
+    notesEl.classList.toggle("on", on);
+    document.getElementById("btnNotes").setAttribute("aria-pressed", String(on));
+  }
+  function toggleTheme() {
+    var cur = document.documentElement.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try { localStorage.setItem("deck-theme", next); } catch (e) {}
+    drawHero();
+  }
+  try {
+    var saved = localStorage.getItem("deck-theme");
+    if (saved) { document.documentElement.setAttribute("data-theme", saved); }
+  } catch (e) {}
+
+  document.getElementById("btnOverview").addEventListener("click", function () { setOverview(!overview); });
+  document.getElementById("btnNotes").addEventListener("click", function () { setNotes(!notesEl.classList.contains("on")); });
+  document.getElementById("btnTheme").addEventListener("click", toggleTheme);
+  document.getElementById("btnHelp").addEventListener("click", function () { helpEl.classList.toggle("on"); });
+  helpEl.addEventListener("click", function () { helpEl.classList.remove("on"); });
+
+  /* ── 클릭 리빌 · 이미지 토글 ───────────────────── */
+  document.addEventListener("click", function (e) {
+    var qb = e.target.closest ? e.target.closest(".q-btn") : null;
+    if (qb) { qb.parentNode.classList.toggle("is-open"); return; }
+
+    var tg = e.target.closest ? e.target.closest(".tg") : null;
+    if (tg) {
+      var group = tg.getAttribute("data-swap");
+      var target = tg.getAttribute("data-target");
+      Array.prototype.forEach.call(document.querySelectorAll('.tg[data-swap="' + group + '"]'), function (b) {
+        b.setAttribute("aria-pressed", String(b === tg));
+      });
+      Array.prototype.forEach.call(document.querySelectorAll('[data-swap-group="' + group + '"] > .swap-i'), function (item) {
+        item.classList.toggle("on", item.getAttribute("data-swap-item") === target);
+      });
+    }
+  });
+
+  /* ── 키보드 ────────────────────────────────────── */
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) { return; }
+    var k = e.key;
+    if (k === "ArrowRight" || k === "PageDown" || k === " " || k === "Spacebar") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowLeft" || k === "PageUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "ArrowDown") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "Home") { e.preventDefault(); go(0); }
+    else if (k === "End") { e.preventDefault(); go(total - 1); }
+    else if (k === "o" || k === "O" || k === "ㅐ") { setOverview(!overview); }
+    else if (k === "n" || k === "N" || k === "ㅜ") { setNotes(!notesEl.classList.contains("on")); }
+    else if (k === "t" || k === "T" || k === "ㅅ") { toggleTheme(); }
+    else if (k === "f" || k === "F" || k === "ㄹ") {
+      if (document.fullscreenElement) { document.exitFullscreen(); }
+      else if (document.documentElement.requestFullscreen) { document.documentElement.requestFullscreen(); }
+    }
+    else if (k === "?" || k === "/") { helpEl.classList.toggle("on"); }
+    else if (k === "Escape") {
+      if (helpEl.classList.contains("on")) { helpEl.classList.remove("on"); }
+      else if (overview) { setOverview(false); }
+    }
+  });
+
+  /* ── 표지 스파크라인 ───────────────────────────── */
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  function drawHero() {
+    var cv = document.getElementById("heroCanvas");
+    if (!cv) { return; }
+    var ctx = cv.getContext("2d");
+    var W = cv.width, H = cv.height;
+    ctx.clearRect(0, 0, W, H);
+
+    var accent = css("--accent") || "#FF7A45";
+    var line   = css("--line") || "#272F3A";
+    var faint  = css("--ink-faint") || "#6B7688";
+
+    /* 격자 */
+    ctx.strokeStyle = line;
+    ctx.lineWidth = 1;
+    var i, y, x;
+    for (i = 1; i <= 4; i++) {
+      y = Math.round((H / 5) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    for (i = 1; i <= 5; i++) {
+      x = Math.round((W / 6) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+    }
+
+    /* 결정적인 CPU 곡선 (난수 없이 재현 가능하게) */
+    var N = 180, pts = [];
+    for (i = 0; i < N; i++) {
+      var t = i / (N - 1);
+      var v = 0.42
+        + 0.16 * Math.sin(t * 8.1 + 0.6)
+        + 0.09 * Math.sin(t * 21.3 + 1.9)
+        + 0.05 * Math.sin(t * 47.7 + 4.2)
+        + 0.10 * Math.exp(-Math.pow((t - 0.68) * 9, 2));
+      v = Math.max(0.08, Math.min(0.92, v));
+      pts.push([6 + t * (W - 12), H - v * H]);
+    }
+
+    var steps = reduce ? N : 0;
+    function render(n) {
+      ctx.clearRect(0, 0, W, H);
+      ctx.strokeStyle = line;
+      for (i = 1; i <= 4; i++) {
+        y = Math.round((H / 5) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+      }
+      for (i = 1; i <= 5; i++) {
+        x = Math.round((W / 6) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+      }
+
+      var m = Math.max(2, n);
+      var grad = ctx.createLinearGradient(0, 0, 0, H);
+      grad.addColorStop(0, accent + "55");
+      grad.addColorStop(1, accent + "00");
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], H);
+      for (i = 0; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.lineTo(pts[m - 1][0], H);
+      ctx.closePath();
+      ctx.fillStyle = grad;
+      ctx.fill();
+
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (i = 1; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.strokeStyle = accent;
+      ctx.lineWidth = 2.4;
+      ctx.lineJoin = "round";
+      ctx.stroke();
+
+      /* 마지막 점 강조 */
+      ctx.beginPath();
+      ctx.arc(pts[m - 1][0], pts[m - 1][1], 4.5, 0, Math.PI * 2);
+      ctx.fillStyle = accent;
+      ctx.fill();
+
+      ctx.font = "500 20px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = faint;
+      ctx.textAlign = "left";
+      ctx.fillText("100%", 8, 22);
+      ctx.fillText("0", 8, H - 8);
+    }
+
+    if (reduce) { render(N); return; }
+    var n0 = 2, t0 = null;
+    function frame(ts) {
+      if (t0 === null) { t0 = ts; }
+      var p = Math.min(1, (ts - t0) / 1100);
+      var e = 1 - Math.pow(1 - p, 3);
+      render(Math.max(n0, Math.round(N * e)));
+      if (p < 1) { requestAnimationFrame(frame); }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  /* ── 초기화 ────────────────────────────────────── */
+  window.addEventListener("resize", fit);
+  window.addEventListener("hashchange", function () {
+    var n = parseInt(location.hash.replace("#", ""), 10);
+    if (!isNaN(n)) { go(n - 1, true); }
+  });
+
+  var start = parseInt(location.hash.replace("#", ""), 10);
+  fit();
+  go(isNaN(start) ? 0 : start - 1, true);
+  drawHero();
+})();
+</script>
+</body>
+</html>

--- a/contents/go/golang-concurrency-1-goroutine-기초/index_en.md
+++ b/contents/go/golang-concurrency-1-goroutine-기초/index_en.md
@@ -57,6 +57,8 @@ Go's creator Rob Pike explains it this way:
 
 In Go, concurrency is about the **structure** of a program. Separating code into independently executable units is concurrency, and actually running them simultaneously on multiple CPUs is parallelism. If you design a Go program to be concurrent, the runtime takes care of leveraging parallelism.
 
+<!-- slides -->
+
 # 2. Why Is Go Strong at Concurrency?
 
 ## 2.1 The CSP Model

--- a/contents/go/golang-concurrency-1-goroutine-기초/slides_en.html
+++ b/contents/go/golang-concurrency-1-goroutine-기초/slides_en.html
@@ -1,0 +1,2322 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Overview and Goroutine Basics — Golang Concurrency Part 1</title>
+<style>
+/* ─────────────────────────────────────────────────────────────
+   계기판(instrument panel) — 차가운 슬레이트 바탕 위 Gopher Blue
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0B6E8C;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(11, 110, 140, .10);
+  --teal:      #146B4E;
+  --teal-ink:  #FFFFFF;
+  --teal-soft: rgba(20, 107, 78, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+
+  --f-display: "Avenir Next", "Apple SD Gothic Neo", "Helvetica Neue", system-ui, sans-serif;
+  --f-body:    "Apple SD Gothic Neo", -apple-system, "Helvetica Neue", "Noto Sans KR", sans-serif;
+  --f-mono:    "MesloLGS NF", "SF Mono", ui-monospace, Menlo, "D2Coding", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0E1117;
+    --surface:   #161B23;
+    --surface-2: #1B212A;
+    --ink:       #E6E9EE;
+    --ink-dim:   #98A2B0;
+    --ink-faint: #6B7688;
+    --line:      #272F3A;
+    --line-soft: #1E252E;
+    --grid:      rgba(255, 255, 255, .038);
+    --accent:    #4FD3F4;
+    --accent-ink:#04222C;
+    --accent-soft: rgba(79, 211, 244, .13);
+    --teal:      #4FC48F;
+    --teal-ink:  #06231A;
+    --teal-soft: rgba(79, 196, 143, .13);
+    --amber:     #E8B84B;
+    --red:       #F0625E;
+    --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg:        #0E1117;
+  --surface:   #161B23;
+  --surface-2: #1B212A;
+  --ink:       #E6E9EE;
+  --ink-dim:   #98A2B0;
+  --ink-faint: #6B7688;
+  --line:      #272F3A;
+  --line-soft: #1E252E;
+  --grid:      rgba(255, 255, 255, .038);
+  --accent:    #4FD3F4;
+  --accent-ink:#04222C;
+  --accent-soft: rgba(79, 211, 244, .13);
+  --teal:      #4FC48F;
+  --teal-ink:  #06231A;
+  --teal-soft: rgba(79, 196, 143, .13);
+  --amber:     #E8B84B;
+  --red:       #F0625E;
+  --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+}
+
+:root[data-theme="light"] {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0B6E8C;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(11, 110, 140, .10);
+  --teal:      #146B4E;
+  --teal-ink:  #FFFFFF;
+  --teal-soft: rgba(20, 107, 78, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ── 무대: 1280×720 고정, 뷰포트에 맞춰 축소 ───────────────── */
+.stage-wrap {
+  position: fixed;
+  inset: 0 0 52px 0;
+  display: grid;
+  /* 가운데 정렬은 fit() 이 translate 로 직접 한다. grid 중앙 정렬에 맡기면
+     무대가 뷰포트보다 클 때 safe alignment 로 좌상단에 고정되어 계산이 어긋난다. */
+  place-items: start;
+  overflow: hidden;
+}
+.stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  transform-origin: 0 0;
+  flex: none;
+}
+.holder {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .22s ease;
+}
+.holder.is-active { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .holder { transition: none; } }
+
+.slide {
+  width: 1280px;
+  height: 720px;
+  padding: 52px 68px 56px;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 40px,
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px) 0 0 / 40px 100%,
+    var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.slide::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0 34%, var(--line) 34% 100%);
+  opacity: .55;
+}
+
+/* ── 슬라이드 머리 ─────────────────────────────────────────── */
+.slide-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  flex: none;
+}
+.eyebrow {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+}
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+}
+.slide-title {
+  font-family: var(--f-display);
+  font-size: 42px;
+  line-height: 1.16;
+  font-weight: 700;
+  letter-spacing: -.022em;
+  margin: 0 0 6px;
+  text-wrap: balance;
+}
+.slide-title .em { color: var(--accent); }
+.slide-lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0 0 4px;
+  max-width: 72ch;
+}
+.rule {
+  height: 1px;
+  background: var(--line);
+  margin: 18px 0 22px;
+  flex: none;
+}
+.slide-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  font-size: 19px;
+  line-height: 1.6;
+}
+.slide-body.top { justify-content: flex-start; }
+
+/* ── 공용 조판 ─────────────────────────────────────────────── */
+.cols { display: grid; gap: 30px; align-items: start; }
+.c-2  { grid-template-columns: 1fr 1fr; }
+.c-2a { grid-template-columns: 1.15fr .85fr; }
+.c-2b { grid-template-columns: .82fr 1.18fr; }
+.c-3  { grid-template-columns: repeat(3, 1fr); }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.stack.tight { gap: 10px; }
+.grow { flex: 1; min-height: 0; }
+.cols.grow { align-items: stretch; }
+.cols.grow > .stack { justify-content: center; }
+
+ul.bul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 13px; }
+ul.bul > li { position: relative; padding-left: 26px; }
+ul.bul > li::before {
+  content: "";
+  position: absolute;
+  left: 4px; top: .62em;
+  width: 9px; height: 2px;
+  background: var(--accent);
+}
+ul.bul.teal > li::before { background: var(--teal); }
+ul.bul.red > li::before { background: var(--red); }
+.dim { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.hl { color: var(--accent); font-weight: 600; }
+.hl-teal { color: var(--teal); font-weight: 600; }
+b, strong { font-weight: 700; }
+
+/* ── 표 ────────────────────────────────────────────────────── */
+.tbl-wrap { overflow-x: auto; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink-faint);
+  padding: 0 14px 9px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: 11px 14px 11px 0;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  line-height: 1.45;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td:first-child { font-weight: 600; white-space: nowrap; }
+table.tbl.sm { font-size: 15.5px; }
+table.tbl.sm td { padding: 8px 12px 8px 0; }
+table.tbl tr.on td { background: var(--accent-soft); }
+table.tbl tr.on td:first-child { color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); padding-left: 12px; }
+table.tbl col.on + col, table.tbl .col-on { background: var(--accent-soft); }
+.num-col { font-family: var(--f-mono); }
+
+/* ── 코드 ──────────────────────────────────────────────────── */
+.code {
+  font-family: var(--f-mono);
+  font-size: 15.5px;
+  line-height: 1.72;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+  padding: 14px 18px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+  tab-size: 2;
+}
+.code.sm { font-size: 14px; line-height: 1.66; padding: 12px 15px; }
+.code.xs { font-size: 12.6px; line-height: 1.6; padding: 11px 14px; }
+.code.plain { border-left-color: var(--line); }
+.code.teal { border-left-color: var(--teal); }
+.code.red { border-left-color: var(--red); }
+.t-fn  { color: var(--accent); }
+.t-str { color: var(--teal); }
+.t-cm  { color: var(--ink-faint); }
+.t-num { color: var(--ink); font-weight: 600; }
+.t-key { color: var(--accent); font-weight: 600; }
+.t-bad { color: var(--red); }
+code.inl {
+  font-family: var(--f-mono);
+  font-size: .88em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  white-space: nowrap;
+}
+
+/* ── 카드 / 콜아웃 ─────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.card.teal { border-color: var(--teal); }
+.card.red { border-color: var(--red); }
+.card-t {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+.callout {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 14px 20px;
+  border-radius: 0 3px 3px 0;
+  font-size: 18px;
+  line-height: 1.55;
+}
+.callout.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+.callout .lbl {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.callout.teal .lbl { color: var(--teal); }
+
+/* ── 인용 ──────────────────────────────────────────────────── */
+.quote {
+  font-family: var(--f-display);
+  font-size: 38px;
+  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: -.02em;
+  margin: 0;
+  text-wrap: balance;
+}
+.quote .em { color: var(--accent); }
+.quote .em2 { color: var(--teal); }
+.quote-by {
+  font-family: var(--f-mono);
+  font-size: 14px;
+  letter-spacing: .1em;
+  color: var(--ink-faint);
+  margin: 18px 0 0;
+}
+
+/* ── 아키텍처 다이어그램 ───────────────────────────────────── */
+.arch {
+  display: grid;
+  grid-template-columns: 1fr 104px 1.02fr 104px 1fr;
+  align-items: center;
+  gap: 0;
+}
+.arch-col { display: flex; flex-direction: column; gap: 11px; }
+.node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 4px;
+  padding: 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.node .n-t { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.node .n-p { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-faint); }
+.node.hero {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  padding: 20px 18px;
+}
+.node.hero .n-t { font-size: 22px; color: var(--accent); }
+.node.hero .n-p { color: var(--ink-dim); }
+.node.teal { border-color: var(--teal); background: var(--teal-soft); }
+.node.teal .n-t { color: var(--teal); }
+.node.mute { border-style: dashed; background: transparent; }
+.arch-link { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.arch-link .l-lbl {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.arch-link .l-line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  position: relative;
+}
+.arch-link .l-line::after {
+  content: "";
+  position: absolute;
+  right: 8px; top: -4px;
+  border: 4.5px solid transparent;
+  border-left-color: var(--accent);
+}
+.arch-link.teal .l-line::after { border-left-color: var(--teal); }
+
+/* ── 공유 메모리 다이어그램 ────────────────────────────────── */
+.share { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 14px; }
+.share .sh-full { grid-column: 1 / -1; }
+.share .sh-a {
+  text-align: center;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* ── 실행 레인 (동시성 vs 병렬성) ──────────────────────────── */
+.lanes { display: flex; flex-direction: column; gap: 20px; }
+.lane-h {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 8px;
+}
+.lane-t { display: flex; gap: 3px; height: 40px; }
+.lane-t + .lane-t { margin-top: 3px; }
+.blk {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  font-weight: 600;
+  border-radius: 2px;
+  min-width: 0;
+}
+.blk.a { background: var(--accent); color: var(--accent-ink); }
+.blk.b { background: var(--teal); color: var(--teal-ink); }
+.blk.idle {
+  background: var(--surface-2);
+  border: 1px dashed var(--line);
+  color: var(--ink-faint);
+  font-weight: 400;
+}
+.axis {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  color: var(--ink-faint);
+  margin-top: 7px;
+}
+
+/* ── 스택 크기 스케일 ──────────────────────────────────────── */
+.scale { display: flex; flex-direction: column; gap: 16px; }
+.sc-row { display: grid; grid-template-columns: 132px 1fr 92px; align-items: center; gap: 14px; }
+.sc-lbl { font-size: 16.5px; font-weight: 700; }
+.sc-bar { height: 26px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 2px; overflow: hidden; }
+.sc-bar > span { display: block; height: 100%; background: var(--accent); min-width: 2px; }
+.sc-bar > span.teal { background: var(--teal); }
+.sc-val { font-family: var(--f-mono); font-size: 16px; color: var(--ink-dim); text-align: right; }
+
+/* ── 숫자 오도미터 ─────────────────────────────────────────── */
+.odo-row { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.odo {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 62px;
+  font-weight: 700;
+  letter-spacing: -.03em;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.odo.sm { font-size: 34px; color: var(--ink); }
+.odo-cap { font-size: 15px; color: var(--ink-dim); }
+.factor {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-family: var(--f-mono);
+  font-size: 19px;
+  color: var(--ink-dim);
+}
+.factor b { color: var(--ink); font-size: 22px; }
+
+/* ── 단계 목록 ─────────────────────────────────────────────── */
+.steps { display: flex; flex-direction: column; gap: 0; }
+.step {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.step:last-child { border-bottom: none; }
+.step .s-n {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 600;
+  padding-top: 3px;
+}
+.step .s-c { font-family: var(--f-mono); font-size: 14.5px; color: var(--ink); }
+.step .s-d { font-size: 15.5px; color: var(--ink-dim); line-height: 1.45; margin-top: 3px; }
+.agenda .step { padding: 13px 0; }
+.agenda .s-c {
+  font-family: var(--f-display);
+  font-size: 21px;
+  font-weight: 700;
+  letter-spacing: -.015em;
+}
+
+/* ── 표지 ──────────────────────────────────────────────────── */
+.cover { display: grid; grid-template-columns: 1.06fr .94fr; gap: 46px; align-items: center; height: 100%; }
+.cover-title {
+  font-family: var(--f-display);
+  font-size: 62px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -.032em;
+  margin: 14px 0 18px;
+  text-wrap: balance;
+}
+.cover-sub { font-size: 21px; color: var(--ink-dim); line-height: 1.5; margin: 0 0 30px; }
+.cover-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .06em;
+}
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+.panel-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+.panel-body { padding: 12px 8px 8px; }
+.panel canvas { display: block; width: 100%; height: 232px; }
+.panel-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 9px 15px 13px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 챕터 구분 ─────────────────────────────────────────────── */
+.slide[data-kind="chapter"] { justify-content: center; }
+.chap { display: grid; grid-template-columns: auto 1fr; gap: 46px; align-items: center; }
+.chap-n {
+  font-family: var(--f-mono);
+  font-size: 168px;
+  font-weight: 700;
+  line-height: .82;
+  letter-spacing: -.06em;
+  color: var(--accent);
+}
+.chap-t {
+  font-family: var(--f-display);
+  font-size: 50px;
+  font-weight: 700;
+  letter-spacing: -.028em;
+  line-height: 1.12;
+  margin: 0 0 14px;
+}
+.chap-d { font-size: 19px; color: var(--ink-dim); line-height: 1.55; margin: 0; max-width: 56ch; }
+.chap-l { border-left: 1px solid var(--line); padding-left: 46px; }
+
+/* ── 퀴즈 ──────────────────────────────────────────────────── */
+.quiz { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 20px; }
+.q {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.q-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 16.5px;
+  line-height: 1.42;
+  font-weight: 600;
+}
+.q-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+.q-btn .q-n { font-family: var(--f-mono); font-size: 12.5px; color: var(--accent); flex: none; }
+.q-a {
+  display: none;
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line-soft);
+  padding-top: 9px;
+}
+.q.is-open .q-a { display: block; }
+.q-a .ref { font-family: var(--f-mono); font-size: 12px; color: var(--ink-faint); }
+
+/* ── 토글 ──────────────────────────────────────────────────── */
+.toggle { display: flex; gap: 8px; }
+.tg {
+  all: unset;
+  cursor: pointer;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.tg[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.tg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.swap > .swap-i { display: none; }
+.swap > .swap-i.on { display: flex; }
+.swap > img.swap-i.on { display: block; }
+
+/* ── 하단 크롬 ─────────────────────────────────────────────── */
+.chrome {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  background: var(--bg);
+  border-top: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.chrome .deck-id { text-transform: uppercase; white-space: nowrap; }
+.rail { flex: 1; display: flex; gap: 2px; align-items: center; height: 22px; min-width: 0; }
+.tick { flex: 1; height: 4px; background: var(--line); border-radius: 1px; transition: background .18s ease, height .18s ease; }
+.tick.done { background: var(--ink-faint); }
+.tick.now  { background: var(--accent); height: 14px; }
+.tick.chap { height: 10px; }
+.counter { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--ink-dim); }
+.counter .cur { color: var(--accent); font-weight: 600; }
+.keys { display: flex; gap: 6px; }
+.kbtn {
+  all: unset;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 4px 8px;
+  color: var(--ink-dim);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+}
+.kbtn:hover { border-color: var(--accent); color: var(--accent); }
+.kbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.kbtn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+/* ── 발표자 노트 ───────────────────────────────────────────── */
+.notes-src { display: none; }
+.notes {
+  position: fixed;
+  left: 0; right: 0; bottom: 52px;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 16px 22px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  display: none;
+  z-index: 19;
+}
+.notes.on { display: block; }
+.notes .n-h {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+/* ── 개요(썸네일) 모드 ─────────────────────────────────────── */
+.deck.is-overview .stage-wrap { place-items: start center; overflow: auto; padding: 24px 18px; }
+.deck.is-overview .stage {
+  width: 100%; height: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 256px);
+  gap: 16px;
+  justify-content: center;
+}
+.deck.is-overview .holder {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  visibility: visible;
+  width: 256px;
+  height: 144px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deck.is-overview .holder.is-active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.deck.is-overview .holder::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 5px; bottom: 4px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  color: var(--ink-faint);
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.deck.is-overview .slide {
+  position: absolute;
+  top: 0; left: 0;
+  transform: scale(.2);
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+/* ── 도움말 ────────────────────────────────────────────────── */
+.help {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  display: none;
+  place-items: center;
+  z-index: 40;
+  padding: 24px;
+}
+.help.on { display: grid; }
+.help-box {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  padding: 26px 30px;
+  min-width: 360px;
+}
+.help-box h3 {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.help-box dl { display: grid; grid-template-columns: auto 1fr; gap: 9px 20px; margin: 0; font-size: 15px; }
+.help-box dt { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.help-box dd { margin: 0; color: var(--ink-dim); }
+
+/* ── 인쇄 ──────────────────────────────────────────────────── */
+@media print {
+  @page { size: 1280px 720px; margin: 0; }
+  body { overflow: visible; background: #fff; }
+  .chrome, .notes, .help { display: none !important; }
+  .stage-wrap { position: static; display: block; inset: auto; overflow: visible; }
+  .stage { width: auto; height: auto; transform: none !important; display: block; }
+  .holder { position: static; opacity: 1; visibility: visible; break-after: page; }
+  .slide { box-shadow: none; }
+}
+</style>
+</head>
+<body>
+
+<div class="deck" id="deck">
+  <div class="stage-wrap" id="stageWrap">
+    <div class="stage" id="stage">
+    <!-- ═══════════ 01 Cover ═══════════ -->
+    <div class="holder" data-n="01">
+      <section class="slide" data-kind="cover">
+        <div class="cover">
+          <div>
+            <div class="eyebrow">Golang Concurrency · Part 1 / 11</div>
+            <h1 class="cover-title">Overview and<br />Goroutine Basics</h1>
+            <p class="cover-sub">Concurrency is <b>structure</b>, parallelism is <b>execution</b><br />— what one line of <code class="inl">go</code> really does</p>
+            <div class="cover-meta">
+              <span class="chip on">Concurrency</span>
+              <span class="chip">Goroutine</span>
+              <span class="chip">GMP scheduler</span>
+              <span class="chip">Leak prevention</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-head">
+              <span><span class="dot"></span>goroutine schedule timeline</span>
+              <span>GOMAXPROCS = 2</span>
+            </div>
+            <div class="panel-body"><canvas id="heroCanvas" width="1000" height="464"></canvas></div>
+            <div class="panel-foot">
+              <span>go func() { … }()  ×8</span>
+              <span>M = OS thread</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Greet the room + note this is Part 1 of 11. Say up front that the picture on the right is today's conclusion — 8 goroutines taking turns on 2 OS threads. Understanding this one slide is the goal.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 02 The problem ═══════════ -->
+    <div class="holder" data-n="02">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">problem</span><span class="stamp">why concurrency</span></div>
+        <h2 class="slide-title">Time spent waiting becomes <span class="em">wall-clock time</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>You must call three external APIs and merge the results</li>
+              <li>100ms each — but most of that 100ms is <b>waiting for a response</b></li>
+              <li>Sequentially that is 300ms. Meanwhile the CPU <b>sits idle</b></li>
+              <li>The three calls are <b>independent</b>. Nothing stops the waits from overlapping</li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">// sequential — the waits pile up</span>
+a := fetch(u1)   <span class="t-cm">// 100ms</span>
+b := fetch(u2)   <span class="t-cm">// 100ms</span>
+c := fetch(u3)   <span class="t-cm">// 100ms</span>
+<span class="t-cm">// total 300ms</span>
+
+<span class="t-cm">// concurrent — the waits overlap</span>
+<span class="t-key">for</span> i, u := <span class="t-key">range</span> urls {
+    <span class="t-key">go</span> <span class="t-fn">func</span>() { out[i] = fetch(u) }()
+}
+wg.<span class="t-fn">Wait</span>()
+<span class="t-cm">// total ~100ms</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">Go's answer</span>
+            <code class="inl">go</code> and <code class="inl">channel</code> are provided <b>by the language itself</b>. There is no step where you pick a library.
+          </div>
+        </div>
+        <div class="notes-src">Opening with "who has written code that calls three APIs one after another?" lands fast. The key point is that the CPU is not busy, it is waiting. Preview that Chapter 3 (when to use it) also covers the opposite case — CPU-bound work.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 03 Series roadmap ═══════════ -->
+    <div class="holder" data-n="03">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">series</span><span class="stamp">11 parts</span></div>
+        <h2 class="slide-title">Where today sits in the whole series</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl sm">
+              <thead><tr><th>Part</th><th>Title</th><th>Area</th></tr></thead>
+              <tbody>
+                <tr class="on"><td>Part 1</td><td>Overview and Goroutine Basics</td><td>Execution unit</td></tr>
+                <tr><td>Parts 2 · 3</td><td>Channels in Depth / Select and Advanced Channel Patterns</td><td>Communication</td></tr>
+                <tr><td>Parts 4 · 5</td><td>Complete sync Package Guide / Complete Context Guide</td><td>Sync · lifecycle</td></tr>
+                <tr><td>Parts 6 · 7</td><td>Concurrency Patterns in Practice / Error Handling Strategies</td><td>Design patterns</td></tr>
+                <tr><td>Parts 8 · 9</td><td>Go Memory Model and Atomic / Debugging and Race Detector</td><td>Low level · debugging</td></tr>
+                <tr><td>Parts 10 · 11</td><td>Real Project and Best Practices / go tool trace Visualization</td><td>Practice · tooling</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="dim" style="margin:0;font-size:17px;">Today is the first part. The other ten all sit on top of it, so
+          <b>what a goroutine is and how it gets scheduled</b> is settled here.</p>
+        </div>
+        <div class="notes-src">Do not try to introduce the whole series. Just place today as "the part that lays the floor". Drawing a line at "channels come next time" keeps questions from running ahead.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 04 Agenda ═══════════ -->
+    <div class="holder" data-n="04">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">agenda</span><span class="stamp">agenda</span></div>
+        <h2 class="slide-title">What we cover today</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="steps agenda">
+            <div class="step">
+              <span class="s-n">01</span>
+              <div><div class="s-c">What concurrency is</div>
+              <div class="s-d">Concurrency vs Parallelism · CSP model · when to use it and when not</div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">02</span>
+              <div><div class="s-c">Goroutine basics</div>
+              <div class="s-d">the <code class="inl">go</code> keyword · vs OS threads · ordering and lifecycle</div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">03</span>
+              <div><div class="s-c">GMP scheduler</div>
+              <div class="s-d">roles of G · M · P · work stealing · <code class="inl">GOMAXPROCS</code></div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">04</span>
+              <div><div class="s-c">Comparison with other languages</div>
+              <div class="s-d">Kotlin Coroutine · Java Platform / Virtual Thread · function coloring</div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">05</span>
+              <div><div class="s-c">Goroutine leak</div>
+              <div class="s-d">why they leak · stopping them with <code class="inl">context</code> · the exit-path rule</div></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Chapters 1 and 2 are concept and basics, 3 is the mechanism, 4 is for an audience with background, 5 is the practical trap. If time runs short, cut Chapter 4 (language comparison) entirely and keep 5.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 05 Chapter 1 ═══════════ -->
+    <div class="holder" data-n="05" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">01</div>
+          <div class="chap-l">
+            <h2 class="chap-t">What concurrency is</h2>
+            <p class="chap-d">Concurrency and parallelism are not the same word. Starting there,
+            we look at why Go chose CSP — and <b>when not to use it</b>.</p>
+          </div>
+        </div>
+        <div class="notes-src">This chapter is conceptual and can drag. Change the rhythm — one table, one diagram, one quote — and move quickly.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 06 Concurrency vs Parallelism ═══════════ -->
+    <div class="holder" data-n="06">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · concept</span><span class="stamp">concurrency vs parallelism</span></div>
+        <h2 class="slide-title">Often mixed up, but <span class="em">different words</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Aspect</th><th>Concurrency</th><th>Parallelism</th></tr></thead>
+              <tbody>
+                <tr><td>Definition</td><td>Structure for <b>dealing with</b> many tasks</td><td><b>Running</b> many tasks at the same time</td></tr>
+                <tr><td>Core</td><td><b>Composition</b> of work</td><td><b>Execution</b> of work</td></tr>
+                <tr><td>CPU</td><td class="hl">Holds even on a single CPU</td><td>Needs multiple CPUs</td></tr>
+                <tr><td>Analogy</td><td>One person alternating between jobs</td><td>Several people each working at once</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Remember just this</span>
+            Concurrency holds on a single-core machine. <b>Dealing with at once</b> and <b>running at once</b> are separate things.
+          </div>
+        </div>
+        <div class="notes-src">Ask the room "is concurrency possible on one CPU?" first — most say no. Flipping that once here makes the rest easy. Directly tied to quiz Q1.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 07 Execution lanes ═══════════ -->
+    <div class="holder" data-n="07">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · concept</span><span class="stamp">timeline</span></div>
+        <h2 class="slide-title">Same two tasks, two different pictures</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="lanes">
+            <div>
+              <div class="lane-h">Concurrency — 1 CPU · taking turns</div>
+              <div class="lane-t">
+                <span class="blk a" style="flex:2.2">A</span>
+                <span class="blk b" style="flex:1.6">B</span>
+                <span class="blk a" style="flex:1.2">A</span>
+                <span class="blk b" style="flex:2.4">B</span>
+                <span class="blk a" style="flex:1.8">A</span>
+                <span class="blk b" style="flex:1.4">B</span>
+                <span class="blk a" style="flex:1.4">A</span>
+              </div>
+            </div>
+            <div>
+              <div class="lane-h">Parallelism — 2 CPUs · truly at the same time</div>
+              <div class="lane-t"><span class="blk a" style="flex:0 0 55%">Task A</span><span class="blk idle" style="flex:1">idle</span></div>
+              <div class="lane-t"><span class="blk b" style="flex:0 0 45%">Task B</span><span class="blk idle" style="flex:1">idle</span></div>
+            </div>
+            <div class="axis"><span>start</span><span>time →</span><span>end</span></div>
+          </div>
+          <div class="callout">
+            <span class="lbl">Go's stance</span>
+            <b>Designing the program concurrently</b> is the developer's job; how many CPUs it runs on is <b>the runtime's call</b>.
+          </div>
+        </div>
+        <div class="notes-src">Point with your hand at how the lower two lanes finish earlier (horizontal length) for the same amount of work. Add one line that speed is not always the point of concurrency — structure comes first. With only one CPU you get the top picture, and concurrency still holds.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 08 Rob Pike quote ═══════════ -->
+    <div class="holder" data-n="08">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · concept</span><span class="stamp">rob pike</span></div>
+        <h2 class="slide-title">One sentence from Go's creator</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div>
+            <p class="quote">“Concurrency is about <span class="em">dealing with</span> lots of things at once.<br />
+            Parallelism is about <span class="em2">doing</span> lots of things at once.”</p>
+            <p class="quote-by">— Rob Pike</p>
+          </div>
+          <div class="cols c-2">
+            <div class="card">
+              <p class="card-t" style="color:var(--accent);">Dealing with — structure</p>
+              <p style="margin:0;font-size:17px;line-height:1.5;" class="dim">Splitting code into <b>independently runnable units</b>. This is a story about the program's <b>structure</b>.</p>
+            </div>
+            <div class="card">
+              <p class="card-t" style="color:var(--teal);">Doing — execution</p>
+              <p style="margin:0;font-size:17px;line-height:1.5;" class="dim">Actually <b>running those units at once</b> on several CPUs. That part belongs to the runtime and the hardware.</p>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The sentence comes from the Go Blog talk "Concurrency is not parallelism". The link to the original video is on the last reference slide. Pause here and give people time to read.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 09 CSP model ═══════════ -->
+    <div class="holder" data-n="09">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · concept</span><span class="stamp">csp</span></div>
+        <h2 class="slide-title">The model Go picked — <span class="em">CSP</span></h2>
+        <p class="slide-lede">Communicating Sequential Processes, proposed by Tony Hoare in 1978. There is only one core idea — <b>independent processes communicate by passing messages.</b></p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b" style="align-items:center;">
+            <div class="tbl-wrap">
+              <table class="tbl sm">
+                <thead><tr><th>CSP concept</th><th>Go's implementation</th></tr></thead>
+                <tbody>
+                  <tr><td>Independent unit of execution</td><td class="num-col hl">goroutine</td></tr>
+                  <tr><td>Means of passing messages</td><td class="num-col hl">channel</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="arch" style="grid-template-columns:1fr 150px 1fr;">
+              <div class="arch-col">
+                <div class="node hero"><span class="n-t">Goroutine A</span><span class="n-p">owns the data</span></div>
+              </div>
+              <div class="arch-link teal"><span class="l-lbl">channel</span><span class="l-line"></span><span class="l-lbl">ownership moves</span></div>
+              <div class="arch-col">
+                <div class="node teal"><span class="n-t">Goroutine B</span><span class="n-p">receives the data</span></div>
+              </div>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Why this is safe</span>
+            Since <b>ownership of the data moves through the channel</b>, only one goroutine touches it at any moment.
+          </div>
+        </div>
+        <div class="notes-src">The name CSP itself does not matter. Leaving one line — "they hand things over as messages" — is enough. If the actor model in Erlang/Akka comes up, just note that Go has channels as first-class objects instead of mailboxes, and move on.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 10 Go proverb ═══════════ -->
+    <div class="holder" data-n="10">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · concept</span><span class="stamp">go proverb</span></div>
+        <h2 class="slide-title">Do not communicate by sharing memory; <span class="em">share memory by communicating</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card red">
+              <p class="card-t" style="color:var(--red);">Traditional — Shared Memory + Lock</p>
+              <div class="share">
+                <div class="node"><span class="n-t">Thread A</span></div>
+                <div class="node"><span class="n-t">Thread B</span></div>
+                <div class="sh-a sh-full">↓ &nbsp; lock / unlock &nbsp; ↓</div>
+                <div class="node sh-full mute"><span class="n-t">Shared Data</span><span class="n-p">guarded by mutex</span></div>
+              </div>
+              <p class="dim" style="margin:12px 0 0;font-size:16px;line-height:1.45;">A <b>human</b> has to apply the guard. Deadlocks and race conditions come from here.</p>
+            </div>
+            <div class="card teal">
+              <p class="card-t" style="color:var(--teal);">The Go way — Message Passing</p>
+              <div class="arch" style="grid-template-columns:1fr 100px 1fr;">
+                <div class="arch-col"><div class="node teal"><span class="n-t">Goroutine A</span></div></div>
+                <div class="arch-link teal"><span class="l-lbl">chan</span><span class="l-line"></span></div>
+                <div class="arch-col"><div class="node teal"><span class="n-t">Goroutine B</span></div></div>
+              </div>
+              <p class="dim" style="margin:12px 0 0;font-size:16px;line-height:1.45;">Because ownership <b>moves</b>, two places never touch it at once. The lock becomes unnecessary.</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">But it is not an absolute rule</span>
+            Go has <code class="inl">sync.Mutex</code> and uses it when needed. Go's attitude is simply that <b>the default choice is a channel</b>.
+          </div>
+        </div>
+        <div class="notes-src">"So we should never use a mutex?" always comes up. The last callout is the answer. Cases like a counter that must share state are covered in Part 4 (the sync package).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 11 When to use ═══════════ -->
+    <div class="holder" data-n="11">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · concept</span><span class="stamp">when to use</span></div>
+        <h2 class="slide-title">Concurrency is <span class="em">not free</span></h2>
+        <p class="slide-lede">Scattering goroutines does not make things faster. You pay the cost of complexity first.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2 grow">
+            <div class="card teal">
+              <p class="card-t" style="color:var(--teal);">Worth using</p>
+              <ul class="bul teal" style="font-size:17px;">
+                <li><b>Work with a lot of I/O waiting</b> — HTTP requests, DB queries, file reads/writes</li>
+                <li><b>Parallel handling of independent work</b> — calling several APIs at once</li>
+                <li><b>Event-driven handling</b> — request handling in a web server</li>
+                <li><b>Pipeline processing</b> — chaining data transform stages</li>
+              </ul>
+            </div>
+            <div class="card red">
+              <p class="card-t" style="color:var(--red);">Over-engineering</p>
+              <ul class="bul red" style="font-size:17px;">
+                <li>When plain sequential code is enough — simple data transforms</li>
+                <li>Spawning too many goroutines for <b>CPU-bound work</b></li>
+                <li>So much shared state that locking gets complex — revisit the design</li>
+                <li>Complex enough that debugging becomes hard</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The right-hand card matters more. In particular, throwing 10,000 goroutines at CPU-bound work does not go faster than the core count — this connects back in Chapter 3 with GOMAXPROCS.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 12 Chapter 2 ═══════════ -->
+    <div class="holder" data-n="12" data-chapter="2">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">02</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Goroutine basics</h2>
+            <p class="chap-d">A unit of execution made with one keyword. You avoid accidents only by knowing
+            exactly how light it is and what it <b>does not guarantee</b>.</p>
+          </div>
+        </div>
+        <div class="notes-src">The core of this chapter is not "it is light" but two things: "order is not guaranteed" and "when main ends, everything ends". The mine people step on most in practice is right here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 13 The go keyword ═══════════ -->
+    <div class="holder" data-n="13">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Goroutine</span><span class="stamp">go keyword</span></div>
+        <h2 class="slide-title">Put <span class="em">go</span> in front of a call. That is all</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2" style="align-items:center;">
+            <pre class="code"><span class="t-cm">// create a goroutine — the go keyword</span>
+<span class="t-key">go</span> <span class="t-fn">func</span>() {
+    fmt.<span class="t-fn">Println</span>(<span class="t-str">"goroutine ran"</span>)
+}()
+
+<span class="t-cm">// named functions work too</span>
+<span class="t-key">go</span> <span class="t-fn">sayHello</span>(<span class="t-str">"World"</span>)</pre>
+            <ul class="bul">
+              <li>A <b>lightweight unit of execution</b> managed by the Go runtime — not an OS thread</li>
+              <li>No extra library, no thread-pool config, no <code class="inl">async/await</code></li>
+              <li>The call <b>returns immediately</b>. The function starts running elsewhere</li>
+              <li>The whole standard library is designed on this premise</li>
+            </ul>
+          </div>
+          <div class="callout">
+            <span class="lbl">What comes with it</span>
+            As easy as it is to create, it is <b>just as easy to forget to clean up.</b> Chapter 5 pays that price.
+          </div>
+        </div>
+        <div class="notes-src">A quick demo works well here. Showing that a Println with go in front prints nothing leads naturally into slide 17 (the main goroutine).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 14 Goroutine vs OS Thread ═══════════ -->
+    <div class="holder" data-n="14">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Goroutine</span><span class="stamp">vs os thread</span></div>
+        <h2 class="slide-title">How is it different from an OS thread</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Aspect</th><th>Goroutine</th><th>OS Thread</th></tr></thead>
+              <tbody>
+                <tr class="on"><td>Initial stack size</td><td>~2KB — grows dynamically as needed</td><td>~1MB fixed</td></tr>
+                <tr><td>Creation cost</td><td>Very cheap</td><td>Relatively expensive</td></tr>
+                <tr><td>Scheduling</td><td class="hl">Go runtime — user space</td><td>OS kernel</td></tr>
+                <tr><td>Concurrent count</td><td>Hundreds of thousands</td><td>Thousands</td></tr>
+                <tr><td>Context switch</td><td>Fast — three registers</td><td>Slow — all registers</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">The key sentence</span>
+            Goroutines are <b>multiplexed</b> onto OS threads. Thousands to tens of thousands run on a handful of OS threads.
+          </div>
+        </div>
+        <div class="notes-src">Why "scheduling in user space" is fast — because there is no switch into kernel mode. Do not go deep here; say it will be drawn out in Chapter 3 on GMP.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 15 Stack size scale ═══════════ -->
+    <div class="holder" data-n="15">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Goroutine</span><span class="stamp">stack size</span></div>
+        <h2 class="slide-title">Put 2KB and 1MB on the <span class="em">same axis</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b" style="align-items:center;">
+            <div class="stack">
+              <div class="factor"><span>1 MB</span><span>÷</span><span>2 KB</span><span>=</span></div>
+              <div class="odo-row">
+                <span class="odo" data-odo="512">0</span>
+                <span class="odo-cap">× — that many more in the same memory</span>
+              </div>
+              <p class="dim" style="margin:0;font-size:16.5px;line-height:1.5;">That is why <b>hundreds of thousands</b> of goroutines and <b>thousands</b> of OS threads are the realistic limits.
+              And a goroutine stack is not fixed — it <b>grows when needed</b>.</p>
+            </div>
+            <div class="scale">
+              <div class="sc-row">
+                <span class="sc-lbl">OS Thread</span>
+                <span class="sc-bar"><span style="width:100%"></span></span>
+                <span class="sc-val">1 MB</span>
+              </div>
+              <div class="sc-row">
+                <span class="sc-lbl">Goroutine</span>
+                <span class="sc-bar"><span class="teal" style="width:0.195%"></span></span>
+                <span class="sc-val">2 KB</span>
+              </div>
+              <p class="dim" style="margin:0;font-size:15.5px;line-height:1.45;">The lower bar looking like <b>a single line</b> is not a bug. That is the real ratio.</p>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Pause while the number counts up. Once 512 sinks in, "10,000 goroutines" on slide 19 needs no explaining.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 16 Non-deterministic order ═══════════ -->
+    <div class="holder" data-n="16">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Goroutine</span><span class="stamp">non-deterministic</span></div>
+        <h2 class="slide-title">Execution order is <span class="em">not guaranteed</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b" style="align-items:center;">
+            <div class="stack">
+              <ul class="bul">
+                <li>Launching 10 in order does not mean they run in order</li>
+                <li>Which <code class="inl">P</code>'s queue they land in and when they are pulled <b>differs every run</b></li>
+                <li>If a test happens to pass, that is <b>luck</b></li>
+              </ul>
+              <div class="callout">
+                <span class="lbl">If you need order</span>
+                You have to <b>build it yourself</b> with a channel or <code class="inl">sync</code>. It is not given by default.
+              </div>
+            </div>
+            <pre class="code sm"><span class="t-key">const</span> numGoroutines = <span class="t-num">10</span>
+wg.<span class="t-fn">Add</span>(numGoroutines)
+
+<span class="t-key">for</span> i := <span class="t-key">range</span> numGoroutines {
+    <span class="t-key">go</span> <span class="t-fn">func</span>() {
+        <span class="t-key">defer</span> wg.<span class="t-fn">Done</span>()
+        mu.<span class="t-fn">Lock</span>()
+        order = <span class="t-fn">append</span>(order, i)
+        mu.<span class="t-fn">Unlock</span>()
+    }()
+}
+wg.<span class="t-fn">Wait</span>()
+t.<span class="t-fn">Logf</span>(<span class="t-str">"exec order: %v"</span>, order)
+
+<span class="t-cm">// exec order: [1 4 2 3 5 9 8 0 6 7]</span></pre>
+          </div>
+        </div>
+        <div class="notes-src">Running the demo two or three times so a different result appears each time needs no further explanation. Note that since Go 1.22 the for-loop variable is fresh each iteration, so you no longer pass i as an argument.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 17 main goroutine ═══════════ -->
+    <div class="holder" data-n="17">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Goroutine</span><span class="stamp">lifecycle</span></div>
+        <h2 class="slide-title">When main ends, <span class="em">everything ends</span></h2>
+        <p class="slide-lede"><code class="inl">main()</code> runs on the main goroutine. Once it returns, the process exits <b>regardless</b> of whether other goroutines finished.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2" style="align-items:center;">
+            <pre class="code sm red"><span class="t-key">func</span> <span class="t-fn">TestMainExitKillsGoroutines</span>(t *testing.T) {
+    <span class="t-key">var</span> completed atomic.Bool
+
+    <span class="t-key">go</span> <span class="t-fn">func</span>() {
+        time.<span class="t-fn">Sleep</span>(<span class="t-num">100</span> * time.Millisecond)
+        completed.<span class="t-fn">Store</span>(<span class="t-key">true</span>)
+    }()
+
+    <span class="t-cm">// without waiting it never completes</span>
+    assert.<span class="t-fn">False</span>(t, completed.<span class="t-fn">Load</span>())
+}</pre>
+            <div class="stack">
+              <ul class="bul">
+                <li>The goroutine just vanishes <b>with no chance to clean up</b> — even <code class="inl">defer</code> does not run</li>
+                <li>Log flushes and connection closes are lost too</li>
+                <li>90% of “why is nothing printed?” is this</li>
+              </ul>
+              <div class="callout">
+                <span class="lbl">Rule</span>
+                If you create a goroutine, decide <b>who waits for it</b> at the same time.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">If you ran the go Println demo on slide 13, give the answer here. People have seen code patched with time.Sleep; why that is bad gets explained next when it is replaced by a WaitGroup.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 18 How to wait ═══════════ -->
+    <div class="holder" data-n="18">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Goroutine</span><span class="stamp">waitgroup</span></div>
+        <h2 class="slide-title">How to wait — <code class="inl">sync.WaitGroup</code></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2" style="align-items:center;">
+            <pre class="code sm teal"><span class="t-key">func</span> <span class="t-fn">TestWaitGroupSolution</span>(t *testing.T) {
+    <span class="t-key">var</span> completed atomic.Bool
+    <span class="t-key">var</span> wg sync.WaitGroup
+
+    wg.<span class="t-fn">Add</span>(<span class="t-num">1</span>)
+    <span class="t-key">go</span> <span class="t-fn">func</span>() {
+        <span class="t-key">defer</span> wg.<span class="t-fn">Done</span>()
+        time.<span class="t-fn">Sleep</span>(<span class="t-num">50</span> * time.Millisecond)
+        completed.<span class="t-fn">Store</span>(<span class="t-key">true</span>)
+    }()
+
+    wg.<span class="t-fn">Wait</span>() <span class="t-cm">// block until done</span>
+    assert.<span class="t-fn">True</span>(t, completed.<span class="t-fn">Load</span>())
+}</pre>
+            <div class="stack">
+              <div class="steps">
+                <div class="step"><span class="s-n">01</span><div><div class="s-c">wg.Add(n)</div><div class="s-d">Raise the count <b>before launching the goroutine</b></div></div></div>
+                <div class="step"><span class="s-n">02</span><div><div class="s-c">defer wg.Done()</div><div class="s-d">Put it on the <b>first line</b> inside the goroutine — the counter drops even on panic</div></div></div>
+                <div class="step"><span class="s-n">03</span><div><div class="s-c">wg.Wait()</div><div class="s-d">Blocks until the count reaches zero</div></div></div>
+              </div>
+              <p class="dim" style="margin:0;font-size:16.5px;line-height:1.5;">A channel can do the same job.
+              Code patched with <code class="inl">time.Sleep</code> is <b>gambling, not waiting</b>.</p>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Mention in one line the trap of calling Add inside the goroutine, which creates a race. The rest of WaitGroup's details are covered in Part 4.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 19 Ten thousand ═══════════ -->
+    <div class="holder" data-n="19">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Goroutine</span><span class="stamp">lightweight</span></div>
+        <h2 class="slide-title">Create 10,000 and <span class="em">nothing happens</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2b" style="align-items:center;">
+            <div class="stack">
+              <div class="odo-row">
+                <span class="odo" data-odo="10000">0</span>
+                <span class="odo-cap">goroutines — all finished fine</span>
+              </div>
+              <div class="tbl-wrap">
+                <table class="tbl sm">
+                  <thead><tr><th>Creating 10,000</th><th>Initial stack total</th></tr></thead>
+                  <tbody>
+                    <tr class="on"><td>Goroutine (~2KB)</td><td class="num-col">about 20 MB</td></tr>
+                    <tr><td>OS Thread (~1MB)</td><td class="num-col">about 10 GB</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <p class="faint" style="margin:0;font-size:15px;">Plain arithmetic from the stack sizes on the previous slide.</p>
+            </div>
+            <pre class="code sm"><span class="t-key">const</span> numGoroutines = <span class="t-num">10000</span>
+<span class="t-key">var</span> counter atomic.Int64
+<span class="t-key">var</span> wg sync.WaitGroup
+wg.<span class="t-fn">Add</span>(numGoroutines)
+
+<span class="t-key">for</span> <span class="t-key">range</span> numGoroutines {
+    <span class="t-key">go</span> <span class="t-fn">func</span>() {
+        <span class="t-key">defer</span> wg.<span class="t-fn">Done</span>()
+        counter.<span class="t-fn">Add</span>(<span class="t-num">1</span>)
+    }()
+}
+
+wg.<span class="t-fn">Wait</span>()
+assert.<span class="t-fn">Equal</span>(t, <span class="t-fn">int64</span>(numGoroutines), counter.<span class="t-fn">Load</span>())</pre>
+          </div>
+        </div>
+        <div class="notes-src">Say "10,000" in a tone that makes it the default, not something to marvel at. It does not mean you can create them without limit though — if you need a cap, use the semaphore pattern (Part 6).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 20 Chapter 3 ═══════════ -->
+    <div class="holder" data-n="20" data-chapter="3">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">03</div>
+          <div class="chap-l">
+            <h2 class="chap-t">GMP scheduler</h2>
+            <p class="chap-d">The OS knows nothing about goroutines, so how does this work?
+            We look at how the Go runtime schedules <b>in user space</b>.</p>
+          </div>
+        </div>
+        <div class="notes-src">This is internals, and going deep has no end. The goal is to leave only three letters — G, M, P — plus work stealing and GOMAXPROCS.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 21 GMP model ═══════════ -->
+    <div class="holder" data-n="21">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · scheduler</span><span class="stamp">gmp model</span></div>
+        <h2 class="slide-title">A structure in three letters — <span class="em">G · M · P</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node teal"><span class="n-t">G1</span><span class="n-p">running</span></div>
+              <div class="node"><span class="n-t">G2</span><span class="n-p">waiting — run queue</span></div>
+              <div class="node"><span class="n-t">G3</span><span class="n-p">waiting — run queue</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">run queue</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">P1</span><span class="n-p">logical processor · owns run queue</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">bind</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">M1</span><span class="n-p">OS Thread — runs on the CPU</span></div>
+              <div class="node mute"><span class="n-t">CPU Core</span><span class="n-p">hardware</span></div>
+            </div>
+          </div>
+          <div class="tbl-wrap">
+            <table class="tbl sm">
+              <thead><tr><th>Component</th><th>Role</th></tr></thead>
+              <tbody>
+                <tr><td>G — Goroutine</td><td>Lightweight unit holding the function to run and its stack</td></tr>
+                <tr><td>M — Machine</td><td>OS thread. It actually executes code on the CPU</td></tr>
+                <tr class="on"><td>P — Processor</td><td>Logical processor. It manages the run queue of goroutines</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="notes-src">Why P is needed comes up every time. Explaining it as "M (the thread) can block, so the list of work (P) was pulled off the thread" meshes with the three steps on the next slide.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 22 Scheduling flow ═══════════ -->
+    <div class="holder" data-n="22">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · scheduler</span><span class="stamp">scheduling flow</span></div>
+        <h2 class="slide-title">One trip around the loop</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a" style="align-items:center;">
+            <div class="steps">
+              <div class="step"><span class="s-n">01</span><div><div class="s-c">go f()</div><div class="s-d">A new <code class="inl">G</code> goes into the current <code class="inl">P</code>'s <b>local run queue</b></div></div></div>
+              <div class="step"><span class="s-n">02</span><div><div class="s-c">P → M</div><div class="s-d"><code class="inl">P</code> pulls goroutines off the queue one by one and runs them on its bound <code class="inl">M</code></div></div></div>
+              <div class="step"><span class="s-n">03</span><div><div class="s-c">block → switch</div><div class="s-d">On I/O, channel waits or <code class="inl">time.Sleep</code>, it <b>switches to the next G at once</b></div></div></div>
+              <div class="step"><span class="s-n">04</span><div><div class="s-c">work stealing</div><div class="s-d">When the local queue empties, it <b>steals from another P's queue</b></div></div></div>
+            </div>
+            <div class="stack">
+              <div class="callout teal">
+                <span class="lbl">Why this switch is cheap</span>
+                It never goes through the kernel. <b>In user space</b>, swapping a few registers is the whole job.
+              </div>
+              <div class="callout">
+                <span class="lbl">What work stealing does</span>
+                It keeps a busy <code class="inl">P</code> and an idle <code class="inl">P</code> from coexisting, <b>evening out the load on its own</b>.
+              </div>
+              <p class="dim" style="margin:0;font-size:16.5px;line-height:1.5;">Since Go 1.14 it is <b>preemptive</b>, so the runtime
+              forcibly pulls off a goroutine that hogs the CPU.</p>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Step 3 is the answer to slide 2 (waiting on I/O). Connect the picture: while waiting, M is not idle — it grabs the next G.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 23 GOMAXPROCS ═══════════ -->
+    <div class="holder" data-n="23">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · scheduler</span><span class="stamp">gomaxprocs</span></div>
+        <h2 class="slide-title"><code class="inl">GOMAXPROCS</code> — how many can <span class="em">run</span> at once</h2>
+        <p class="slide-lede">It is not <b>how many goroutines you can create</b>; it sets how many <code class="inl">P</code>s exist. The default is the CPU core count.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2" style="align-items:center;">
+            <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">TestGOMAXPROCS</span>(t *testing.T) {
+    <span class="t-cm">// passing 0 returns the current value unchanged</span>
+    currentProcs := runtime.<span class="t-fn">GOMAXPROCS</span>(<span class="t-num">0</span>)
+    numCPU := runtime.<span class="t-fn">NumCPU</span>()
+
+    t.<span class="t-fn">Logf</span>(<span class="t-str">"NumCPU: %d"</span>, numCPU)           <span class="t-cm">// 12</span>
+    t.<span class="t-fn">Logf</span>(<span class="t-str">"GOMAXPROCS: %d"</span>, currentProcs) <span class="t-cm">// 12</span>
+
+    runtime.<span class="t-fn">GOMAXPROCS</span>(<span class="t-num">1</span>) <span class="t-cm">// down to one P</span>
+}</pre>
+            <div class="stack">
+              <div class="card">
+                <p class="card-t" style="color:var(--accent);">GOMAXPROCS = 1</p>
+                <p style="margin:0;font-size:16.5px;line-height:1.5;" class="dim">You can still create <b>as many goroutines as you like.</b> Only one runs at a time — concurrency yes, parallelism no. <b>Useful for reproducing races and debugging</b>.</p>
+              </div>
+              <div class="card teal">
+                <p class="card-t" style="color:var(--teal);">GOMAXPROCS = N</p>
+                <p style="margin:0;font-size:16.5px;line-height:1.5;" class="dim">At most N run physically at once. <b>Leaving the default alone is recommended</b>. In a container, just check that it matches the CPU limit.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The most common misunderstanding is "isn't it a cap on the number of goroutines?". Quiz Q4 asks exactly that. Do not go deep on the container issue where GOMAXPROCS picks up the host core count — one line is enough.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 24 Chapter 4 ═══════════ -->
+    <div class="holder" data-n="24" data-chapter="4">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">04</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Comparison with other languages</h2>
+            <p class="chap-d">Set side by side with Kotlin coroutines and Java threads, it gets clear
+            <b>what goroutines gave up and what they gained</b>.</p>
+          </div>
+        </div>
+        <div class="notes-src">Adjust the weight to the audience. With many JVM people this is the chapter that lands best; otherwise one table is enough before moving on.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 25 Full comparison table ═══════════ -->
+    <div class="holder" data-n="25">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · comparison</span><span class="stamp">side by side</span></div>
+        <h2 class="slide-title">All four side by side</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl sm">
+              <thead><tr><th>Aspect</th><th>Go Goroutine</th><th>Kotlin Coroutine</th><th>Java Platform Thread</th><th>Java Virtual Thread (21+)</th></tr></thead>
+              <tbody>
+                <tr class="on"><td>Stack size</td><td>~2KB · grows</td><td>stackless · heap object</td><td>~1MB fixed</td><td>~few KB · dynamic</td></tr>
+                <tr><td>Scheduling</td><td>Go runtime · <b>preemptive</b></td><td>cooperative · suspend/resume</td><td>OS kernel</td><td>JVM · cooperative</td></tr>
+                <tr><td>Creation cost</td><td>Very cheap</td><td>Very cheap</td><td>Expensive</td><td>Cheap</td></tr>
+                <tr><td>Concurrent count</td><td>Hundreds of thousands</td><td>Hundreds of thousands</td><td>Thousands</td><td>Millions</td></tr>
+                <tr><td>Communication</td><td class="hl">Channel — CSP</td><td>Flow, Channel</td><td>synchronized, Lock</td><td>synchronized, Lock</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">The rows to watch</span>
+            Not the numbers — <b>scheduling</b> and <b>communication</b>. The remaining slides just unpack those two.
+          </div>
+        </div>
+        <div class="notes-src">Do not read the table cell by cell. Point at two rows and move on. If "millions" for Virtual Thread gets a reaction, preview that the missing channel is covered on slide 28.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 26 preemptive vs cooperative ═══════════ -->
+    <div class="holder" data-n="26">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · comparison</span><span class="stamp">preemptive vs cooperative</span></div>
+        <h2 class="slide-title">The biggest difference is <span class="em">when it yields</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack tight">
+              <p class="card-t" style="margin:0;">Kotlin — cooperative</p>
+              <pre class="code sm plain"><span class="t-cm">// suspends only at suspend points</span>
+<span class="t-key">suspend fun</span> <span class="t-fn">fetchData</span>() {
+    <span class="t-fn">delay</span>(<span class="t-num">1000</span>)  <span class="t-cm">// yields here</span>
+
+    <span class="t-cm">// CPU work without suspend</span>
+    <span class="t-cm">// never yields</span>
+}</pre>
+              <p class="dim" style="margin:0;font-size:16px;line-height:1.45;">Code that just spins on the CPU <b>holds the thread</b> and will not let go.</p>
+            </div>
+            <div class="stack tight">
+              <p class="card-t" style="margin:0;color:var(--accent);">Go — preemptive</p>
+              <pre class="code sm"><span class="t-cm">// runtime switches, no keyword</span>
+<span class="t-key">func</span> <span class="t-fn">fetchData</span>() {
+    time.<span class="t-fn">Sleep</span>(time.Second)
+
+    <span class="t-cm">// CPU-bound work too is</span>
+    <span class="t-cm">// forcibly switched (Go 1.14+)</span>
+}</pre>
+              <p class="dim" style="margin:0;font-size:16px;line-height:1.45;">If a goroutine hogs the CPU, <b>the runtime pulls it off</b>.</p>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Where you feel it in practice</span>
+            In Go you never have to think about “inserting a yield point”.
+          </div>
+        </div>
+        <div class="notes-src">One line of history: before Go 1.14 a tight loop really could starve the scheduler. Today signal-based asynchronous preemption is in place.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 27 Function coloring ═══════════ -->
+    <div class="holder" data-n="27">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · comparison</span><span class="stamp">function coloring</span></div>
+        <h2 class="slide-title">Function coloring — Go has <span class="em">no colors</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack tight">
+              <p class="card-t" style="margin:0;">Kotlin — the color spreads</p>
+              <pre class="code sm plain"><span class="t-key">suspend fun</span> <span class="t-fn">a</span>() = <span class="t-fn">b</span>()
+<span class="t-key">suspend fun</span> <span class="t-fn">b</span>() = <span class="t-fn">c</span>()
+<span class="t-key">suspend fun</span> <span class="t-fn">c</span>() = <span class="t-fn">delay</span>(<span class="t-num">100</span>)
+
+<span class="t-cm">// the moment c becomes suspend,</span>
+<span class="t-cm">// suspend spreads up the whole chain</span></pre>
+              <p class="dim" style="margin:0;font-size:16px;line-height:1.45;">A <code class="inl">suspend</code> function is callable only from a <code class="inl">suspend</code> function or a coroutine.</p>
+            </div>
+            <div class="stack tight">
+              <p class="card-t" style="margin:0;color:var(--accent);">Go — they are all the same function</p>
+              <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">a</span>() { <span class="t-fn">b</span>() }
+<span class="t-key">func</span> <span class="t-fn">b</span>() { <span class="t-fn">c</span>() }
+<span class="t-key">func</span> <span class="t-fn">c</span>() { time.<span class="t-fn">Sleep</span>(t) }
+
+<span class="t-key">go</span> <span class="t-fn">a</span>()  <span class="t-cm">// any func as a goroutine</span>
+<span class="t-fn">a</span>()     <span class="t-cm">// or just call it</span></pre>
+              <p class="dim" style="margin:0;font-size:16px;line-height:1.45;">There is no <code class="inl">async</code> · <code class="inl">await</code> · <code class="inl">suspend</code> distinction at all.</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">Where Kotlin is better instead</span>
+            <b>Structured concurrency</b> is built into the language, so cancelling a parent cancels its children, and
+            <code class="inl">CoroutineExceptionHandler</code> makes <b>error propagation</b> systematic.
+          </div>
+        </div>
+        <div class="notes-src">This slide keeps the balance. Taking a "Go wins" tone closes off the JVM crowd. State on the next slide that Go has no structured concurrency, so Context and WaitGroup must be managed by hand.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 28 Java Thread ═══════════ -->
+    <div class="holder" data-n="28">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · comparison</span><span class="stamp">java</span></div>
+        <h2 class="slide-title">Java — <span class="em">closer now</span> with virtual threads</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2" style="align-items:center;">
+            <div class="stack tight">
+              <pre class="code sm plain"><span class="t-cm">// Platform Thread — 1:1 with an OS thread</span>
+<span class="t-key">new</span> <span class="t-fn">Thread</span>(() -&gt; <span class="t-fn">doWork</span>()).<span class="t-fn">start</span>();
+<span class="t-cm">// ~1MB stack allocated</span>
+
+<span class="t-cm">// Virtual Thread (Java 21+) — goroutine-like</span>
+Thread.<span class="t-fn">startVirtualThread</span>(() -&gt; <span class="t-fn">doWork</span>());</pre>
+              <p class="dim" style="margin:0;font-size:16.5px;line-height:1.5;">Past a few thousand platform threads, memory and context-switch costs spike. Virtual threads solve that conceptually <b>the same way goroutines do</b>.</p>
+            </div>
+            <div class="stack">
+              <div class="callout">
+                <span class="lbl">What still differs</span>
+                Java has <b>no channel-like communication mechanism built into the language.</b>
+                You pick a separate tool such as <code class="inl">BlockingQueue</code> or <code class="inl">CompletableFuture</code>.
+              </div>
+              <div class="callout teal">
+                <span class="lbl">So the conclusion</span>
+                “Lightweight units of execution” are no longer Go's alone. Where Go still differs is that
+                <b>the unit of execution and the means of communication ship together in the language</b>.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">If people know Loom/virtual threads, the conversation can run long here. Steer it back to the axis of "communication built into the language" and move on.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 29 Strengths and weaknesses ═══════════ -->
+    <div class="holder" data-n="29">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · comparison</span><span class="stamp">summary</span></div>
+        <h2 class="slide-title">Recap — what goroutines got and did not get</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2 grow">
+            <div class="card teal">
+              <p class="card-t" style="color:var(--teal);">Strengths</p>
+              <div class="steps">
+                <div class="step"><span class="s-n">01</span><div><div class="s-c">Built into the language</div><div class="s-d"><code class="inl">go</code> + <code class="inl">chan</code> come as keywords, so no extra library is needed</div></div></div>
+                <div class="step"><span class="s-n">02</span><div><div class="s-c">No coloring problem</div><div class="s-d">Every function is the same — no <code class="inl">async/await/suspend</code> split</div></div></div>
+                <div class="step"><span class="s-n">03</span><div><div class="s-c">Preemptive</div><div class="s-d">The runtime switches even CPU-bound goroutines automatically</div></div></div>
+                <div class="step"><span class="s-n">04</span><div><div class="s-c">Consistent ecosystem</div><div class="s-d">The whole standard library is designed around goroutines</div></div></div>
+              </div>
+            </div>
+            <div class="card red">
+              <p class="card-t" style="color:var(--red);">Weaknesses</p>
+              <div class="steps">
+                <div class="step"><span class="s-n">01</span><div><div class="s-c">No structured concurrency</div><div class="s-d">Parent–child ties are not in the language. You manage <code class="inl">Context</code> and <code class="inl">WaitGroup</code> <b>by hand</b></div></div></div>
+                <div class="step"><span class="s-n">02</span><div><div class="s-c">Panic propagation</div><div class="s-d">A <code class="inl">panic</code> in a goroutine can <b>terminate the whole program</b></div></div></div>
+              </div>
+              <div class="callout" style="margin-top:14px;">
+                <span class="lbl">Coming next</span>
+                What happens when you get lazy about "managing it by hand" — that is a goroutine leak.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The weakness card is the bridge into the next chapter. Go straight to Chapter 5 from here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 30 Chapter 5 ═══════════ -->
+    <div class="holder" data-n="30" data-chapter="5">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">05</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Goroutine leak</h2>
+            <p class="chap-d">As easy as they are to create, <b>they are just as easy to forget to clean up.</b>
+            A leaked goroutine is not reclaimed by the GC either.</p>
+          </div>
+        </div>
+        <div class="notes-src">The chapter that touches real work most directly. Even when time is short, keep this one.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 31 What a leak is ═══════════ -->
+    <div class="holder" data-n="31">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · Leak</span><span class="stamp">what &amp; why</span></div>
+        <h2 class="slide-title">A goroutine that <span class="em">stays alive</span> instead of ending</h2>
+        <p class="slide-lede">It is no longer needed yet never finishes. It holds memory and <b>is not a GC candidate</b>, so usage keeps climbing over time.</p>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a" style="align-items:center;">
+            <div class="tbl-wrap">
+              <table class="tbl">
+                <thead><tr><th>Typical cause</th><th>In what code</th></tr></thead>
+                <tbody>
+                  <tr class="on"><td>Channel wait</td><td>Blocked forever on a channel nobody receives from or sends to</td></tr>
+                  <tr><td>Infinite loop</td><td>A goroutine with no exit condition</td></tr>
+                  <tr><td>No context</td><td>A goroutine with no way to receive a cancel signal</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="stack">
+              <div class="callout">
+                <span class="lbl">Why the GC cannot catch it</span>
+                A running goroutine is a <b>live root</b>. Even blocked, it counts as "running", so it is not reclaimable.
+              </div>
+              <pre class="code sm plain"><span class="t-cm">// counting live goroutines shows it</span>
+runtime.<span class="t-fn">NumGoroutine</span>()</pre>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">"I have heard of memory leaks but never goroutine leaks" is a common reaction. Tell them that on a long-running server, NumGoroutine trending upward is the signal. Part 9 covers catching it with pprof.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 32 Leaky code → Context (toggle) ═══════════ -->
+    <div class="holder" data-n="32">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · Leak</span><span class="stamp">before → after</span></div>
+        <h2 class="slide-title">The leaky code, and the <span class="em">fixed code</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="stack tight">
+            <div class="toggle">
+              <button class="tg" type="button" data-swap="leak" data-target="bad" aria-pressed="true">leaky code</button>
+              <button class="tg" type="button" data-swap="leak" data-target="fix" aria-pressed="false">fixed with context</button>
+            </div>
+            <div class="cols c-2" style="align-items:start;">
+              <div class="swap" data-swap-group="leak">
+                <div class="swap-i on stack tight" data-swap-item="bad">
+                  <pre class="code xs red">leakyFunc := <span class="t-key">func</span>() &lt;-<span class="t-key">chan</span> <span class="t-key">int</span> {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>)
+    <span class="t-key">go</span> <span class="t-fn">func</span>() {
+        ch &lt;- <span class="t-num">42</span> <span class="t-cm">// blocks forever if nobody receives</span>
+    }()
+    <span class="t-key">return</span> ch
+}
+
+_ = <span class="t-fn">leakyFunc</span>() <span class="t-cm">// returned but never used → leak!</span>
+
+time.<span class="t-fn">Sleep</span>(<span class="t-num">50</span> * time.Millisecond)
+runtime.<span class="t-fn">NumGoroutine</span>() <span class="t-cm">// 2 at start → 3 after the leak</span></pre>
+                </div>
+                <div class="swap-i stack tight" data-swap-item="fix">
+                  <pre class="code xs teal">safeFunc := <span class="t-key">func</span>(ctx context.Context) &lt;-<span class="t-key">chan</span> <span class="t-key">int</span> {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">1</span>) <span class="t-cm">// buffered → send never blocks</span>
+    <span class="t-key">go</span> <span class="t-fn">func</span>() {
+        <span class="t-key">defer</span> <span class="t-fn">close</span>(ch)
+        <span class="t-key">select</span> {
+        <span class="t-key">case</span> ch &lt;- <span class="t-num">42</span>:     <span class="t-cm">// value delivered normally</span>
+        <span class="t-key">case</span> &lt;-ctx.<span class="t-fn">Done</span>(): <span class="t-cm">// exit when context is cancelled</span>
+            <span class="t-key">return</span>
+        }
+    }()
+    <span class="t-key">return</span> ch
+}
+
+ctx, cancel := context.<span class="t-fn">WithCancel</span>(context.<span class="t-fn">Background</span>())
+ch := <span class="t-fn">safeFunc</span>(ctx)
+<span class="t-fn">cancel</span>() <span class="t-cm">// cancelling cleans the goroutine up</span></pre>
+                </div>
+              </div>
+              <div class="swap" data-swap-group="leak">
+                <div class="swap-i on stack" data-swap-item="bad">
+                  <ul class="bul red">
+                    <li>The channel is unbuffered, so the send finishes only once <b>a receiver shows up</b></li>
+                    <li>If the caller never reads it, the goroutine stops <b>forever</b> at <code class="inl">ch &lt;- 42</code></li>
+                    <li>Repeat this per request and goroutines <b>pile up</b></li>
+                  </ul>
+                  <div class="callout">
+                    <span class="lbl">The symptom</span>
+                    Memory usage climbs <b>slowly but steadily</b>. A restart makes it fine for a while.
+                  </div>
+                </div>
+                <div class="swap-i stack" data-swap-item="fix">
+                  <ul class="bul teal">
+                    <li><b>Buffered channel</b> — the send does not block even with no receiver</li>
+                    <li><b><code class="inl">select</code> + <code class="inl">ctx.Done()</code></b> — on cancel it leaves via <code class="inl">return</code></li>
+                    <li><b><code class="inl">defer close(ch)</code></b> — the channel is cleaned up on exit too</li>
+                  </ul>
+                  <div class="callout teal">
+                    <span class="lbl">What changed</span>
+                    The goroutine now has <b>a way to be ended from outside</b>.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Press the two buttons alternately to compare. Ask "can you see why this code leaks?" first, and if no answer comes, hint only that a send on an unbuffered channel blocks. Ties to quiz Q6.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 33 The core rule ═══════════ -->
+    <div class="holder" data-n="33">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · Leak</span><span class="stamp">the rule</span></div>
+        <h2 class="slide-title">When you create a goroutine, create its <span class="em">exit path</span> too</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-3">
+            <div class="card">
+              <p class="card-t" style="color:var(--accent);">context</p>
+              <p style="margin:0;font-size:16.5px;line-height:1.5;" class="dim">Slot <code class="inl">ctx.Done()</code> into a <code class="inl">select</code>. Cancel, timeout and deadline all arrive here.</p>
+            </div>
+            <div class="card">
+              <p class="card-t" style="color:var(--accent);">done channel</p>
+              <p style="margin:0;font-size:16.5px;line-height:1.5;" class="dim">For sending only a stop signal where context is awkward. Closing it wakes every receiver.</p>
+            </div>
+            <div class="card">
+              <p class="card-t" style="color:var(--accent);">close</p>
+              <p style="margin:0;font-size:16.5px;line-height:1.5;" class="dim">The sender announces it is done sending. Pair it with <code class="inl">defer close(ch)</code>.</p>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">One question to ask in code review</span>
+            “<b>When and by whom</b> does this goroutine end?” — if there is no answer, it is a leak.
+          </div>
+          <p class="dim" style="margin:0;font-size:17px;">The full picture of Context is in <b>Part 5</b>, and actually catching leaked goroutines is in <b>Part 9</b>.</p>
+        </div>
+        <div class="notes-src">If you take exactly one line from today's talk, it is this callout. Stress that it was given in a form you can use in a real code review.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 34 Recap ═══════════ -->
+    <div class="holder" data-n="34">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">wrap-up</span><span class="stamp">recap</span></div>
+        <h2 class="slide-title">What to take away today</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <ul class="bul" style="font-size:20px;gap:17px;">
+            <li>Concurrency is <b>structure</b>, parallelism is <b>execution</b> — write the structure, the runtime supplies the execution</li>
+            <li>Go picked CSP — <b>do not communicate by sharing memory; share memory by communicating</b></li>
+            <li>A goroutine is a <b>~2KB</b> unit made with one <code class="inl">go</code>. Tens of thousands is normal</li>
+            <li><b>Order is not guaranteed</b>, and <b>when main ends everything ends</b> — build it yourself if needed</li>
+            <li>Scheduling is three pieces, <b>G · M · P</b>. <code class="inl">GOMAXPROCS</code> (default = core count) sets how many run at once</li>
+            <li>Always create the <b>exit path</b> along with the goroutine — otherwise it leaks</li>
+          </ul>
+        </div>
+        <div class="notes-src">Reading the six lines out loud is enough of a summary. You can start taking questions from here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 35 Quiz ═══════════ -->
+    <div class="holder" data-n="35">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Answer these yourself</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>Does concurrency hold on a single-core machine?</span></button>
+              <div class="q-a">Yes. Concurrency is the <b>structure of dealing with</b> many tasks at once; needing several CPUs is parallelism. On one core they simply take turns. <span class="ref">→ Slide 06</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>I launched 10 goroutines in order but the output is not <code class="inl">0..9</code>. A bug?</span></button>
+              <div class="q-a">No. Execution order is <b>not guaranteed</b>. If you need order, build it yourself with a channel or <code class="inl">sync</code>. <span class="ref">→ Slide 16</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>What happens if <code class="inl">main</code> launches a goroutine and returns right away?</span></button>
+              <div class="q-a">The process exits and the goroutine never completes. Not even <code class="inl">defer</code> runs. Wait with a <code class="inl">WaitGroup</code> or a channel. <span class="ref">→ Slide 17 · 18</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>With <code class="inl">GOMAXPROCS=1</code>, is only one goroutine created?</span></button>
+              <div class="q-a">No. There is just one <code class="inl">P</code>, so <b>only one runs at a time</b>. You can still create any number of goroutines: concurrency without parallelism. <span class="ref">→ Slide 23</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>The two biggest differences between Kotlin's <code class="inl">suspend</code> and a goroutine?</span></button>
+              <div class="q-a">① Scheduling — Kotlin is <b>cooperative</b> and yields only at suspend points; Go is <b>preemptive</b> and the runtime forces a switch. ② <b>Function coloring</b> — Go has no <code class="inl">suspend</code>-style split. <span class="ref">→ Slide 26 · 27</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q6</span><span>A goroutine sends on an unbuffered channel and nobody receives. Then what?</span></button>
+              <div class="q-a">The send <b>blocks forever</b> and the GC cannot reclaim it — a goroutine leak. Build an exit path with a buffered channel plus <code class="inl">select</code>/<code class="inl">ctx.Done()</code>. <span class="ref">→ Slide 32</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Let the audience answer first, then click to open. If time is tight, picking just Q4 and Q6 is enough.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 36 Next part ═══════════ -->
+    <div class="holder" data-n="36">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">next</span><span class="stamp">part 2</span></div>
+        <h2 class="slide-title">Next up — Channels in Depth</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack">
+              <p class="dim" style="margin:0;font-size:18px;line-height:1.6;">Today covered only the <b>unit of execution</b>. Even if you can launch many goroutines,
+              there is nothing you can do if they <b>cannot pass data between them</b>.
+              Next time we take the other half of CSP, <b>channels</b>, from start to finish.</p>
+              <div class="callout">
+                <span class="lbl">Left for later today</span>
+                Unbuffered vs buffered, what <code class="inl">close</code> exactly means, directional channels —
+                everything the leak slide brushed past is the subject of the next part.
+              </div>
+            </div>
+            <div class="card">
+              <p class="card-t">References</p>
+              <ul class="bul" style="font-size:16.5px;gap:9px;">
+                <li>Full code — <code class="inl">github.com/kenshin579/tutorials-go</code> <span class="faint">/golang/concurrency</span></li>
+                <li>Effective Go — Concurrency <span class="faint">go.dev/doc/effective_go#concurrency</span></li>
+                <li>Concurrency is not parallelism <span class="faint">go.dev/blog/waza-talk</span></li>
+                <li>Share Memory By Communicating <span class="faint">go.dev/blog/codelab-share</span></li>
+                <li>Go Proverbs <span class="faint">go-proverbs.github.io</span></li>
+              </ul>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Thank you</span>
+            Questions welcome — <code class="inl">advenoh.pe.kr</code>
+          </div>
+        </div>
+        <div class="notes-src">Take Q&amp;A with the GitHub repository address left on screen.</div>
+      </section>
+    </div>
+    </div><!-- /stage -->
+  </div><!-- /stage-wrap -->
+
+  <div class="notes" id="notes" aria-live="polite">
+    <div class="n-h">Speaker notes</div>
+    <div id="notesBody"></div>
+  </div>
+
+  <div class="chrome">
+    <span class="deck-id">Goroutine Basics · Go Concurrency 1</span>
+    <div class="rail" id="rail"></div>
+    <span class="counter" id="counter"><span class="cur">01</span> / 36</span>
+    <div class="keys">
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="Overview (O)">Overview</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="Speaker notes (N)">Notes</button>
+      <button class="kbtn" id="btnTheme" type="button" title="Toggle theme (T)">Theme</button>
+      <button class="kbtn" id="btnHelp" type="button" title="Shortcuts (?)">?</button>
+    </div>
+  </div>
+
+  <div class="help" id="help">
+    <div class="help-box">
+      <h3>Shortcuts</h3>
+      <dl>
+        <dt>→ · Space · PgDn</dt><dd>Next slide</dd>
+        <dt>← · PgUp</dt><dd>Previous slide</dd>
+        <dt>Home · End</dt><dd>First · Last</dd>
+        <dt>O</dt><dd>Slide overview</dd>
+        <dt>N</dt><dd>Speaker notes</dd>
+        <dt>T</dt><dd>Light / dark theme</dd>
+        <dt>F</dt><dd>Fullscreen</dd>
+        <dt>Esc</dt><dd>Close</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var deck     = document.getElementById("deck");
+  var stage    = document.getElementById("stage");
+  var wrap     = document.getElementById("stageWrap");
+  var rail     = document.getElementById("rail");
+  var counter  = document.getElementById("counter");
+  var notesEl  = document.getElementById("notes");
+  var notesBody= document.getElementById("notesBody");
+  var helpEl   = document.getElementById("help");
+  var holders  = Array.prototype.slice.call(stage.querySelectorAll(".holder"));
+  var total    = holders.length;
+  var idx      = 0;
+  var overview = false;
+  var reduce   = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ── 눈금 레일 ─────────────────────────────────── */
+  var ticks = holders.map(function (h, i) {
+    var t = document.createElement("span");
+    t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
+    t.title = "Slide " + (i + 1);
+    t.addEventListener("click", function () { go(i); });
+    rail.appendChild(t);
+    return t;
+  });
+
+  function pad(n) { return (n < 10 ? "0" : "") + n; }
+
+  /* ── 무대 스케일 ───────────────────────────────── */
+  /* 무대는 stage-wrap 의 좌상단에 고정(place-items:start)해 두고,
+     축소한 뒤 남는 여백만큼 직접 translate 해서 가운데로 옮긴다.
+     transform-origin 을 center 로 두고 grid 중앙 정렬에 맡기면,
+     뷰포트가 1280x720 보다 작을 때 브라우저가 넘치는 항목을
+     좌상단에 고정(safe alignment)해 버려서 축소 결과가 오른쪽 아래로 쏠린다. */
+  function fit() {
+    if (overview) { stage.style.transform = ""; return; }
+    var k = Math.min(wrap.clientWidth / 1280, wrap.clientHeight / 720);
+    var tx = (wrap.clientWidth - 1280 * k) / 2;
+    var ty = (wrap.clientHeight - 720 * k) / 2;
+    stage.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + k + ")";
+  }
+
+  /* ── 이동 ──────────────────────────────────────── */
+  function go(n, silent) {
+    n = Math.max(0, Math.min(total - 1, n));
+    idx = n;
+    holders.forEach(function (h, i) { h.classList.toggle("is-active", i === n); });
+    ticks.forEach(function (t, i) {
+      t.classList.toggle("done", i < n);
+      t.classList.toggle("now", i === n);
+    });
+    counter.innerHTML = '<span class="cur">' + pad(n + 1) + "</span> / " + total;
+    var src = holders[n].querySelector(".notes-src");
+    notesBody.textContent = src ? src.textContent.trim() : "—";
+    if (!silent) { history.replaceState(null, "", "#" + (n + 1)); }
+    runOdometers(holders[n]);
+    if (overview) {
+      holders[n].scrollIntoView({ block: "nearest", behavior: reduce ? "auto" : "smooth" });
+    }
+  }
+
+  /* ── 숫자 오도미터 ─────────────────────────────── */
+  function runOdometers(holder) {
+    var list = holder.querySelectorAll("[data-odo]");
+    Array.prototype.forEach.call(list, function (el, i) {
+      var to = parseInt(el.getAttribute("data-odo"), 10);
+      if (reduce) { el.textContent = to.toLocaleString("en-US"); return; }
+      var dur = 900, delay = i * 420, t0 = null;
+      el.textContent = "0";
+      function frame(ts) {
+        if (t0 === null) { t0 = ts; }
+        var p = (ts - t0 - delay) / dur;
+        if (p < 0) { requestAnimationFrame(frame); return; }
+        if (p > 1) { p = 1; }
+        var e = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(to * e).toLocaleString("en-US");
+        if (p < 1) { requestAnimationFrame(frame); }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
+  /* ── 개요 모드 ─────────────────────────────────── */
+  function setOverview(on) {
+    overview = on;
+    deck.classList.toggle("is-overview", on);
+    document.getElementById("btnOverview").setAttribute("aria-pressed", String(on));
+    fit();
+    if (on) { holders[idx].scrollIntoView({ block: "center" }); }
+  }
+
+  holders.forEach(function (h, i) {
+    h.addEventListener("click", function () { if (overview) { setOverview(false); go(i); } });
+  });
+
+  /* ── 노트 · 테마 · 도움말 ──────────────────────── */
+  function setNotes(on) {
+    notesEl.classList.toggle("on", on);
+    document.getElementById("btnNotes").setAttribute("aria-pressed", String(on));
+  }
+  function toggleTheme() {
+    var cur = document.documentElement.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try { localStorage.setItem("deck-theme", next); } catch (e) {}
+    drawHero();
+  }
+  try {
+    var saved = localStorage.getItem("deck-theme");
+    if (saved) { document.documentElement.setAttribute("data-theme", saved); }
+  } catch (e) {}
+
+  document.getElementById("btnOverview").addEventListener("click", function () { setOverview(!overview); });
+  document.getElementById("btnNotes").addEventListener("click", function () { setNotes(!notesEl.classList.contains("on")); });
+  document.getElementById("btnTheme").addEventListener("click", toggleTheme);
+  document.getElementById("btnHelp").addEventListener("click", function () { helpEl.classList.toggle("on"); });
+  helpEl.addEventListener("click", function () { helpEl.classList.remove("on"); });
+
+  /* ── 클릭 리빌 · 코드 토글 ─────────────────────── */
+  document.addEventListener("click", function (e) {
+    var qb = e.target.closest ? e.target.closest(".q-btn") : null;
+    if (qb) { qb.parentNode.classList.toggle("is-open"); return; }
+
+    var tg = e.target.closest ? e.target.closest(".tg") : null;
+    if (tg) {
+      var group = tg.getAttribute("data-swap");
+      var target = tg.getAttribute("data-target");
+      Array.prototype.forEach.call(document.querySelectorAll('.tg[data-swap="' + group + '"]'), function (b) {
+        b.setAttribute("aria-pressed", String(b === tg));
+      });
+      Array.prototype.forEach.call(document.querySelectorAll('[data-swap-group="' + group + '"] > .swap-i'), function (item) {
+        item.classList.toggle("on", item.getAttribute("data-swap-item") === target);
+      });
+    }
+  });
+
+  /* ── 키보드 ────────────────────────────────────── */
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) { return; }
+    var k = e.key;
+    if (k === "ArrowRight" || k === "PageDown" || k === " " || k === "Spacebar") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowLeft" || k === "PageUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "ArrowDown") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "Home") { e.preventDefault(); go(0); }
+    else if (k === "End") { e.preventDefault(); go(total - 1); }
+    else if (k === "o" || k === "O" || k === "ㅐ") { setOverview(!overview); }
+    else if (k === "n" || k === "N" || k === "ㅜ") { setNotes(!notesEl.classList.contains("on")); }
+    else if (k === "t" || k === "T" || k === "ㅅ") { toggleTheme(); }
+    else if (k === "f" || k === "F" || k === "ㄹ") {
+      if (document.fullscreenElement) { document.exitFullscreen(); }
+      else if (document.documentElement.requestFullscreen) { document.documentElement.requestFullscreen(); }
+    }
+    else if (k === "?" || k === "/") { helpEl.classList.toggle("on"); }
+    else if (k === "Escape") {
+      if (helpEl.classList.contains("on")) { helpEl.classList.remove("on"); }
+      else if (overview) { setOverview(false); }
+    }
+  });
+
+  /* ── 표지: goroutine 스케줄 타임라인 ───────────── */
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  /* [goroutine 번호, 시작 비율, 끝 비율] — 난수 없이 재현 가능하게 고정 */
+  var LANES = [
+    [[1, 0, .13], [4, .13, .29], [2, .29, .38], [7, .38, .56], [1, .56, .69], [5, .69, .85], [3, .85, 1]],
+    [[2, 0, .10], [3, .10, .25], [6, .25, .42], [4, .42, .53], [8, .53, .72], [2, .72, .87], [6, .87, 1]]
+  ];
+
+  function drawHero() {
+    var cv = document.getElementById("heroCanvas");
+    if (!cv) { return; }
+    var ctx = cv.getContext("2d");
+    var W = cv.width, H = cv.height;
+
+    var accent = css("--accent") || "#4FD3F4";
+    var teal   = css("--teal")   || "#4FC48F";
+    var amber  = css("--amber")  || "#E8B84B";
+    var line   = css("--line")   || "#272F3A";
+    var faint  = css("--ink-faint") || "#6B7688";
+    var surf2  = css("--surface-2") || "#1B212A";
+    var bg     = css("--bg") || "#0E1117";
+    var palette = [accent, teal, amber];
+
+    var padL = 76, padR = 16, padT = 48, laneH = 152, gap = 56;
+    var trackW = W - padL - padR;
+    var bottom = padT + laneH * 2 + gap;
+
+    function render(p) {
+      ctx.clearRect(0, 0, W, H);
+
+      /* 시간 격자 */
+      ctx.strokeStyle = line;
+      ctx.lineWidth = 1;
+      for (var i = 0; i <= 6; i++) {
+        var gx = Math.round(padL + trackW / 6 * i) + .5;
+        ctx.beginPath();
+        ctx.moveTo(gx, padT - 14);
+        ctx.lineTo(gx, bottom + 10);
+        ctx.stroke();
+      }
+
+      LANES.forEach(function (lane, li) {
+        var y = padT + li * (laneH + gap);
+
+        /* 빈 트랙 */
+        ctx.fillStyle = surf2;
+        ctx.fillRect(padL, y, trackW, laneH);
+
+        /* 레인 이름 */
+        ctx.font = "600 26px ui-monospace, Menlo, monospace";
+        ctx.fillStyle = faint;
+        ctx.textAlign = "left";
+        ctx.textBaseline = "middle";
+        ctx.fillText("M" + (li + 1), 8, y + laneH / 2);
+
+        /* 실행 블록 */
+        var limit = padL + trackW * p;
+        lane.forEach(function (b) {
+          var x0 = padL + trackW * b[1];
+          var x1 = padL + trackW * b[2];
+          if (x0 >= limit) { return; }
+          var w = Math.min(x1, limit) - x0 - 4;
+          if (w <= 0) { return; }
+          ctx.fillStyle = palette[(b[0] - 1) % 3];
+          ctx.fillRect(x0, y, w, laneH);
+          if (w > 46) {
+            ctx.font = "600 24px ui-monospace, Menlo, monospace";
+            ctx.fillStyle = bg;
+            ctx.textAlign = "center";
+            ctx.fillText("G" + b[0], x0 + w / 2, y + laneH / 2);
+          }
+        });
+      });
+
+      /* 시간 축 */
+      ctx.font = "500 22px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = faint;
+      ctx.textAlign = "left";
+      ctx.textBaseline = "alphabetic";
+      ctx.fillText("time →", padL, bottom + 40);
+      ctx.textAlign = "right";
+      ctx.fillText("goroutine 8", W - padR, bottom + 40);
+    }
+
+    if (reduce) { render(1); return; }
+    var t0 = null;
+    function frame(ts) {
+      if (t0 === null) { t0 = ts; }
+      var p = Math.min(1, (ts - t0) / 1300);
+      var e = 1 - Math.pow(1 - p, 3);
+      render(Math.max(.02, e));
+      if (p < 1) { requestAnimationFrame(frame); }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  /* ── 초기화 ────────────────────────────────────── */
+  window.addEventListener("resize", fit);
+  window.addEventListener("hashchange", function () {
+    var n = parseInt(location.hash.replace("#", ""), 10);
+    if (!isNaN(n)) { go(n - 1, true); }
+  });
+
+  var start = parseInt(location.hash.replace("#", ""), 10);
+  fit();
+  go(isNaN(start) ? 0 : start - 1, true);
+  drawHero();
+})();
+</script>
+</body>
+</html>

--- a/contents/go/golang-concurrency-2-channel-완전-정복/index_en.md
+++ b/contents/go/golang-concurrency-2-channel-완전-정복/index_en.md
@@ -31,6 +31,8 @@ ch := make(chan int)       // unbuffered channel (int type)
 ch := make(chan string, 5) // buffered channel (string type, buffer size 5)
 ```
 
+<!-- slides -->
+
 # 2. Send / Receive Behavior
 
 To send a value to a channel, use the `<-` operator.

--- a/contents/go/golang-concurrency-2-channel-완전-정복/slides_en.html
+++ b/contents/go/golang-concurrency-2-channel-완전-정복/slides_en.html
@@ -1,0 +1,2110 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Channels in Depth — Golang Concurrency Part 2</title>
+<style>
+/* ─────────────────────────────────────────────────────────────
+   계기판(instrument panel) — 차가운 슬레이트 바탕 위 따뜻한 표시등
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0B6E8C;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(11, 110, 140, .10);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+
+  --f-display: "Avenir Next", "Apple SD Gothic Neo", "Helvetica Neue", system-ui, sans-serif;
+  --f-body:    "Apple SD Gothic Neo", -apple-system, "Helvetica Neue", "Noto Sans KR", sans-serif;
+  --f-mono:    "MesloLGS NF", "SF Mono", ui-monospace, Menlo, "D2Coding", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0E1117;
+    --surface:   #161B23;
+    --surface-2: #1B212A;
+    --ink:       #E6E9EE;
+    --ink-dim:   #98A2B0;
+    --ink-faint: #6B7688;
+    --line:      #272F3A;
+    --line-soft: #1E252E;
+    --grid:      rgba(255, 255, 255, .038);
+    --accent:    #4FD3F4;
+    --accent-ink:#04222C;
+    --accent-soft: rgba(79, 211, 244, .13);
+    --teal:      #46C7B0;
+    --teal-soft: rgba(70, 199, 176, .13);
+    --amber:     #E8B84B;
+    --red:       #F0625E;
+    --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg:        #0E1117;
+  --surface:   #161B23;
+  --surface-2: #1B212A;
+  --ink:       #E6E9EE;
+  --ink-dim:   #98A2B0;
+  --ink-faint: #6B7688;
+  --line:      #272F3A;
+  --line-soft: #1E252E;
+  --grid:      rgba(255, 255, 255, .038);
+  --accent:    #4FD3F4;
+  --accent-ink:#04222C;
+  --accent-soft: rgba(79, 211, 244, .13);
+  --teal:      #46C7B0;
+  --teal-soft: rgba(70, 199, 176, .13);
+  --amber:     #E8B84B;
+  --red:       #F0625E;
+  --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+}
+
+:root[data-theme="light"] {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0B6E8C;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(11, 110, 140, .10);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ── 무대: 1280×720 고정, 뷰포트에 맞춰 축소 ───────────────── */
+.stage-wrap {
+  position: fixed;
+  inset: 0 0 52px 0;
+  display: grid;
+  /* 가운데 정렬은 fit() 이 translate 로 직접 한다. grid 중앙 정렬에 맡기면
+     무대가 뷰포트보다 클 때 safe alignment 로 좌상단에 고정되어 계산이 어긋난다. */
+  place-items: start;
+  overflow: hidden;
+}
+.stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  transform-origin: 0 0;
+  flex: none;
+}
+.holder {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .22s ease;
+}
+.holder.is-active { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .holder { transition: none; } }
+
+.slide {
+  width: 1280px;
+  height: 720px;
+  padding: 52px 68px 56px;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 40px,
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px) 0 0 / 40px 100%,
+    var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.slide::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0 34%, var(--line) 34% 100%);
+  opacity: .55;
+}
+
+/* ── 슬라이드 머리 ─────────────────────────────────────────── */
+.slide-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  flex: none;
+}
+.eyebrow {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+}
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+}
+.slide-title {
+  font-family: var(--f-display);
+  font-size: 42px;
+  line-height: 1.16;
+  font-weight: 700;
+  letter-spacing: -.022em;
+  margin: 0 0 6px;
+  text-wrap: balance;
+}
+.slide-title .em { color: var(--accent); }
+.slide-lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0 0 4px;
+  max-width: 72ch;
+}
+.rule {
+  height: 1px;
+  background: var(--line);
+  margin: 18px 0 22px;
+  flex: none;
+}
+.slide-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  font-size: 19px;
+  line-height: 1.6;
+}
+.slide-body.top { justify-content: flex-start; }
+
+/* ── 공용 조판 ─────────────────────────────────────────────── */
+.cols { display: grid; gap: 30px; align-items: start; }
+.c-2  { grid-template-columns: 1fr 1fr; }
+.c-2a { grid-template-columns: 1.15fr .85fr; }
+.c-2b { grid-template-columns: .82fr 1.18fr; }
+.c-3  { grid-template-columns: repeat(3, 1fr); }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.stack.tight { gap: 10px; }
+.grow { flex: 1; min-height: 0; }
+/* 높이를 채우는 2단 조판에서는 각 열이 늘어나고, 내용은 열 안에서 세로 중앙에 놓인다 */
+.cols.grow { align-items: stretch; }
+.cols.grow > .stack { justify-content: center; }
+
+ul.bul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 13px; }
+ul.bul > li { position: relative; padding-left: 26px; }
+ul.bul > li::before {
+  content: "";
+  position: absolute;
+  left: 4px; top: .62em;
+  width: 9px; height: 2px;
+  background: var(--accent);
+}
+ul.bul.teal > li::before { background: var(--teal); }
+.dim { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.hl { color: var(--accent); font-weight: 600; }
+.hl-teal { color: var(--teal); font-weight: 600; }
+b, strong { font-weight: 700; }
+
+/* ── 표 ────────────────────────────────────────────────────── */
+.tbl-wrap { overflow-x: auto; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink-faint);
+  padding: 0 14px 9px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: 11px 14px 11px 0;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  line-height: 1.45;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td:first-child { font-weight: 600; white-space: nowrap; }
+table.tbl.sm { font-size: 15.5px; }
+table.tbl.sm td { padding: 8px 12px 8px 0; }
+table.tbl tr.on td { background: var(--accent-soft); }
+table.tbl tr.on td:first-child { color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); padding-left: 12px; }
+.num-col { font-family: var(--f-mono); }
+
+/* ── 코드 ──────────────────────────────────────────────────── */
+.code {
+  font-family: var(--f-mono);
+  font-size: 15.5px;
+  line-height: 1.72;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+  padding: 14px 18px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+  tab-size: 2;
+}
+.code.sm { font-size: 14px; line-height: 1.66; padding: 12px 15px; }
+.code.xs { font-size: 12.6px; line-height: 1.6; padding: 11px 14px; }
+.code.plain { border-left-color: var(--line); }
+.code.teal { border-left-color: var(--teal); }
+.t-fn  { color: var(--accent); }
+.t-str { color: var(--teal); }
+.t-cm  { color: var(--ink-faint); }
+.t-num { color: var(--ink); font-weight: 600; }
+.t-key { color: var(--accent); font-weight: 600; }
+.t-bad { color: var(--red); }
+code.inl {
+  font-family: var(--f-mono);
+  font-size: .88em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  white-space: nowrap;
+}
+
+/* ── 카드 / 콜아웃 ─────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.card-t {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+.callout {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 14px 20px;
+  border-radius: 0 3px 3px 0;
+  font-size: 18px;
+  line-height: 1.55;
+}
+.callout.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+.callout .lbl {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.callout.teal .lbl { color: var(--teal); }
+
+/* ── 그림 ──────────────────────────────────────────────────── */
+.figure { display: flex; flex-direction: column; justify-content: center; gap: 10px; min-height: 0; }
+.figure img {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: var(--shadow);
+  background: var(--surface-2);
+}
+.figure figcaption, .cap {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.fit img { max-height: 100%; }
+
+/* ── 아키텍처 다이어그램 ───────────────────────────────────── */
+.arch {
+  display: grid;
+  grid-template-columns: 1fr 104px 1.02fr 104px 1fr;
+  align-items: center;
+  gap: 0;
+}
+.arch-col { display: flex; flex-direction: column; gap: 11px; }
+.node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 4px;
+  padding: 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.node .n-t { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.node .n-p { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-faint); }
+.node.hero {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  padding: 20px 18px;
+}
+.node.hero .n-t { font-size: 22px; color: var(--accent); }
+.node.hero .n-p { color: var(--ink-dim); }
+.node.mute { border-style: dashed; background: transparent; }
+.arch-link { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.arch-link .l-lbl {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.arch-link .l-line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  position: relative;
+}
+.arch-link .l-line::after {
+  content: "";
+  position: absolute;
+  right: 8px; top: -4px;
+  border: 4.5px solid transparent;
+  border-left-color: var(--accent);
+}
+
+/* ── 트리 ──────────────────────────────────────────────────── */
+.tree { font-family: var(--f-mono); font-size: 15px; line-height: 2.05; }
+.tree .lv { display: block; white-space: pre; }
+.tree .k { color: var(--accent); font-weight: 600; }
+.tree .v { color: var(--ink-dim); }
+
+/* ── 쿼리 해부도 ───────────────────────────────────────────── */
+.anat { display: flex; flex-direction: column; gap: 14px; }
+.anat-q {
+  font-family: var(--f-mono);
+  font-size: 24px;
+  letter-spacing: -.01em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.anat-q .p { padding: 3px 2px; border-bottom: 2px solid transparent; }
+.anat-q .p1 { border-bottom-color: var(--accent); }
+.anat-q .p2 { border-bottom-color: var(--teal); }
+.anat-q .p3 { border-bottom-color: var(--amber); }
+.anat-q .p4 { border-bottom-color: var(--ink-faint); }
+.legend { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.legend .lg-i { display: flex; flex-direction: column; gap: 4px; }
+.legend .lg-b { height: 3px; width: 34px; }
+.legend .lg-n { font-size: 15px; font-weight: 700; }
+.legend .lg-d { font-size: 14px; color: var(--ink-dim); line-height: 1.42; }
+
+/* ── 카디널리티 계산기 ─────────────────────────────────────── */
+.odo-row { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.odo {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 62px;
+  font-weight: 700;
+  letter-spacing: -.03em;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.odo.sm { font-size: 34px; color: var(--ink); }
+.odo-cap { font-size: 15px; color: var(--ink-dim); }
+.factor {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-family: var(--f-mono);
+  font-size: 19px;
+  color: var(--ink-dim);
+}
+.factor b { color: var(--ink); font-size: 22px; }
+
+/* ── 단계 목록 ─────────────────────────────────────────────── */
+.steps { display: flex; flex-direction: column; gap: 0; }
+.step {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.step:last-child { border-bottom: none; }
+.step .s-n {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 600;
+  padding-top: 3px;
+}
+.step .s-c { font-family: var(--f-mono); font-size: 14.5px; color: var(--ink); }
+.step .s-d { font-size: 15.5px; color: var(--ink-dim); line-height: 1.45; margin-top: 3px; }
+
+/* ── 표지 ──────────────────────────────────────────────────── */
+.cover { display: grid; grid-template-columns: 1.06fr .94fr; gap: 46px; align-items: center; height: 100%; }
+.cover-title {
+  font-family: var(--f-display);
+  font-size: 62px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -.032em;
+  margin: 14px 0 18px;
+  text-wrap: balance;
+}
+.cover-sub { font-size: 21px; color: var(--ink-dim); line-height: 1.5; margin: 0 0 30px; }
+.cover-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .06em;
+}
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+.panel-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+.panel-body { padding: 12px 8px 8px; }
+.panel canvas { display: block; width: 100%; height: 232px; }
+.panel-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 9px 15px 13px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 챕터 구분 ─────────────────────────────────────────────── */
+.slide[data-kind="chapter"] { justify-content: center; }
+.chap { display: grid; grid-template-columns: auto 1fr; gap: 46px; align-items: center; }
+.chap-n {
+  font-family: var(--f-mono);
+  font-size: 168px;
+  font-weight: 700;
+  line-height: .82;
+  letter-spacing: -.06em;
+  color: var(--accent);
+}
+.chap-t {
+  font-family: var(--f-display);
+  font-size: 50px;
+  font-weight: 700;
+  letter-spacing: -.028em;
+  line-height: 1.12;
+  margin: 0 0 14px;
+}
+.chap-d { font-size: 19px; color: var(--ink-dim); line-height: 1.55; margin: 0; max-width: 56ch; }
+.chap-l { border-left: 1px solid var(--line); padding-left: 46px; }
+
+/* ── 퀴즈 ──────────────────────────────────────────────────── */
+.quiz { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 20px; }
+.q {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.q-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 16.5px;
+  line-height: 1.42;
+  font-weight: 600;
+}
+.q-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+.q-btn .q-n { font-family: var(--f-mono); font-size: 12.5px; color: var(--accent); flex: none; }
+.q-a {
+  display: none;
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line-soft);
+  padding-top: 9px;
+}
+.q.is-open .q-a { display: block; }
+.q-a .ref { font-family: var(--f-mono); font-size: 12px; color: var(--ink-faint); }
+
+/* ── 토글 (Counter 슬라이드) ───────────────────────────────── */
+.toggle { display: flex; gap: 8px; }
+.tg {
+  all: unset;
+  cursor: pointer;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.tg[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.tg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.swap > .swap-i { display: none; }
+.swap > .swap-i.on { display: flex; }
+.swap > img.swap-i.on { display: block; }
+
+/* ── 하단 크롬 ─────────────────────────────────────────────── */
+.chrome {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  background: var(--bg);
+  border-top: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.chrome .deck-id { text-transform: uppercase; white-space: nowrap; }
+.rail { flex: 1; display: flex; gap: 2px; align-items: center; height: 22px; min-width: 0; }
+.tick { flex: 1; height: 4px; background: var(--line); border-radius: 1px; transition: background .18s ease, height .18s ease; }
+.tick.done { background: var(--ink-faint); }
+.tick.now  { background: var(--accent); height: 14px; }
+.tick.chap { height: 10px; }
+.counter { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--ink-dim); }
+.counter .cur { color: var(--accent); font-weight: 600; }
+.keys { display: flex; gap: 6px; }
+.kbtn {
+  all: unset;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 4px 8px;
+  color: var(--ink-dim);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+}
+.kbtn:hover { border-color: var(--accent); color: var(--accent); }
+.kbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.kbtn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+/* ── 발표자 노트 ───────────────────────────────────────────── */
+.notes-src { display: none; }
+.notes {
+  position: fixed;
+  left: 0; right: 0; bottom: 52px;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 16px 22px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  display: none;
+  z-index: 19;
+}
+.notes.on { display: block; }
+.notes .n-h {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+/* ── 개요(썸네일) 모드 ─────────────────────────────────────── */
+.deck.is-overview .stage-wrap { place-items: start center; overflow: auto; padding: 24px 18px; }
+.deck.is-overview .stage {
+  width: 100%; height: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 256px);
+  gap: 16px;
+  justify-content: center;
+}
+.deck.is-overview .holder {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  visibility: visible;
+  width: 256px;
+  height: 144px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deck.is-overview .holder.is-active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.deck.is-overview .holder::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 5px; bottom: 4px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  color: var(--ink-faint);
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.deck.is-overview .slide {
+  position: absolute;
+  top: 0; left: 0;
+  transform: scale(.2);
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+/* ── 도움말 ────────────────────────────────────────────────── */
+.help {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  display: none;
+  place-items: center;
+  z-index: 40;
+  padding: 24px;
+}
+.help.on { display: grid; }
+.help-box {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  padding: 26px 30px;
+  min-width: 360px;
+}
+.help-box h3 {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.help-box dl { display: grid; grid-template-columns: auto 1fr; gap: 9px 20px; margin: 0; font-size: 15px; }
+.help-box dt { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.help-box dd { margin: 0; color: var(--ink-dim); }
+
+/* ── 인쇄 ──────────────────────────────────────────────────── */
+@media print {
+  @page { size: 1280px 720px; margin: 0; }
+  body { overflow: visible; background: #fff; }
+  .chrome, .notes, .help { display: none !important; }
+  .stage-wrap { position: static; display: block; inset: auto; overflow: visible; }
+  .stage { width: auto; height: auto; transform: none !important; display: block; }
+  .holder { position: static; opacity: 1; visibility: visible; break-after: page; }
+  .slide { box-shadow: none; }
+}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+  <div class="stage-wrap" id="stageWrap">
+    <div class="stage" id="stage">
+    <!-- ═══════════ 01 Cover ═══════════ -->
+    <div class="holder" data-n="01">
+      <section class="slide" data-kind="cover">
+        <div class="cover">
+          <div>
+            <div class="eyebrow">Golang Concurrency · Part 2 / 11</div>
+            <h1 class="cover-title">Channels<br />in Depth</h1>
+            <p class="cover-sub">Don't communicate by sharing memory, <b>share memory by communicating</b><br />— how a single pipe also does your synchronization</p>
+            <div class="cover-meta">
+              <span class="chip on">Unbuffered</span>
+              <span class="chip">Buffered</span>
+              <span class="chip">Direction</span>
+              <span class="chip">close · range</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-head">
+              <span><span class="dot"></span>life of a channel</span>
+              <span>make → send → close</span>
+            </div>
+            <div class="panel-body" style="display:block;padding:22px 20px;">
+              <div class="tree">
+                <span class="lv"><span class="k">make(chan T, n)</span> <span class="v">opens a typed pipe</span></span>
+                <span class="lv">├─ n = 0 <span class="v">unbuffered · handshake</span></span>
+                <span class="lv">└─ n &gt; 0 <span class="v">buffered · queue</span></span>
+                <span class="lv"> </span>
+                <span class="lv"><span class="k">ch &lt;- v</span> <span class="v">the sending side</span></span>
+                <span class="lv"><span class="k">v, ok := &lt;-ch</span> <span class="v">the receiving side</span></span>
+                <span class="lv"> </span>
+                <span class="lv"><span class="k">close(ch)</span> <span class="v">declares: no more sends</span></span>
+                <span class="lv">└─ <span class="v">range stops on this signal</span></span>
+              </div>
+            </div>
+            <div class="panel-foot">
+              <span>the sender makes · sends · closes</span>
+              <span>the receiver only receives</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Greeting + part 2 of 11. Part 1 got as far as "launching" goroutines, so connect today as the story of moving values between them. The tree on the right is both the outline and the conclusion — say that once those six lines are second nature, 90% of channel code reads itself.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 02 The problem ═══════════ -->
+    <div class="holder" data-n="02">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">problem</span><span class="stamp">why channel</span></div>
+        <h2 class="slide-title">You launched a goroutine, but there's <span class="em">no way to get the result</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>Part 1 only got us to the <b>unit of execution</b> — no way to pass values yet</li>
+              <li>A shared variable + mutex works, but <b>a human has to remember the lock order</b></li>
+              <li>Go's answer is CSP — <b>hand the value over</b> and ownership goes with it</li>
+              <li>A channel solves <b>communication and synchronization at once</b>. Nothing to lock</li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">// shared memory — humans keep the lock order</span>
+mu.<span class="t-fn">Lock</span>()
+result = <span class="t-num">42</span>
+mu.<span class="t-fn">Unlock</span>()
+
+<span class="t-cm">// channel — hand it over, ownership goes too</span>
+ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>)
+<span class="t-key">go</span> <span class="t-key">func</span>() { ch &lt;- <span class="t-num">42</span> }()
+v := &lt;-ch</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">Go Proverb</span>
+            Don't communicate by sharing memory; <b>share memory by communicating.</b>
+          </div>
+        </div>
+        <div class="notes-src">Opening with "Ever launched three goroutines and tried to collect the results?" works well. This is not a claim that mutexes are bad (part 4 covers sync properly) — only that for handing values over, a channel is the better tool. Don't linger here — one minute.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 03 Chapter 01 ═══════════ -->
+    <div class="holder" data-n="03" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">01</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Channel Basics</h2>
+            <p class="chap-d">How to make one, and how to put values in and take them out. The syntax takes ten
+            minutes, but without training your eye here, blocking and close later will all blur together.</p>
+          </div>
+        </div>
+        <div class="notes-src">The goal is "read the direction straight off the code". The syntax itself is short, so cut it at 3–4 minutes and move to blocking.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 04 make ═══════════ -->
+    <div class="holder" data-n="04">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Basics</span><span class="stamp">make</span></div>
+        <h2 class="slide-title">A channel is a <span class="em">pipe with a fixed type</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">make(chan T)</code> — only T flows. Anything else is a <b>compile error</b></li>
+              <li>The second argument is the <b>buffer size</b>. Omit it and it's 0</li>
+              <li>That one number changes the synchronization: 0 is a handshake, 1+ is a queue</li>
+              <li>The zero value is <code class="inl">nil</code>. A nil channel blocks send and receive <b>forever</b></li>
+            </ul>
+            <pre class="code sm">ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>)        <span class="t-cm">// unbuffered</span>
+ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">string</span>, <span class="t-num">5</span>) <span class="t-cm">// buffered (5 slots)</span>
+
+ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> Result)     <span class="t-cm">// structs work too</span>
+ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">chan</span> <span class="t-key">int</span>)   <span class="t-cm">// channels of channels too</span>
+
+<span class="t-key">var</span> ch <span class="t-key">chan</span> <span class="t-key">int</span>             <span class="t-cm">// nil — never proceeds</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">the weight of one number</span>
+            <code class="inl">make(chan int)</code> and <code class="inl">make(chan int, 1)</code> have <b>the same type</b>. Yet their synchronization behavior is entirely different.
+          </div>
+        </div>
+        <div class="notes-src">Keep the nil channel to "such a thing exists" for now. It's worth teasing that it comes back in part 3 on select, as "a switch that turns a case off".</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 05 send / receive ═══════════ -->
+    <div class="holder" data-n="05">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Basics</span><span class="stamp">&lt;-</span></div>
+        <h2 class="slide-title">The arrow's <span class="em">position</span> alone splits send from receive</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>Arrow on the <b>right</b> of the channel is a send — <code class="inl">ch &lt;- v</code></li>
+              <li>Arrow on the <b>left</b> of the channel is a receive — <code class="inl">v := &lt;-ch</code></li>
+              <li>You needn't take the value. A bare <code class="inl">&lt;-ch</code> means "<b>wait</b> until one arrives"</li>
+              <li>In the two-value form <code class="inl">v, ok := &lt;-ch</code>, <code class="inl">ok</code> tells you if the channel is <b>still alive</b></li>
+            </ul>
+            <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">TestChannelSendReceive</span>(t *testing.T) {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>)
+
+    <span class="t-key">go</span> <span class="t-key">func</span>() {
+        ch &lt;- <span class="t-num">42</span> <span class="t-cm">// send</span>
+    }()
+
+    value := &lt;-ch <span class="t-cm">// blocks until the send</span>
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">42</span>, value)
+}</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">how to read it</span>
+            The arrow always points <b>the way the value flows</b>. Into the channel is a send, out of it is a receive.
+          </div>
+        </div>
+        <div class="notes-src">It's fine to pause here and have the audience read the code out loud. Landing that the <code>value := &lt;-ch</code> line means "stop here until 42 arrives" is the whole of this section.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 06 Sending structs ═══════════ -->
+    <div class="holder" data-n="06">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · Basics</span><span class="stamp">any type</span></div>
+        <h2 class="slide-title">Send a struct and <span class="em">value and error arrive together</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">TestChannelStructType</span>(t *testing.T) {
+    <span class="t-key">type</span> Result <span class="t-key">struct</span> {
+        Value <span class="t-key">int</span>
+        Err   <span class="t-key">error</span>
+    }
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> Result)
+
+    <span class="t-key">go</span> <span class="t-key">func</span>() {
+        ch &lt;- Result{Value: <span class="t-num">100</span>, Err: <span class="t-key">nil</span>}
+    }()
+
+    result := &lt;-ch
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">100</span>, result.Value)
+    assert.<span class="t-fn">NoError</span>(t, result.Err)
+}</pre>
+          <div class="callout teal">
+            <span class="lbl">why write it this way</span>
+            A separate error channel creates a new job: <b>pairing the two up</b>. Bundle value and error into one struct and that problem disappears.
+          </div>
+        </div>
+        <div class="notes-src">This is the shape you'll use most in production. Asking "anyone split it into two channels, result and err?" always gets a reaction — in that case ordering problems appear in select over which arrives first. Say that much and hand it to part 3.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 07 Chapter 02 ═══════════ -->
+    <div class="holder" data-n="07" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">02</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Blocking and Buffers</h2>
+            <p class="chap-d">A channel's essence is not "it moves values" but "<b>it waits</b>".
+            Know when it stops and the unbuffered/buffered difference follows on its own.</p>
+          </div>
+        </div>
+        <div class="notes-src">The heart of today's talk. If time runs short, cut other chapters and spend it here. 8–12 minutes.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 08 Blocking is a feature ═══════════ -->
+    <div class="holder" data-n="08">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Blocking</span><span class="stamp">by design</span></div>
+        <h2 class="slide-title">Blocking isn't a side effect, it's the <span class="em">synchronization</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">Unbuffered — meet to proceed</div>
+              <p>Send and receive must be <b>ready at the same time</b> for the value to cross.</p>
+              <p class="dim">Whoever arrives first waits for the other. That meeting instant becomes the sync point of the two goroutines.</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Buffered — room means pass</div>
+              <p>If the buffer has a free slot, the send finishes <b>immediately</b>.</p>
+              <p class="dim">Once it's full the sender waits; once it's empty the receiver waits. A queue has slipped in between.</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">in one line</span>
+            The waiting itself <b>creates order</b>. That's why channels guarantee "B after A" without any lock.
+          </div>
+        </div>
+        <div class="notes-src">Break the "blocking = bad" preconception right here. Saying up front that the next two slides (09 and 10) are these two cards drawn out makes them easy to follow.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 09 Unbuffered diagram ═══════════ -->
+    <div class="holder" data-n="09">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Blocking</span><span class="stamp">unbuffered</span></div>
+        <h2 class="slide-title">Unbuffered — the value crosses only when <span class="em">both sides meet</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Goroutine A</span><span class="n-p">ch &lt;- 42 — waits here</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">waiting</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">Handshake</span><span class="n-p">both proceed at once</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">waiting</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Goroutine B</span><span class="n-p">v := &lt;-ch — waits here</span></div>
+            </div>
+          </div>
+          <p class="cap">The middle is <b>the meeting point</b>. Whichever side arrives first stands still until the other shows up.</p>
+          <div class="callout">
+            <span class="lbl">why that's useful</span>
+            The moment the value crosses, <b>both sides know it happened</b>. That property is exactly a "work completed" acknowledgment.
+          </div>
+        </div>
+        <div class="notes-src">The "handshake" metaphor lands well — one hand out is not a handshake. Mention that the next slide deliberately reuses the same diagram frame so buffered can be compared against this.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 10 Buffered diagram ═══════════ -->
+    <div class="holder" data-n="10">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Blocking</span><span class="stamp">buffered</span></div>
+        <h2 class="slide-title">Buffered — the buffer <span class="em">absorbs the speed gap</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Producer</span><span class="n-p">3 sends pass instantly</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">fills</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">Buffer (size 3)</span><span class="n-p">4th send blocks</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">drains</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Consumer</span><span class="n-p">receive waits when empty</span></div>
+            </div>
+          </div>
+          <p class="cap">The lines show where values flow. The buffer is <b>FIFO</b> — out in the order they went in.</p>
+          <div class="callout">
+            <span class="lbl">easy to get wrong</span>
+            A buffer absorbs <b>momentary spikes</b> only. If average production outruns consumption, it clogs no matter the size.
+          </div>
+        </div>
+        <div class="notes-src">"Does a bigger buffer make it faster?" comes up often. The answer is in the callout — unless the average rates flip, a buffer only postpones the problem.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 11 Unbuffered in code ═══════════ -->
+    <div class="holder" data-n="11">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Blocking</span><span class="stamp">in code</span></div>
+        <h2 class="slide-title">Unbuffered — the sender stands there <span class="em">waiting for a receiver</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">TestUnbufferedChannel</span>(t *testing.T) {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>) <span class="t-cm">// buffer size 0</span>
+
+    <span class="t-key">go</span> <span class="t-key">func</span>() {
+        ch &lt;- <span class="t-num">42</span> <span class="t-cm">// blocks here until a receiver is ready</span>
+    }()
+
+    time.<span class="t-fn">Sleep</span>(<span class="t-num">100</span> * time.Millisecond) <span class="t-cm">// sender is already waiting</span>
+    value := &lt;-ch                      <span class="t-cm">// receiving frees the sender too</span>
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">42</span>, value)
+}</pre>
+          <div class="callout">
+            <span class="lbl">drop the <code class="inl">go</code> here?</span>
+            The main goroutine ends up waiting on itself — <span class="hl"><b>fatal error: all goroutines are asleep - deadlock!</b></span>
+          </div>
+        </div>
+        <div class="notes-src">Be sure to note the Sleep is for illustration, not production code. Everyone has seen the deadlock message in the callout at least once, so it gets a laugh — close by saying they can now explain why it appears.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 12 Buffered in code ═══════════ -->
+    <div class="holder" data-n="12">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Blocking</span><span class="stamp">in code</span></div>
+        <h2 class="slide-title">Buffered — with no receiver, <span class="em">buffer-many sends</span> still pass</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">TestBufferedChannel</span>(t *testing.T) {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">3</span>)
+
+    <span class="t-cm">// with no receiver, the first 3 sends finish instantly</span>
+    ch &lt;- <span class="t-num">1</span>
+    ch &lt;- <span class="t-num">2</span>
+    ch &lt;- <span class="t-num">3</span>
+    <span class="t-bad">// ch &lt;- 4 → blocks here (buffer full)</span>
+
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">1</span>, &lt;-ch)
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">2</span>, &lt;-ch)
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">3</span>, &lt;-ch)
+}</pre>
+          <div class="callout teal">
+            <span class="lbl">what changed</span>
+            There is <b>no goroutine at all</b>. Unbuffered, the very first line <code class="inl">ch &lt;- 1</code> would deadlock.
+          </div>
+        </div>
+        <div class="notes-src">Put it next to the previous slide and point out that the goroutine is gone — that's the core of this slide. Ask what happens if the commented-out fourth send is enabled and take answers; it connects to quiz Q2.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 13 cap / len ═══════════ -->
+    <div class="holder" data-n="13">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Blocking</span><span class="stamp">cap · len</span></div>
+        <h2 class="slide-title"><span class="em">cap</span> is the size of the bowl, <span class="em">len</span> what's in it now</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">cap(ch)</code> — the <b>buffer capacity</b> fixed at creation. It never changes</li>
+              <li><code class="inl">len(ch)</code> — how many <b>values are queued</b> in the buffer right now</li>
+              <li>An unbuffered channel is always <code class="inl">cap 0</code>, <code class="inl">len 0</code></li>
+              <li>Fine for monitoring and logs. But <b>never use them for flow control</b></li>
+            </ul>
+            <pre class="code sm">ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">string</span>, <span class="t-num">5</span>)
+
+assert.<span class="t-fn">Equal</span>(t, <span class="t-num">5</span>, <span class="t-fn">cap</span>(ch)) <span class="t-cm">// capacity</span>
+assert.<span class="t-fn">Equal</span>(t, <span class="t-num">0</span>, <span class="t-fn">len</span>(ch)) <span class="t-cm">// values waiting</span>
+
+ch &lt;- <span class="t-str">"a"</span>
+ch &lt;- <span class="t-str">"b"</span>
+
+assert.<span class="t-fn">Equal</span>(t, <span class="t-num">5</span>, <span class="t-fn">cap</span>(ch))
+assert.<span class="t-fn">Equal</span>(t, <span class="t-num">2</span>, <span class="t-fn">len</span>(ch))</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">don't branch on len</span>
+            <code class="inl">if len(ch) &lt; cap(ch) { ch &lt;- v }</code> — another goroutine can fill it between the check and the send. That job belongs to <code class="inl">select</code>'s <code class="inl">default</code> (part 3).
+          </div>
+        </div>
+        <div class="notes-src">The value is already stale the instant you read it — a textbook TOCTOU. Lay down one more teaser for part 3 here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 14 Choosing ═══════════ -->
+    <div class="holder" data-n="14">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · Blocking</span><span class="stamp">choosing</span></div>
+        <h2 class="slide-title">Which one to pick, and when</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Situation</th><th>Pick</th><th>Why</th></tr></thead>
+              <tbody>
+                <tr class="on"><td>Handshake between goroutines</td><td><code class="inl">Unbuffered</code></td><td>The meeting instant is the sync point</td></tr>
+                <tr class="on"><td>Done · quit signals</td><td><code class="inl">Unbuffered</code></td><td>Signals have no reason to pile up</td></tr>
+                <tr><td>Producer / consumer speed gap</td><td><code class="inl">Buffered</code></td><td>Absorbs short bursts</td></tr>
+                <tr><td>Producer / Consumer</td><td><code class="inl">Buffered</code></td><td>Neither waits on the other every time</td></tr>
+                <tr><td>Bulk data transfer</td><td><code class="inl">Buffered</code></td><td>Fewer context switches</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">in doubt, unbuffered</span>
+            Buffers work by <b>hiding problems</b>. Better to size one once you can actually see the bottleneck.
+          </div>
+        </div>
+        <div class="notes-src">Don't read the table out; say the callout line only. To "what buffer size?" the right answer is "don't pick one without measuring" — most codebases have an unjustified 1 or core-count baked in.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 15 Chapter 03 ═══════════ -->
+    <div class="holder" data-n="15" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">03</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Direction</h2>
+            <p class="chap-d">Carve the direction into the type and wrong usage is caught <b>at compile time</b>.
+            The runtime cost is zero and the syntax is one arrow moved.</p>
+          </div>
+        </div>
+        <div class="notes-src">Keep it to 4 minutes. The syntax is simple enough to fly through, but be sure to leave the message "the signature is the documentation".</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 16 Direction syntax ═══════════ -->
+    <div class="holder" data-n="16">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · Direction</span><span class="stamp">chan&lt;- · &lt;-chan</span></div>
+        <h2 class="slide-title">Arrow <span class="em">after chan means put in</span>, before means take out</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">chan&lt;- int</code> — <b>send-only</b>. Receiving is a compile error</li>
+              <li><code class="inl">&lt;-chan int</code> — <b>receive-only</b>. Sending or closing is a compile error</li>
+              <li>The runtime cost is <b>zero</b>. Purely a compile-time check</li>
+              <li>Mostly used on <b>function parameters and return types</b>. Rarely on variables</li>
+            </ul>
+            <pre class="code sm"><span class="t-key">chan</span> <span class="t-key">int</span>     <span class="t-cm">// bidirectional</span>
+<span class="t-key">chan</span>&lt;- <span class="t-key">int</span>   <span class="t-cm">// send-only — put in only</span>
+&lt;-<span class="t-key">chan</span> <span class="t-key">int</span>   <span class="t-cm">// receive-only — take out only</span>
+
+<span class="t-key">func</span> <span class="t-fn">produce</span>(ch <span class="t-key">chan</span>&lt;- <span class="t-key">int</span>) { ch &lt;- <span class="t-num">1</span> } <span class="t-cm">// OK</span>
+<span class="t-key">func</span> <span class="t-fn">consume</span>(ch &lt;-<span class="t-key">chan</span> <span class="t-key">int</span>) { &lt;-ch }   <span class="t-cm">// OK</span>
+
+<span class="t-key">func</span> <span class="t-fn">bad</span>(ch &lt;-<span class="t-key">chan</span> <span class="t-key">int</span>) { <span class="t-fn">close</span>(ch) } <span class="t-bad">// compile error</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">the type is the doc</span>
+            From the signature alone you know whether a function <b>puts in or takes out</b>. A stronger contract than any comment.
+          </div>
+        </div>
+        <div class="notes-src">A mnemonic: arrow pointing at chan means going in, arrow leaving chan means coming out. If confused, recall the two expressions <code>ch &lt;- v</code> and <code>&lt;-ch</code>.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 17 producer / consumer signatures ═══════════ -->
+    <div class="holder" data-n="17">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · Direction</span><span class="stamp">contract</span></div>
+        <h2 class="slide-title">The signature is a <span class="em">declaration of role</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm">// producer — send-only. cannot receive here</span>
+<span class="t-key">func</span> <span class="t-fn">produce</span>(ch <span class="t-key">chan</span>&lt;- <span class="t-key">int</span>, values []<span class="t-key">int</span>) {
+    <span class="t-key">for</span> _, v := <span class="t-key">range</span> values {
+        ch &lt;- v
+    }
+    <span class="t-fn">close</span>(ch) <span class="t-cm">// the sender closes</span>
+}
+<span class="t-cm">// consumer — receive-only. cannot close here</span>
+<span class="t-key">func</span> <span class="t-fn">consume</span>(ch &lt;-<span class="t-key">chan</span> <span class="t-key">int</span>) []<span class="t-key">int</span> {
+    <span class="t-key">var</span> out []<span class="t-key">int</span>
+    <span class="t-key">for</span> v := <span class="t-key">range</span> ch {
+        out = <span class="t-fn">append</span>(out, v)
+    }
+    <span class="t-key">return</span> out
+}</pre>
+          <div class="callout">
+            <span class="lbl">this pair is the base form</span>
+            <b>The sending function closes</b>, and the receiving one reads to the end with <code class="inl">range</code>. Every remaining example today is a variation on this shape.
+          </div>
+        </div>
+        <div class="notes-src">Point out that the caller just passes a bidirectional <code>ch := make(chan int, 5)</code> — the conversion is automatic, so calling code doesn't change at all. That's the next slide.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 18 Conversion direction ═══════════ -->
+    <div class="holder" data-n="18">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · Direction</span><span class="stamp">one way only</span></div>
+        <h2 class="slide-title">Permission flows only <span class="em">toward the narrower</span> side</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">Allowed — implicit conversion</div>
+              <p><code class="inl">chan int</code> → <code class="inl">chan&lt;- int</code></p>
+              <p><code class="inl">chan int</code> → <code class="inl">&lt;-chan int</code></p>
+              <p class="dim">Assignment and argument passing both just work. No cast needed.</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Not allowed — compile error</div>
+              <p><code class="inl">chan&lt;- int</code> ⇸ <code class="inl">chan int</code></p>
+              <p><code class="inl">&lt;-chan int</code> ⇸ <code class="inl">chan int</code></p>
+              <p class="dim">Once narrowed, permission can't be undone. To widen you must still hold the original bidirectional channel.</p>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">how to use it in design</span>
+            Keep the bidirectional channel <b>only where it was made</b> and expose only narrowed types outward. Then there is no way left to break the rules.
+          </div>
+        </div>
+        <div class="notes-src">Comparing it to "exposing a private field through a getter only" lands well with an object-oriented audience. The generator pattern on 23 is exactly this idea in code.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 19 Chapter 04 ═══════════ -->
+    <div class="holder" data-n="19" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">04</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Close</h2>
+            <p class="chap-d">close doesn't destroy the channel; it announces "<b>I will send no more</b>".
+            Break one of three rules and it blows up as a <b>runtime panic</b>, not a compile error.</p>
+          </div>
+        </div>
+        <div class="notes-src">This is where production incidents come from most. Spend the time on the rules table (22) and the generator pattern (23). 6–8 minutes.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 20 What close means ═══════════ -->
+    <div class="holder" data-n="20">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · Close</span><span class="stamp">declaration</span></div>
+        <h2 class="slide-title">close is not destruction, it's a <span class="em">declaration</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>It doesn't remove the channel. Values left in the buffer <b>all still come out</b></li>
+              <li>It means "<b>no more sends</b>", not "all values have arrived"</li>
+              <li>So <b>only the sender</b> can close — the receiver has no way to know the end</li>
+              <li>You needn't always close. It's needed <b>when someone reads with <code class="inl">range</code></b></li>
+            </ul>
+            <pre class="code sm">ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">2</span>)
+ch &lt;- <span class="t-num">1</span>
+ch &lt;- <span class="t-num">2</span>
+<span class="t-fn">close</span>(ch) <span class="t-cm">// no more sends</span>
+
+fmt.<span class="t-fn">Println</span>(&lt;-ch) <span class="t-cm">// 1 — leftovers intact</span>
+fmt.<span class="t-fn">Println</span>(&lt;-ch) <span class="t-cm">// 2</span>
+fmt.<span class="t-fn">Println</span>(&lt;-ch) <span class="t-cm">// 0 — all drained</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">nothing to do with memory</span>
+            Even unclosed, once the references go the GC reclaims it. close is <b>a signal, not cleanup</b>.
+          </div>
+        </div>
+        <div class="notes-src">"Must I always close it, like a file?" is guaranteed to come up. The answer is the callout — it's a protocol, not resource release. The only reason to close is to tell the receiver it's over.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 21 Receiving from a closed channel ═══════════ -->
+    <div class="holder" data-n="21">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · Close</span><span class="stamp">v, ok</span></div>
+        <h2 class="slide-title">A closed channel instantly returns <span class="em">zero value + false</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">TestReceiveFromClosedChannel</span>(t *testing.T) {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">1</span>)
+    ch &lt;- <span class="t-num">42</span>
+    <span class="t-fn">close</span>(ch)
+
+    <span class="t-cm">// values left in the buffer come back normally</span>
+    val, ok := &lt;-ch
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">42</span>, val)
+    assert.<span class="t-fn">True</span>(t, ok) <span class="t-cm">// a valid value</span>
+
+    <span class="t-cm">// empty and closed → zero value + false</span>
+    val, ok = &lt;-ch
+    assert.<span class="t-fn">Equal</span>(t, <span class="t-num">0</span>, val) <span class="t-cm">// zero value of int</span>
+    assert.<span class="t-fn">False</span>(t, ok)     <span class="t-cm">// closed marker</span>
+}</pre>
+          <div class="callout">
+            <span class="lbl">without ok you can't tell</span>
+            Whether that <code class="inl">0</code> came from a close or from a sender is known <b>only to <code class="inl">ok</code></b>. And it doesn't block — it returns at once.
+          </div>
+        </div>
+        <div class="notes-src">"Won't receiving from a closed channel loop forever?" — yes, zero values come out endlessly without blocking. That's why you need an <code>ok</code> check or <code>range</code>. It leads naturally into the next slide.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 22 close rules ═══════════ -->
+    <div class="holder" data-n="22">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · Close</span><span class="stamp">four rules</span></div>
+        <h2 class="slide-title">Three <span class="em">panic</span>, one is safe</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Rule</th><th>If broken</th></tr></thead>
+              <tbody>
+                <tr class="on"><td><b>The sender closes</b></td><td>If the receiver closes, the sender sends on a closed channel → <span class="hl">panic</span></td></tr>
+                <tr><td><b>Never close twice</b></td><td><code class="inl">panic: close of closed channel</code></td></tr>
+                <tr><td><b>Never send on a closed channel</b></td><td><code class="inl">panic: send on closed channel</code></td></tr>
+                <tr><td>Receiving from a closed channel is <b>safe</b></td><td class="faint">Allowed — returns zero value + false at once</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">the compiler can't catch these</span>
+            All three blow up <b>at runtime</b>. So "<b>who closes, and when</b>" has to be nailed down by <b>design</b>, not by code.
+          </div>
+        </div>
+        <div class="notes-src">A real incident story fits well here — retry logic calling close twice is a common shape. The fix is sync.Once or "funnel closing into a single owner", and the latter is the next slide.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 23 generator pattern ═══════════ -->
+    <div class="holder" data-n="23">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · Close</span><span class="stamp">generator</span></div>
+        <h2 class="slide-title">Make, send and close, <span class="em">gathered in one place</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">generator</span>() &lt;-<span class="t-key">chan</span> <span class="t-key">int</span> {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>)
+    <span class="t-key">go</span> <span class="t-key">func</span>() {
+        <span class="t-key">defer</span> <span class="t-fn">close</span>(ch) <span class="t-cm">// the sender closes</span>
+        <span class="t-key">for</span> i := <span class="t-key">range</span> <span class="t-num">5</span> {
+            ch &lt;- i
+        }
+    }()
+    <span class="t-key">return</span> ch <span class="t-cm">// receive-only — callers can't close</span>
+}
+
+<span class="t-key">for</span> v := <span class="t-key">range</span> <span class="t-fn">generator</span>() {
+    fmt.<span class="t-fn">Println</span>(v) <span class="t-cm">// 0 1 2 3 4</span>
+}</pre>
+          <div class="callout teal">
+            <span class="lbl">no way left to break the rules</span>
+            The return type is narrowed to <code class="inl">&lt;-chan</code>, so <b>callers can neither close nor send</b>. All three rules from 22 have turned into compile errors.
+          </div>
+        </div>
+        <div class="notes-src">It's fair to say that if you photograph one slide today, make it this one. Note that <code>defer close(ch)</code> sits on the first line inside the goroutine — it closes even on panic. It's also the basic brick of pipelines (part 3).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 24 Chapter 05 ═══════════ -->
+    <div class="holder" data-n="24" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">05</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Range and Signals</h2>
+            <p class="chap-d">The receiver's idiom <code class="inl">range</code>, and the value-less channel <code class="inl">chan struct{}</code>.
+            Both sit on top of the close we just learned.</p>
+          </div>
+        </div>
+        <div class="notes-src">We just did the close rules, so this follows naturally. 5–6 minutes.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 25 range ═══════════ -->
+    <div class="holder" data-n="25">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · Range</span><span class="stamp">for range ch</span></div>
+        <h2 class="slide-title">range ends on <span class="em">one thing only: close</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">for v := range ch</code> — waits for values and pulls them out one by one</li>
+              <li>It ends in exactly one case: <b>the channel closing</b>. It doesn't count values</li>
+              <li>Forget the close and it <b>blocks forever</b> — the classic cause of goroutine leaks</li>
+              <li>Same as writing <code class="inl">v, ok := &lt;-ch</code>, but it <b>does the <code class="inl">ok</code> check for you</b></li>
+            </ul>
+            <pre class="code sm">ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">5</span>)
+<span class="t-key">go</span> <span class="t-key">func</span>() {
+    <span class="t-key">for</span> i := <span class="t-num">1</span>; i &lt;= <span class="t-num">5</span>; i++ {
+        ch &lt;- i
+    }
+    <span class="t-fn">close</span>(ch) <span class="t-bad">// without it range never ends</span>
+}()
+
+<span class="t-key">for</span> v := <span class="t-key">range</span> ch { <span class="t-cm">// 1 2 3 4 5</span>
+    out = <span class="t-fn">append</span>(out, v)
+}</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">they come as a pair</span>
+            The moment you write code that reads with <code class="inl">range</code>, you must also decide <b>who closes that channel, and when</b>. They're one set.
+          </div>
+        </div>
+        <div class="notes-src">If you can answer "how many times does range loop?" with "until it's closed", this slide is done. Tease that the infinite wait gets cut off by select + ctx.Done() in part 3.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 26 chan struct{} ═══════════ -->
+    <div class="holder" data-n="26">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · Signals</span><span class="stamp">chan struct{}</span></div>
+        <h2 class="slide-title">When you want to send <span class="em">"it's done"</span>, not data</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">struct{}</code> has no fields, so it's <b>0 bytes</b> — the type shows you mean to carry no value</li>
+              <li>With <code class="inl">chan bool</code>, "what does true mean, and false?" always follows</li>
+              <li>Signals have no reason to pile up, so they're usually <b>unbuffered</b></li>
+              <li>By convention they're named <code class="inl">done</code>, <code class="inl">quit</code>, <code class="inl">ready</code></li>
+            </ul>
+            <pre class="code sm">done := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">struct</span>{})
+
+<span class="t-key">go</span> <span class="t-key">func</span>() {
+    <span class="t-cm">// do the work...</span>
+    <span class="t-fn">close</span>(done) <span class="t-cm">// done signal</span>
+}()
+
+&lt;-done <span class="t-cm">// wait until it's done</span></pre>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">cost</span>
+            <code class="inl">unsafe.Sizeof(struct{}{})</code> is <b>0</b> — the values crossing cost nothing. (The channel itself is a separate cost.)
+          </div>
+        </div>
+        <div class="notes-src">"Why struct{}, why not bool?" always comes up. Frame the answer as <b>expressing intent</b>, not performance — pinning down in the type that the value carries no meaning.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 27 close vs send ═══════════ -->
+    <div class="holder" data-n="27">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · Signals</span><span class="stamp">broadcast</span></div>
+        <h2 class="slide-title">close wakes <span class="em">everyone</span>, send wakes one</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">done &lt;- struct{}{}</div>
+              <p>Wakes exactly <b>one</b> waiting receiver.</p>
+              <p class="dim">Three waiting means sending three times. That is, the sender <b>must know the receiver count</b>.</p>
+            </div>
+            <div class="card">
+              <div class="card-t">close(done)</div>
+              <p><b>Everyone</b> waiting wakes at once.</p>
+              <p class="dim">Any number is fine, and receivers that <b>arrive after the close</b> pass through immediately. The signal can't be missed.</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">so use close for cancel and shutdown</span>
+            You needn't know the receiver count, and latecomers don't miss it. <code class="inl">context.Done()</code> works exactly this way — we meet it again in part 5.
+          </div>
+        </div>
+        <div class="notes-src">"The signal can't be missed" is the key — with a send, a receiver that arrives late never gets a signal that already passed. This is where you convince them why context was designed around closing a channel.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 28 struct{} vs struct{}{} ═══════════ -->
+    <div class="holder" data-n="28">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · Signals</span><span class="stamp">FAQ</span></div>
+        <h2 class="slide-title"><span class="em">struct{}</span> is the blueprint, <span class="em">struct{}{}</span> the thing</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Expression</th><th>Meaning</th><th>Analogy</th></tr></thead>
+              <tbody>
+                <tr><td><code class="inl">int</code></td><td>the int type</td><td class="faint">blueprint</td></tr>
+                <tr><td><code class="inl">42</code></td><td>an int value</td><td class="faint">the thing</td></tr>
+                <tr class="on"><td><code class="inl">struct{}</code></td><td>empty struct <b>type</b></td><td>blueprint — with no fields</td></tr>
+                <tr class="on"><td><code class="inl">struct{}{}</code></td><td>empty struct <b>value</b></td><td>the thing — with no contents</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">how to parse it</span>
+            <code class="inl">struct{}</code> + <code class="inl">{}</code> — type first, empty literal second. Exactly like <code class="inl">Person{}</code> being <code class="inl">Person</code> + <code class="inl">{}</code>.
+            So <code class="inl">make(chan struct{})</code> takes a type and <code class="inl">done &lt;- struct{}{}</code> takes a value.
+          </div>
+        </div>
+        <div class="notes-src">This slide shows that only the four braces jammed together look odd — the rule itself is ordinary. Thirty seconds is plenty, so move on quickly.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 29 Chapter 06 ═══════════ -->
+    <div class="holder" data-n="29" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">06</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Practice — Producer / Consumer</h2>
+            <p class="chap-d">Everything so far, gathered into one piece of code. The moment there are several
+            producers, "<b>who closes</b>" turns into a real design question.</p>
+          </div>
+        </div>
+        <div class="notes-src">From here it's assembling the earlier pieces. The only new concept is WaitGroup, and draw the line early that it's a part 4 topic.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 30 producer/consumer base form ═══════════ -->
+    <div class="holder" data-n="30">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">06 · Practice</span><span class="stamp">1 : 1</span></div>
+        <h2 class="slide-title">One producer, one consumer — the <span class="em">base form</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">TestProducerConsumer</span>(t *testing.T) {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">10</span>)
+    <span class="t-key">var</span> results []<span class="t-key">int</span>
+
+    <span class="t-key">go</span> <span class="t-key">func</span>() { <span class="t-cm">// Producer — makes squares</span>
+        <span class="t-key">for</span> i := <span class="t-num">1</span>; i &lt;= <span class="t-num">10</span>; i++ {
+            ch &lt;- i * i
+        }
+        <span class="t-fn">close</span>(ch) <span class="t-cm">// declares: all sent</span>
+    }()
+    <span class="t-key">for</span> val := <span class="t-key">range</span> ch { <span class="t-cm">// Consumer — collects until closed</span>
+        results = <span class="t-fn">append</span>(results, val)
+    }
+    assert.<span class="t-fn">Len</span>(t, results, <span class="t-num">10</span>)
+}</pre>
+          <div class="callout">
+            <span class="lbl">what buffer 10 buys</span>
+            The producer <b>needn't wait for the consumer every time</b>. Set it to 0 and the result is the same, but then they shake hands on every value.
+          </div>
+        </div>
+        <div class="notes-src">Every earlier piece is in here — make, send, close, range, and the reason for buffering. Walking the code top to bottom once makes a good review.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 31 many producers ═══════════ -->
+    <div class="holder" data-n="31">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">06 · Practice</span><span class="stamp">N : 1</span></div>
+        <h2 class="slide-title">With many producers, <span class="em">nobody can close alone</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code xs">ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">20</span>)
+<span class="t-key">var</span> wg sync.WaitGroup
+
+<span class="t-key">for</span> p := <span class="t-key">range</span> <span class="t-num">3</span> { <span class="t-cm">// 3 producers</span>
+    wg.<span class="t-fn">Add</span>(<span class="t-num">1</span>)
+    <span class="t-key">go</span> <span class="t-key">func</span>() {
+        <span class="t-key">defer</span> wg.<span class="t-fn">Done</span>()
+        <span class="t-key">for</span> i := <span class="t-key">range</span> <span class="t-num">5</span> {
+            ch &lt;- p*<span class="t-num">100</span> + i
+        }
+    }()
+}
+
+<span class="t-key">go</span> <span class="t-key">func</span>() { <span class="t-cm">// watcher — closes only when all are done</span>
+    wg.<span class="t-fn">Wait</span>()
+    <span class="t-fn">close</span>(ch)
+}()</pre>
+          <div class="callout">
+            <span class="lbl">give closing its own role</span>
+            None of the three producers knows it is "the last one". <b>A fourth goroutine waiting on the WaitGroup</b> takes that role. The receiving side is unchanged from the previous slide.
+          </div>
+        </div>
+        <div class="notes-src">"Can't I close inside the producer?" — that's a double close and a panic. This is where rule 22 collides with reality. Draw the line that WaitGroup itself is covered properly in part 4.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 32 shutdown order ═══════════ -->
+    <div class="holder" data-n="32">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">06 · Practice</span><span class="stamp">step by step</span></div>
+        <h2 class="slide-title">What happens, <span class="em">in order</span>, up to the close</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="steps">
+            <div class="step"><span class="s-n">1</span><div><div class="s-c">wg.Add(1) — <b>before</b> launching the goroutine</div><div class="s-d">Add inside the goroutine and Wait may slip past first</div></div></div>
+            <div class="step"><span class="s-n">2</span><div><div class="s-c">defer wg.Done() — each producer reports its own exit</div><div class="s-d">defer keeps the counter dropping even on a panic</div></div></div>
+            <div class="step"><span class="s-n">3</span><div><div class="s-c">wg.Wait() → close(ch) — closes only after everyone is done</div><div class="s-d">this job needs its own goroutine so the range below can run</div></div></div>
+            <div class="step"><span class="s-n">4</span><div><div class="s-c">for range ch — the loop ends itself on the close signal</div><div class="s-d">the consumer never needs to know how many producers there are</div></div></div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">why a separate watcher</span>
+            Call <code class="inl">wg.Wait()</code> in main and the producers stall the moment the buffer fills while main stalls on Wait — <b>each waiting on the other, forever</b>.
+          </div>
+        </div>
+        <div class="notes-src">Step 4 is the real value of this pattern — the consumer is fully decoupled from the producer count. It's the prototype of fan-in, and part 3 extends this exact shape.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 33 Recap ═══════════ -->
+    <div class="holder" data-n="33">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">wrap-up</span><span class="stamp">recap</span></div>
+        <h2 class="slide-title">What to take away</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <ul class="bul" style="font-size:20px;gap:17px;">
+            <li>A channel is a <b>type-safe pipe</b> between goroutines — communication and synchronization at once</li>
+            <li><b>Unbuffered</b> is a handshake, <b>buffered</b> is a queue — one number in <code class="inl">make</code> changes the behavior</li>
+            <li>Narrow the direction with <code class="inl">chan&lt;-</code> and <code class="inl">&lt;-chan</code> and <b>the compiler</b> blocks wrong usage</li>
+            <li><code class="inl">close</code> declares "no more sends" and must be done by <b>the sender</b> — closing twice panics</li>
+            <li>A closed channel instantly returns <b>zero value + false</b>. <code class="inl">range</code> ends on that signal</li>
+            <li>For signals use <code class="inl">chan struct{}</code> — to tell everyone, don't send, <b>close</b></li>
+          </ul>
+        </div>
+        <div class="notes-src">Reading the six lines aloud is itself the summary. It's fine to start taking questions from here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 34 Quiz ① ═══════════ -->
+    <div class="holder" data-n="34">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check ①</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Answer for yourself — buffers and direction</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>You send on an unbuffered channel and nobody receives. Then?</span></button>
+              <div class="q-a">The sender <b>keeps blocking</b> until it meets a receiver. If every goroutine is in that state, the runtime kills it with <code class="inl">all goroutines are asleep - deadlock!</code> <span class="ref">→ Slide 09 · 11</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>Four sends on <code class="inl">make(chan int, 3)</code> with no receiver?</span></button>
+              <div class="q-a">The first three <b>pass instantly</b> and the fourth blocks. A buffer only absorbs momentary speed gaps; it is not an infinite queue. <span class="ref">→ Slide 10 · 12</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>Why is <code class="inl">if len(ch) &lt; cap(ch) { ch &lt;- v }</code> dangerous?</span></button>
+              <div class="q-a">Another goroutine can fill the buffer <b>between</b> the check and the send. It's stale the instant you read it. Non-blocking send needs <code class="inl">select</code> + <code class="inl">default</code>. <span class="ref">→ Slide 13</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>Take a parameter as <code class="inl">&lt;-chan int</code> — what is forbidden?</span></button>
+              <div class="q-a"><b>Both send and close</b>. Receiving only. It's caught at <b>compile time</b>, not runtime, so no test is needed. <span class="ref">→ Slide 16 · 17</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>Can you assign <code class="inl">&lt;-chan int</code> to a <code class="inl">chan int</code> variable?</span></button>
+              <div class="q-a">No. Conversion happens automatically only in the <b>narrowing</b> direction. To widen, you must hold the original bidirectional channel. <span class="ref">→ Slide 18</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Let them answer first, then click to open. If time is short, Q2 and Q3 alone are enough.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 35 Quiz ② ═══════════ -->
+    <div class="holder" data-n="35">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check ②</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Answer for yourself — close and signals</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>Why is calling <code class="inl">close(ch)</code> on the receiver side dangerous?</span></button>
+              <div class="q-a">If a sender is still sending you get <code class="inl">panic: send on closed channel</code>. <b>Only the sender knows the end</b>, so closing is the sender's job too. <span class="ref">→ Slide 22 · 23</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>Is the <code class="inl">0</code> you received "from a close" or "sent by a sender"?</span></button>
+              <div class="q-a">Only the <b><code class="inl">ok</code></b> of <code class="inl">v, ok := &lt;-ch</code> tells them apart. A closed channel returns zero value and <code class="inl">false</code> at once, without blocking. <span class="ref">→ Slide 21</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span><code class="inl">for v := range ch</code> never ends. What's missing?</span></button>
+              <div class="q-a"><code class="inl">close(ch)</code>. range ends on <b>close alone</b>, and how many values were sent makes no difference. <span class="ref">→ Slide 25</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>Difference between <code class="inl">close(done)</code> and <code class="inl">done &lt;- struct{}{}</code>?</span></button>
+              <div class="q-a">close wakes <b>everyone</b> waiting and lets late receivers through. send wakes <b>one</b>, so the sender must know the receiver count. <span class="ref">→ Slide 26 · 27</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>With three producers, who closes, and when?</span></button>
+              <div class="q-a">No producer knows it is the last. A <b>separate goroutine</b> waiting on <code class="inl">wg.Wait()</code> closes once all are done. <span class="ref">→ Slide 31 · 32</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Q1 and Q5 are the two that blow up most often in production. If time is left, have everyone recall who calls close in their own codebase.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 36 Next part ═══════════ -->
+    <div class="holder" data-n="36">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">next</span><span class="stamp">part 3</span></div>
+        <h2 class="slide-title">Next — select and channels in depth</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack">
+              <p class="dim" style="margin:0;font-size:18px;line-height:1.6;">Today we handled <b>one</b> channel. In practice you wait on a value channel and an error
+              channel, plus timeout and cancellation — <b>several at once</b>. That's the next part's topic.</p>
+              <div class="callout">
+                <span class="lbl">what we deferred today</span>
+                Non-blocking send (<code class="inl">default</code>), timeouts that cut off endless waits, switching a case off with a nil channel —
+                everything brushed past today falls out of one construct, <code class="inl">select</code>. fan-in / fan-out too.
+              </div>
+            </div>
+            <div class="card">
+              <p class="card-t">References</p>
+              <ul class="bul" style="font-size:16.5px;gap:9px;">
+                <li>Full code — <code class="inl">github.com/kenshin579/tutorials-go</code> <span class="faint">/golang/concurrency</span></li>
+                <li>Go Tour — Channels <span class="faint">go.dev/tour/concurrency/2</span></li>
+                <li>Effective Go — Channels <span class="faint">go.dev/doc/effective_go#channels</span></li>
+                <li>Go Blog — Pipelines and cancellation <span class="faint">go.dev/blog/pipelines</span></li>
+              </ul>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Thank you</span>
+            Questions welcome — <code class="inl">advenoh.pe.kr</code>
+          </div>
+        </div>
+        <div class="notes-src">Leave the GitHub repository address up while taking Q&amp;A.</div>
+      </section>
+    </div>
+    </div><!-- /stage -->
+  </div><!-- /stage-wrap -->
+
+  <div class="notes" id="notes" aria-live="polite">
+    <div class="n-h">Speaker notes</div>
+    <div id="notesBody"></div>
+  </div>
+
+  <div class="chrome">
+    <span class="deck-id">Channels · Go Concurrency 2</span>
+    <div class="rail" id="rail"></div>
+    <span class="counter" id="counter"><span class="cur">01</span> / 36</span>
+    <div class="keys">
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="Overview (O)">Overview</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="Speaker notes (N)">Notes</button>
+      <button class="kbtn" id="btnTheme" type="button" title="Toggle theme (T)">Theme</button>
+      <button class="kbtn" id="btnHelp" type="button" title="Shortcuts (?)">?</button>
+    </div>
+  </div>
+
+  <div class="help" id="help">
+    <div class="help-box">
+      <h3>Shortcuts</h3>
+      <dl>
+        <dt>→ · Space · PgDn</dt><dd>Next slide</dd>
+        <dt>← · PgUp</dt><dd>Previous slide</dd>
+        <dt>Home · End</dt><dd>First · Last</dd>
+        <dt>O</dt><dd>Slide overview</dd>
+        <dt>N</dt><dd>Speaker notes</dd>
+        <dt>T</dt><dd>Light / dark theme</dd>
+        <dt>F</dt><dd>Fullscreen</dd>
+        <dt>Esc</dt><dd>Close</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var deck     = document.getElementById("deck");
+  var stage    = document.getElementById("stage");
+  var wrap     = document.getElementById("stageWrap");
+  var rail     = document.getElementById("rail");
+  var counter  = document.getElementById("counter");
+  var notesEl  = document.getElementById("notes");
+  var notesBody= document.getElementById("notesBody");
+  var helpEl   = document.getElementById("help");
+  var holders  = Array.prototype.slice.call(stage.querySelectorAll(".holder"));
+  var total    = holders.length;
+  var idx      = 0;
+  var overview = false;
+  var reduce   = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ── 눈금 레일 ─────────────────────────────────── */
+  var ticks = holders.map(function (h, i) {
+    var t = document.createElement("span");
+    t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
+    t.title = "Slide " + (i + 1);
+    t.addEventListener("click", function () { go(i); });
+    rail.appendChild(t);
+    return t;
+  });
+
+  function pad(n) { return (n < 10 ? "0" : "") + n; }
+
+  /* ── 무대 스케일 ───────────────────────────────── */
+  /* 무대는 stage-wrap 의 좌상단에 고정(place-items:start)해 두고,
+     축소한 뒤 남는 여백만큼 직접 translate 해서 가운데로 옮긴다.
+     transform-origin 을 center 로 두고 grid 중앙 정렬에 맡기면,
+     뷰포트가 1280x720 보다 작을 때 브라우저가 넘치는 항목을
+     좌상단에 고정(safe alignment)해 버려서 축소 결과가 오른쪽 아래로 쏠린다. */
+  function fit() {
+    if (overview) { stage.style.transform = ""; return; }
+    var k = Math.min(wrap.clientWidth / 1280, wrap.clientHeight / 720);
+    var tx = (wrap.clientWidth - 1280 * k) / 2;
+    var ty = (wrap.clientHeight - 720 * k) / 2;
+    stage.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + k + ")";
+  }
+
+  /* ── 이동 ──────────────────────────────────────── */
+  function go(n, silent) {
+    n = Math.max(0, Math.min(total - 1, n));
+    idx = n;
+    holders.forEach(function (h, i) { h.classList.toggle("is-active", i === n); });
+    ticks.forEach(function (t, i) {
+      t.classList.toggle("done", i < n);
+      t.classList.toggle("now", i === n);
+    });
+    counter.innerHTML = '<span class="cur">' + pad(n + 1) + "</span> / " + total;
+    var src = holders[n].querySelector(".notes-src");
+    notesBody.textContent = src ? src.textContent.trim() : "—";
+    if (!silent) { history.replaceState(null, "", "#" + (n + 1)); }
+    runOdometers(holders[n]);
+    if (overview) {
+      holders[n].scrollIntoView({ block: "nearest", behavior: reduce ? "auto" : "smooth" });
+    }
+  }
+
+  /* ── 카디널리티 카운터 ─────────────────────────── */
+  function runOdometers(holder) {
+    var list = holder.querySelectorAll("[data-odo]");
+    Array.prototype.forEach.call(list, function (el, i) {
+      var to = parseInt(el.getAttribute("data-odo"), 10);
+      if (reduce) { el.textContent = to.toLocaleString("en-US"); return; }
+      var dur = 900, delay = i * 420, t0 = null;
+      el.textContent = "0";
+      function frame(ts) {
+        if (t0 === null) { t0 = ts; }
+        var p = (ts - t0 - delay) / dur;
+        if (p < 0) { requestAnimationFrame(frame); return; }
+        if (p > 1) { p = 1; }
+        var e = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(to * e).toLocaleString("en-US");
+        if (p < 1) { requestAnimationFrame(frame); }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
+  /* ── 개요 모드 ─────────────────────────────────── */
+  function setOverview(on) {
+    overview = on;
+    deck.classList.toggle("is-overview", on);
+    document.getElementById("btnOverview").setAttribute("aria-pressed", String(on));
+    fit();
+    if (on) { holders[idx].scrollIntoView({ block: "center" }); }
+  }
+
+  holders.forEach(function (h, i) {
+    h.addEventListener("click", function () { if (overview) { setOverview(false); go(i); } });
+  });
+
+  /* ── 노트 · 테마 · 도움말 ──────────────────────── */
+  function setNotes(on) {
+    notesEl.classList.toggle("on", on);
+    document.getElementById("btnNotes").setAttribute("aria-pressed", String(on));
+  }
+  function toggleTheme() {
+    var cur = document.documentElement.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try { localStorage.setItem("deck-theme", next); } catch (e) {}
+    drawHero();
+  }
+  try {
+    var saved = localStorage.getItem("deck-theme");
+    if (saved) { document.documentElement.setAttribute("data-theme", saved); }
+  } catch (e) {}
+
+  document.getElementById("btnOverview").addEventListener("click", function () { setOverview(!overview); });
+  document.getElementById("btnNotes").addEventListener("click", function () { setNotes(!notesEl.classList.contains("on")); });
+  document.getElementById("btnTheme").addEventListener("click", toggleTheme);
+  document.getElementById("btnHelp").addEventListener("click", function () { helpEl.classList.toggle("on"); });
+  helpEl.addEventListener("click", function () { helpEl.classList.remove("on"); });
+
+  /* ── 클릭 리빌 · 이미지 토글 ───────────────────── */
+  document.addEventListener("click", function (e) {
+    var qb = e.target.closest ? e.target.closest(".q-btn") : null;
+    if (qb) { qb.parentNode.classList.toggle("is-open"); return; }
+
+    var tg = e.target.closest ? e.target.closest(".tg") : null;
+    if (tg) {
+      var group = tg.getAttribute("data-swap");
+      var target = tg.getAttribute("data-target");
+      Array.prototype.forEach.call(document.querySelectorAll('.tg[data-swap="' + group + '"]'), function (b) {
+        b.setAttribute("aria-pressed", String(b === tg));
+      });
+      Array.prototype.forEach.call(document.querySelectorAll('[data-swap-group="' + group + '"] > .swap-i'), function (item) {
+        item.classList.toggle("on", item.getAttribute("data-swap-item") === target);
+      });
+    }
+  });
+
+  /* ── 키보드 ────────────────────────────────────── */
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) { return; }
+    var k = e.key;
+    if (k === "ArrowRight" || k === "PageDown" || k === " " || k === "Spacebar") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowLeft" || k === "PageUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "ArrowDown") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "Home") { e.preventDefault(); go(0); }
+    else if (k === "End") { e.preventDefault(); go(total - 1); }
+    else if (k === "o" || k === "O" || k === "ㅐ") { setOverview(!overview); }
+    else if (k === "n" || k === "N" || k === "ㅜ") { setNotes(!notesEl.classList.contains("on")); }
+    else if (k === "t" || k === "T" || k === "ㅅ") { toggleTheme(); }
+    else if (k === "f" || k === "F" || k === "ㄹ") {
+      if (document.fullscreenElement) { document.exitFullscreen(); }
+      else if (document.documentElement.requestFullscreen) { document.documentElement.requestFullscreen(); }
+    }
+    else if (k === "?" || k === "/") { helpEl.classList.toggle("on"); }
+    else if (k === "Escape") {
+      if (helpEl.classList.contains("on")) { helpEl.classList.remove("on"); }
+      else if (overview) { setOverview(false); }
+    }
+  });
+
+  /* ── 표지 스파크라인 ───────────────────────────── */
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  function drawHero() {
+    var cv = document.getElementById("heroCanvas");
+    if (!cv) { return; }
+    var ctx = cv.getContext("2d");
+    var W = cv.width, H = cv.height;
+    ctx.clearRect(0, 0, W, H);
+
+    var accent = css("--accent") || "#4FD3F4";
+    var line   = css("--line") || "#272F3A";
+    var faint  = css("--ink-faint") || "#6B7688";
+
+    /* 격자 */
+    ctx.strokeStyle = line;
+    ctx.lineWidth = 1;
+    var i, y, x;
+    for (i = 1; i <= 4; i++) {
+      y = Math.round((H / 5) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    for (i = 1; i <= 5; i++) {
+      x = Math.round((W / 6) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+    }
+
+    /* 결정적인 CPU 곡선 (난수 없이 재현 가능하게) */
+    var N = 180, pts = [];
+    for (i = 0; i < N; i++) {
+      var t = i / (N - 1);
+      var v = 0.42
+        + 0.16 * Math.sin(t * 8.1 + 0.6)
+        + 0.09 * Math.sin(t * 21.3 + 1.9)
+        + 0.05 * Math.sin(t * 47.7 + 4.2)
+        + 0.10 * Math.exp(-Math.pow((t - 0.68) * 9, 2));
+      v = Math.max(0.08, Math.min(0.92, v));
+      pts.push([6 + t * (W - 12), H - v * H]);
+    }
+
+    var steps = reduce ? N : 0;
+    function render(n) {
+      ctx.clearRect(0, 0, W, H);
+      ctx.strokeStyle = line;
+      for (i = 1; i <= 4; i++) {
+        y = Math.round((H / 5) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+      }
+      for (i = 1; i <= 5; i++) {
+        x = Math.round((W / 6) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+      }
+
+      var m = Math.max(2, n);
+      var grad = ctx.createLinearGradient(0, 0, 0, H);
+      grad.addColorStop(0, accent + "55");
+      grad.addColorStop(1, accent + "00");
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], H);
+      for (i = 0; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.lineTo(pts[m - 1][0], H);
+      ctx.closePath();
+      ctx.fillStyle = grad;
+      ctx.fill();
+
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (i = 1; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.strokeStyle = accent;
+      ctx.lineWidth = 2.4;
+      ctx.lineJoin = "round";
+      ctx.stroke();
+
+      /* 마지막 점 강조 */
+      ctx.beginPath();
+      ctx.arc(pts[m - 1][0], pts[m - 1][1], 4.5, 0, Math.PI * 2);
+      ctx.fillStyle = accent;
+      ctx.fill();
+
+      ctx.font = "500 20px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = faint;
+      ctx.textAlign = "left";
+      ctx.fillText("100%", 8, 22);
+      ctx.fillText("0", 8, H - 8);
+    }
+
+    if (reduce) { render(N); return; }
+    var n0 = 2, t0 = null;
+    function frame(ts) {
+      if (t0 === null) { t0 = ts; }
+      var p = Math.min(1, (ts - t0) / 1100);
+      var e = 1 - Math.pow(1 - p, 3);
+      render(Math.max(n0, Math.round(N * e)));
+      if (p < 1) { requestAnimationFrame(frame); }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  /* ── 초기화 ────────────────────────────────────── */
+  window.addEventListener("resize", fit);
+  window.addEventListener("hashchange", function () {
+    var n = parseInt(location.hash.replace("#", ""), 10);
+    if (!isNaN(n)) { go(n - 1, true); }
+  });
+
+  var start = parseInt(location.hash.replace("#", ""), 10);
+  fit();
+  go(isNaN(start) ? 0 : start - 1, true);
+  drawHero();
+})();
+</script>
+</body>
+</html>

--- a/contents/go/golang-concurrency-3-select와-channel-심화/index_en.md
+++ b/contents/go/golang-concurrency-3-select와-channel-심화/index_en.md
@@ -66,6 +66,8 @@ func TestSelectMultipleReady(t *testing.T) {
 }
 ```
 
+<!-- slides -->
+
 # 2. Using the default Case
 
 Adding a `default` case makes it **non-blocking**. When no channel is ready, default runs immediately.

--- a/contents/go/golang-concurrency-3-select와-channel-심화/slides_en.html
+++ b/contents/go/golang-concurrency-3-select와-channel-심화/slides_en.html
@@ -1,0 +1,1874 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Select and Advanced Channel Patterns — Golang Concurrency Part 3</title>
+<style>
+/* ─────────────────────────────────────────────────────────────
+   계기판(instrument panel) — 차가운 슬레이트 바탕 위 따뜻한 표시등
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0B6E8C;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(11, 110, 140, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+
+  --f-display: "Avenir Next", "Apple SD Gothic Neo", "Helvetica Neue", system-ui, sans-serif;
+  --f-body:    "Apple SD Gothic Neo", -apple-system, "Helvetica Neue", "Noto Sans KR", sans-serif;
+  --f-mono:    "MesloLGS NF", "SF Mono", ui-monospace, Menlo, "D2Coding", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0E1117;
+    --surface:   #161B23;
+    --surface-2: #1B212A;
+    --ink:       #E6E9EE;
+    --ink-dim:   #98A2B0;
+    --ink-faint: #6B7688;
+    --line:      #272F3A;
+    --line-soft: #1E252E;
+    --grid:      rgba(255, 255, 255, .038);
+    --accent:    #4FD3F4;
+    --accent-ink:#04222C;
+    --accent-soft: rgba(79, 211, 244, .14);
+    --teal:      #46C7B0;
+    --teal-soft: rgba(70, 199, 176, .13);
+    --amber:     #E8B84B;
+    --red:       #F0625E;
+    --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg:        #0E1117;
+  --surface:   #161B23;
+  --surface-2: #1B212A;
+  --ink:       #E6E9EE;
+  --ink-dim:   #98A2B0;
+  --ink-faint: #6B7688;
+  --line:      #272F3A;
+  --line-soft: #1E252E;
+  --grid:      rgba(255, 255, 255, .038);
+  --accent:    #4FD3F4;
+  --accent-ink:#04222C;
+  --accent-soft: rgba(79, 211, 244, .14);
+  --teal:      #46C7B0;
+  --teal-soft: rgba(70, 199, 176, .13);
+  --amber:     #E8B84B;
+  --red:       #F0625E;
+  --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+}
+
+:root[data-theme="light"] {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0B6E8C;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(11, 110, 140, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ── 무대: 1280×720 고정, 뷰포트에 맞춰 축소 ───────────────── */
+.stage-wrap {
+  position: fixed;
+  inset: 0 0 52px 0;
+  display: grid;
+  /* 가운데 정렬은 fit() 이 translate 로 직접 한다. grid 중앙 정렬에 맡기면
+     무대가 뷰포트보다 클 때 safe alignment 로 좌상단에 고정되어 계산이 어긋난다. */
+  place-items: start;
+  overflow: hidden;
+}
+.stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  transform-origin: 0 0;
+  flex: none;
+}
+.holder {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .22s ease;
+}
+.holder.is-active { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .holder { transition: none; } }
+
+.slide {
+  width: 1280px;
+  height: 720px;
+  padding: 52px 68px 56px;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 40px,
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px) 0 0 / 40px 100%,
+    var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.slide::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0 34%, var(--line) 34% 100%);
+  opacity: .55;
+}
+
+/* ── 슬라이드 머리 ─────────────────────────────────────────── */
+.slide-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  flex: none;
+}
+.eyebrow {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+}
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+}
+.slide-title {
+  font-family: var(--f-display);
+  font-size: 42px;
+  line-height: 1.16;
+  font-weight: 700;
+  letter-spacing: -.022em;
+  margin: 0 0 6px;
+  text-wrap: balance;
+}
+.slide-title .em { color: var(--accent); }
+.slide-lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0 0 4px;
+  max-width: 72ch;
+}
+.rule {
+  height: 1px;
+  background: var(--line);
+  margin: 18px 0 22px;
+  flex: none;
+}
+.slide-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  font-size: 19px;
+  line-height: 1.6;
+}
+.slide-body.top { justify-content: flex-start; }
+
+/* ── 공용 조판 ─────────────────────────────────────────────── */
+.cols { display: grid; gap: 30px; align-items: start; }
+.c-2  { grid-template-columns: 1fr 1fr; }
+.c-2a { grid-template-columns: 1.15fr .85fr; }
+.c-2b { grid-template-columns: .82fr 1.18fr; }
+.c-3  { grid-template-columns: repeat(3, 1fr); }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.stack.tight { gap: 10px; }
+.grow { flex: 1; min-height: 0; }
+/* 높이를 채우는 2단 조판에서는 각 열이 늘어나고, 내용은 열 안에서 세로 중앙에 놓인다 */
+.cols.grow { align-items: stretch; }
+.cols.grow > .stack { justify-content: center; }
+
+ul.bul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 13px; }
+ul.bul > li { position: relative; padding-left: 26px; }
+ul.bul > li::before {
+  content: "";
+  position: absolute;
+  left: 4px; top: .62em;
+  width: 9px; height: 2px;
+  background: var(--accent);
+}
+ul.bul.teal > li::before { background: var(--teal); }
+.dim { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.hl { color: var(--accent); font-weight: 600; }
+.hl-teal { color: var(--teal); font-weight: 600; }
+b, strong { font-weight: 700; }
+
+/* ── 표 ────────────────────────────────────────────────────── */
+.tbl-wrap { overflow-x: auto; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink-faint);
+  padding: 0 14px 9px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: 11px 14px 11px 0;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  line-height: 1.45;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td:first-child { font-weight: 600; white-space: nowrap; }
+table.tbl.sm { font-size: 15.5px; }
+table.tbl.sm td { padding: 8px 12px 8px 0; }
+table.tbl tr.on td { background: var(--accent-soft); }
+table.tbl tr.on td:first-child { color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); padding-left: 12px; }
+.num-col { font-family: var(--f-mono); }
+
+/* ── 코드 ──────────────────────────────────────────────────── */
+.code {
+  font-family: var(--f-mono);
+  font-size: 15.5px;
+  line-height: 1.72;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+  padding: 14px 18px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+  tab-size: 2;
+}
+.code.sm { font-size: 14px; line-height: 1.66; padding: 12px 15px; }
+.code.xs { font-size: 12.6px; line-height: 1.6; padding: 11px 14px; }
+.code.plain { border-left-color: var(--line); }
+.code.teal { border-left-color: var(--teal); }
+.t-fn  { color: var(--accent); }
+.t-str { color: var(--teal); }
+.t-cm  { color: var(--ink-faint); }
+.t-num { color: var(--ink); font-weight: 600; }
+.t-key { color: var(--accent); font-weight: 600; }
+.t-bad { color: var(--red); }
+code.inl {
+  font-family: var(--f-mono);
+  font-size: .88em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  white-space: nowrap;
+}
+
+/* ── 카드 / 콜아웃 ─────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.card-t {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+.callout {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 14px 20px;
+  border-radius: 0 3px 3px 0;
+  font-size: 18px;
+  line-height: 1.55;
+}
+.callout.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+.callout .lbl {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.callout.teal .lbl { color: var(--teal); }
+
+/* ── 그림 ──────────────────────────────────────────────────── */
+.figure { display: flex; flex-direction: column; justify-content: center; gap: 10px; min-height: 0; }
+.figure img {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: var(--shadow);
+  background: var(--surface-2);
+}
+.figure figcaption, .cap {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.fit img { max-height: 100%; }
+
+/* ── 아키텍처 다이어그램 ───────────────────────────────────── */
+.arch {
+  display: grid;
+  grid-template-columns: 1fr 104px 1.02fr 104px 1fr;
+  align-items: center;
+  gap: 0;
+}
+.arch-col { display: flex; flex-direction: column; gap: 11px; }
+.node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 4px;
+  padding: 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.node .n-t { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.node .n-p { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-faint); }
+.node.hero {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  padding: 20px 18px;
+}
+.node.hero .n-t { font-size: 22px; color: var(--accent); }
+.node.hero .n-p { color: var(--ink-dim); }
+.node.mute { border-style: dashed; background: transparent; }
+.arch-link { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.arch-link .l-lbl {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.arch-link .l-line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  position: relative;
+}
+.arch-link .l-line::after {
+  content: "";
+  position: absolute;
+  right: 8px; top: -4px;
+  border: 4.5px solid transparent;
+  border-left-color: var(--accent);
+}
+
+/* ── 트리 ──────────────────────────────────────────────────── */
+.tree { font-family: var(--f-mono); font-size: 15px; line-height: 2.05; }
+.tree .lv { display: block; white-space: pre; }
+.tree .k { color: var(--accent); font-weight: 600; }
+.tree .v { color: var(--ink-dim); }
+
+/* ── 쿼리 해부도 ───────────────────────────────────────────── */
+.anat { display: flex; flex-direction: column; gap: 14px; }
+.anat-q {
+  font-family: var(--f-mono);
+  font-size: 24px;
+  letter-spacing: -.01em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.anat-q .p { padding: 3px 2px; border-bottom: 2px solid transparent; }
+.anat-q .p1 { border-bottom-color: var(--accent); }
+.anat-q .p2 { border-bottom-color: var(--teal); }
+.anat-q .p3 { border-bottom-color: var(--amber); }
+.anat-q .p4 { border-bottom-color: var(--ink-faint); }
+.legend { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.legend .lg-i { display: flex; flex-direction: column; gap: 4px; }
+.legend .lg-b { height: 3px; width: 34px; }
+.legend .lg-n { font-size: 15px; font-weight: 700; }
+.legend .lg-d { font-size: 14px; color: var(--ink-dim); line-height: 1.42; }
+
+/* ── 카디널리티 계산기 ─────────────────────────────────────── */
+.odo-row { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.odo {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 62px;
+  font-weight: 700;
+  letter-spacing: -.03em;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.odo.sm { font-size: 34px; color: var(--ink); }
+.odo-cap { font-size: 15px; color: var(--ink-dim); }
+.factor {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-family: var(--f-mono);
+  font-size: 19px;
+  color: var(--ink-dim);
+}
+.factor b { color: var(--ink); font-size: 22px; }
+
+/* ── 단계 목록 ─────────────────────────────────────────────── */
+.steps { display: flex; flex-direction: column; gap: 0; }
+.step {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.step:last-child { border-bottom: none; }
+.step .s-n {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 600;
+  padding-top: 3px;
+}
+.step .s-c { font-family: var(--f-mono); font-size: 14.5px; color: var(--ink); }
+.step .s-d { font-size: 15.5px; color: var(--ink-dim); line-height: 1.45; margin-top: 3px; }
+
+/* ── 표지 ──────────────────────────────────────────────────── */
+.cover { display: grid; grid-template-columns: 1.06fr .94fr; gap: 46px; align-items: center; height: 100%; }
+.cover-title {
+  font-family: var(--f-display);
+  font-size: 62px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -.032em;
+  margin: 14px 0 18px;
+  text-wrap: balance;
+}
+.cover-sub { font-size: 21px; color: var(--ink-dim); line-height: 1.5; margin: 0 0 30px; }
+.cover-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .06em;
+}
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+.panel-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+.panel-body { padding: 12px 8px 8px; }
+.panel canvas { display: block; width: 100%; height: 232px; }
+.panel-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 9px 15px 13px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 챕터 구분 ─────────────────────────────────────────────── */
+.slide[data-kind="chapter"] { justify-content: center; }
+.chap { display: grid; grid-template-columns: auto 1fr; gap: 46px; align-items: center; }
+.chap-n {
+  font-family: var(--f-mono);
+  font-size: 168px;
+  font-weight: 700;
+  line-height: .82;
+  letter-spacing: -.06em;
+  color: var(--accent);
+}
+.chap-t {
+  font-family: var(--f-display);
+  font-size: 50px;
+  font-weight: 700;
+  letter-spacing: -.028em;
+  line-height: 1.12;
+  margin: 0 0 14px;
+}
+.chap-d { font-size: 19px; color: var(--ink-dim); line-height: 1.55; margin: 0; max-width: 56ch; }
+.chap-l { border-left: 1px solid var(--line); padding-left: 46px; }
+
+/* ── 퀴즈 ──────────────────────────────────────────────────── */
+.quiz { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 20px; }
+.q {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.q-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 16.5px;
+  line-height: 1.42;
+  font-weight: 600;
+}
+.q-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+.q-btn .q-n { font-family: var(--f-mono); font-size: 12.5px; color: var(--accent); flex: none; }
+.q-a {
+  display: none;
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line-soft);
+  padding-top: 9px;
+}
+.q.is-open .q-a { display: block; }
+.q-a .ref { font-family: var(--f-mono); font-size: 12px; color: var(--ink-faint); }
+
+/* ── 토글 (Counter 슬라이드) ───────────────────────────────── */
+.toggle { display: flex; gap: 8px; }
+.tg {
+  all: unset;
+  cursor: pointer;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.tg[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.tg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.swap > .swap-i { display: none; }
+.swap > .swap-i.on { display: flex; }
+.swap > img.swap-i.on { display: block; }
+
+/* ── 하단 크롬 ─────────────────────────────────────────────── */
+.chrome {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  background: var(--bg);
+  border-top: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.chrome .deck-id { text-transform: uppercase; white-space: nowrap; }
+.rail { flex: 1; display: flex; gap: 2px; align-items: center; height: 22px; min-width: 0; }
+.tick { flex: 1; height: 4px; background: var(--line); border-radius: 1px; transition: background .18s ease, height .18s ease; }
+.tick.done { background: var(--ink-faint); }
+.tick.now  { background: var(--accent); height: 14px; }
+.tick.chap { height: 10px; }
+.counter { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--ink-dim); }
+.counter .cur { color: var(--accent); font-weight: 600; }
+.keys { display: flex; gap: 6px; }
+.kbtn {
+  all: unset;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 4px 8px;
+  color: var(--ink-dim);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+}
+.kbtn:hover { border-color: var(--accent); color: var(--accent); }
+.kbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.kbtn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+/* ── 발표자 노트 ───────────────────────────────────────────── */
+.notes-src { display: none; }
+.notes {
+  position: fixed;
+  left: 0; right: 0; bottom: 52px;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 16px 22px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  display: none;
+  z-index: 19;
+}
+.notes.on { display: block; }
+.notes .n-h {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+/* ── 개요(썸네일) 모드 ─────────────────────────────────────── */
+.deck.is-overview .stage-wrap { place-items: start center; overflow: auto; padding: 24px 18px; }
+.deck.is-overview .stage {
+  width: 100%; height: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 256px);
+  gap: 16px;
+  justify-content: center;
+}
+.deck.is-overview .holder {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  visibility: visible;
+  width: 256px;
+  height: 144px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deck.is-overview .holder.is-active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.deck.is-overview .holder::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 5px; bottom: 4px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  color: var(--ink-faint);
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.deck.is-overview .slide {
+  position: absolute;
+  top: 0; left: 0;
+  transform: scale(.2);
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+/* ── 도움말 ────────────────────────────────────────────────── */
+.help {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  display: none;
+  place-items: center;
+  z-index: 40;
+  padding: 24px;
+}
+.help.on { display: grid; }
+.help-box {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  padding: 26px 30px;
+  min-width: 360px;
+}
+.help-box h3 {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.help-box dl { display: grid; grid-template-columns: auto 1fr; gap: 9px 20px; margin: 0; font-size: 15px; }
+.help-box dt { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.help-box dd { margin: 0; color: var(--ink-dim); }
+
+/* ── 인쇄 ──────────────────────────────────────────────────── */
+@media print {
+  @page { size: 1280px 720px; margin: 0; }
+  body { overflow: visible; background: #fff; }
+  .chrome, .notes, .help { display: none !important; }
+  .stage-wrap { position: static; display: block; inset: auto; overflow: visible; }
+  .stage { width: auto; height: auto; transform: none !important; display: block; }
+  .holder { position: static; opacity: 1; visibility: visible; break-after: page; }
+  .slide { box-shadow: none; }
+}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+  <div class="stage-wrap" id="stageWrap">
+    <div class="stage" id="stage">
+    <!-- ═══════════ 01 Cover ═══════════ -->
+    <div class="holder" data-n="01">
+      <section class="slide" data-kind="cover">
+        <div class="cover">
+          <div>
+            <div class="eyebrow">Golang Concurrency · Part 3 / 11</div>
+            <h1 class="cover-title">Select &amp; Advanced<br />Channel Patterns</h1>
+            <p class="cover-sub">The one construct that waits on <b>many channels at once</b><br />— timeout · fan-in/out · nil channel</p>
+            <div class="cover-meta">
+              <span class="chip on">select</span>
+              <span class="chip">timeout</span>
+              <span class="chip">fan-in · fan-out</span>
+              <span class="chip">nil channel</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-head">
+              <span><span class="dot"></span>five faces of select</span>
+              <span>keyword × 1</span>
+            </div>
+            <div class="panel-body" style="display:block;padding:22px 20px;">
+              <div class="tree">
+                <span class="lv"><span class="k">select</span></span>
+                <span class="lv">├─ case only          <span class="v">waits until one is ready</span></span>
+                <span class="lv">├─ + default          <span class="v">never waits</span></span>
+                <span class="lv">├─ + time.After       <span class="v">wakes when time is up</span></span>
+                <span class="lv">├─ case &lt;-nilCh       <span class="v">that case is off</span></span>
+                <span class="lv">└─ <span class="k">select {}</span>          <span class="v">blocks forever</span></span>
+              </div>
+            </div>
+            <div class="panel-foot">
+              <span>one case = plain &lt;-ch</span>
+              <span>several ready = random</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Greeting + part 3 of an 11-part series. The first two parts covered goroutines and channels separately, so frame today as the story of <b>combining</b> them. The right-hand panel is everything we cover — there is only one keyword, select, and it grows five faces depending on what you attach.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 02 The problem ═══════════ -->
+    <div class="holder" data-n="02">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">problem</span><span class="stamp">why select</span></div>
+        <h2 class="slide-title">One channel is easy. <span class="em">Two</span> is the problem</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>You want <b>whichever of two APIs answers first</b></li>
+              <li>But write <code class="inl">&lt;-ch1</code> first and no matter how fast ch2 is, you <b>sit waiting on ch1</b></li>
+              <li>And if ch1 never comes? <b>The program stops</b> on that line</li>
+              <li>The moment you fix an order, the requirement <b>whichever comes first</b> is broken</li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">// one channel: this is enough</span>
+msg := <span class="t-key">&lt;-</span>ch1
+
+<span class="t-cm">// the moment there are two —</span>
+a := <span class="t-key">&lt;-</span>ch1   <span class="t-cm">// even if ch2 is first</span>
+b := <span class="t-key">&lt;-</span>ch2   <span class="t-cm">// we never get here</span>
+
+<span class="t-cm">// select: takes whichever is ready</span>
+<span class="t-key">select</span> {
+<span class="t-key">case</span> m := <span class="t-key">&lt;-</span>ch1:
+<span class="t-key">case</span> m := <span class="t-key">&lt;-</span>ch2:
+}</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">Go's answer</span>
+            <code class="inl">select</code> is the syntax that <b>lines up several channel operations and picks the one that becomes possible first</b>. Every pattern today derives from it.
+          </div>
+        </div>
+        <div class="notes-src">Opening with "how did you write the code that fires two requests and takes the first reply?" gets a good reaction. Nail down that the problem with sequential receives is not slowness but that they <b>force an order</b>. If timeout comes up here, push it to Chapter 3.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 03 Series roadmap ═══════════ -->
+    <div class="holder" data-n="03">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">series</span><span class="stamp">11 parts</span></div>
+        <h2 class="slide-title">Where today sits in the series</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl sm">
+              <thead><tr><th>Part</th><th>Title</th><th>Focus</th></tr></thead>
+              <tbody>
+                <tr><td>Part 1</td><td>Overview and Goroutine Basics</td><td>unit of execution</td></tr>
+                <tr><td>Part 2</td><td>Channels in Depth</td><td>communication</td></tr>
+                <tr class="on"><td>Part 3</td><td>Select and Advanced Channel Patterns</td><td>choice · composition</td></tr>
+                <tr><td>Part 4 · 5</td><td>The sync Package / The Context Package</td><td>sync · lifecycle</td></tr>
+                <tr><td>Part 6 · 7</td><td>Concurrency Patterns / Error Handling</td><td>design patterns</td></tr>
+                <tr><td>Part 8 · 9</td><td>Memory Model and Atomic / Race Detector</td><td>low level · debugging</td></tr>
+                <tr><td>Part 10 · 11</td><td>Real Project / go tool trace</td><td>practice · tooling</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="dim" style="margin:0;font-size:17px;">Part 1 gave the <b>unit of execution</b>, Part 2 the <b>means of communication</b>. Today <b>weaves</b> the two together.</p>
+        </div>
+        <div class="notes-src">We assume goroutines and channels are known. If someone is not there yet, point them at parts 1 and 2 and keep going. Do not spend time here — 30 seconds.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 04 Agenda ═══════════ -->
+    <div class="holder" data-n="04">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">contents</span><span class="stamp">agenda</span></div>
+        <h2 class="slide-title">What we cover today</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="steps">
+            <div class="step">
+              <span class="s-n">01</span>
+              <div><div class="s-c">Select Statement Basics</div>
+              <div class="s-d">How it differs from switch · anatomy of a case · the <b>random pick</b> when several are ready</div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">02</span>
+              <div><div class="s-c">Default and Non-blocking</div>
+              <div class="s-d">Receive / send without waiting · the five shapes of select · the busy-wait trap</div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">03</span>
+              <div><div class="s-c">Handling Timeouts</div>
+              <div class="s-d"><code class="inl">time.After</code> · <code class="inl">context.WithTimeout</code> · which one to pick</div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">04</span>
+              <div><div class="s-c">Fan-out / Fan-in</div>
+              <div class="s-d">One out to many · many back into one · the two joined into a pipeline</div></div>
+            </div>
+            <div class="step">
+              <span class="s-n">05</span>
+              <div><div class="s-c">The Nil Channel Trick</div>
+              <div class="s-d">Using blocks-forever as a <b>switch</b> · turning off drained sources</div></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Chapters 1 and 2 are syntax; the real work starts at 3. If time runs short, skip the fan-out code slide (18), show only the diagram, and save Chapter 5. Flag Chapter 5 (nil channel) up front as today's highlight.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 05 Chapter 1 ═══════════ -->
+    <div class="holder" data-n="05" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">01</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Select Statement Basics</h2>
+            <p class="chap-d">It looks like switch, but what it chooses over is different.
+            We look at <b>what decides</b> which case runs, and what happens when <b>several are ready at once</b>.</p>
+          </div>
+        </div>
+        <div class="notes-src">A syntax chapter, so move fast. Three slides (06 · 07 · 08), and of those only 08 (the random pick) has to stick.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 06 select vs switch ═══════════ -->
+    <div class="holder" data-n="06">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · basics</span><span class="stamp">select vs switch</span></div>
+        <h2 class="slide-title">switch looks at <span class="em">values</span>, select at <span class="em">readiness</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>Each case is exactly one <b>channel operation</b> — receive or send</li>
+              <li>The criterion is not a value but <b>whether that op can proceed now</b></li>
+              <li>If no case can proceed, it <b>waits right there</b></li>
+              <li><b>Exactly one</b> case runs. There is no fallthrough</li>
+              <li>A select with a single case is just <code class="inl">&lt;-ch</code></li>
+            </ul>
+            <pre class="code sm"><span class="t-key">select</span> {
+<span class="t-key">case</span> msg := <span class="t-key">&lt;-</span>ch1: <span class="t-cm">// if ch1 is first</span>
+    fmt.<span class="t-fn">Println</span>(<span class="t-str">"ch1:"</span>, msg)
+<span class="t-key">case</span> msg := <span class="t-key">&lt;-</span>ch2: <span class="t-cm">// if ch2 is first</span>
+    fmt.<span class="t-fn">Println</span>(<span class="t-str">"ch2:"</span>, msg)
+}
+<span class="t-cm">// neither ready? it waits right here</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">in one line</span>
+            select is the syntax that <b>picks whichever becomes ready first</b>. Which one that is, the code does not decide.
+          </div>
+        </div>
+        <div class="notes-src">Setting it next to switch makes it click fast. "Can I put a value comparison in a case?" → No. It must be a channel operation. Mention here that send cases work too and slide 10 follows naturally.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 07 Anatomy of a case ═══════════ -->
+    <div class="holder" data-n="07">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · basics</span><span class="stamp">anatomy</span></div>
+        <h2 class="slide-title">One case line is made of <span class="em">four pieces</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="anat">
+            <div class="anat-q"><span class="p p4">case</span> <span class="p p1">v</span>, <span class="p p2">ok</span> := <span class="p p3">&lt;-ch</span>:</div>
+            <div class="legend">
+              <div class="lg-i"><span class="lg-b" style="background:var(--ink-faint)"></span><span class="lg-n">case</span><span class="lg-d">One candidate. Only one of them runs</span></div>
+              <div class="lg-i"><span class="lg-b" style="background:var(--accent)"></span><span class="lg-n">v</span><span class="lg-d">Value taken from the channel. Omit if unused</span></div>
+              <div class="lg-i"><span class="lg-b" style="background:var(--teal)"></span><span class="lg-n">ok</span><span class="lg-d"><code class="inl">false</code> means the channel is <b>closed</b></span></div>
+              <div class="lg-i"><span class="lg-b" style="background:var(--amber)"></span><span class="lg-n">&lt;-ch</span><span class="lg-d">Whether this op can proceed is <b>the criterion</b></span></div>
+            </div>
+            <div class="callout teal" style="margin-top:8px;">
+              <span class="lbl">watch the ok</span>
+              A closed channel keeps handing out zero values <b>without ever blocking</b> — so that case is <b>ready forever</b>. Catching that through <code class="inl">ok</code> is where the Chapter 5 nil channel trick starts.
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The point here is to plant <code>ok</code> early. Say the sentence "a closed channel does not block" out loud once before moving on — it comes back on slide 24.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 08 Random pick ═══════════ -->
+    <div class="holder" data-n="08">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">01 · basics</span><span class="stamp">pseudo-random</span></div>
+        <h2 class="slide-title">Both ready? <span class="em">The one written first</span> does not win</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>When several cases are ready the runtime picks one <b>at random</b></li>
+              <li>It does not scan top-down — <b>never rely on source order</b></li>
+              <li>That is what prevents <b>starvation</b>, where one channel is served forever</li>
+              <li>If you need priority you have to build it outside select</li>
+            </ul>
+            <pre class="code sm">ch1Count, ch2Count := <span class="t-num">0</span>, <span class="t-num">0</span>
+<span class="t-key">for range</span> <span class="t-num">1000</span> {
+    ch1 <span class="t-key">&lt;-</span> <span class="t-num">1</span>  <span class="t-cm">// make both ready</span>
+    ch2 <span class="t-key">&lt;-</span> <span class="t-num">2</span>
+
+    <span class="t-key">select</span> {
+    <span class="t-key">case</span> <span class="t-key">&lt;-</span>ch1:
+        ch1Count++
+    <span class="t-key">case</span> <span class="t-key">&lt;-</span>ch2:
+        ch2Count++
+    }
+    <span class="t-fn">drain</span>(ch1, ch2) <span class="t-cm">// clear leftovers</span>
+}
+<span class="t-cm">// ch1: 516, ch2: 484 — roughly 50:50</span></pre>
+          </div>
+        </div>
+        <div class="notes-src">Stress that the numbers shift a little on every run if you try it yourself. "So how do I give priority?" comes up often — describe the two-level structure (an outer select checking the priority channel non-blocking, then the inner select) in words only and move on.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 09 Chapter 2 ═══════════ -->
+    <div class="holder" data-n="09" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">02</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Default and Non-blocking</h2>
+            <p class="chap-d">One <code class="inl">default</code> line changes the whole character of a select.
+            From <b>a structure that waits</b> to <b>one that only checks what is possible now</b>.</p>
+          </div>
+        </div>
+        <div class="notes-src">A short chapter. Two slides (10 · 11), and the busy-wait warning on 11 is the mine people step on most often in production.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 10 non-blocking ═══════════ -->
+    <div class="holder" data-n="10">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · default</span><span class="stamp">non-blocking</span></div>
+        <h2 class="slide-title">With default, select <span class="em">never blocks</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack tight">
+              <div class="card-t">non-blocking receive</div>
+              <pre class="code sm"><span class="t-key">select</span> {
+<span class="t-key">case</span> val := <span class="t-key">&lt;-</span>ch:
+    fmt.<span class="t-fn">Println</span>(<span class="t-str">"received:"</span>, val)
+<span class="t-key">default</span>:
+    <span class="t-cm">// empty? straight to here</span>
+    fmt.<span class="t-fn">Println</span>(<span class="t-str">"no data"</span>)
+}</pre>
+            </div>
+            <div class="stack tight">
+              <div class="card-t">non-blocking send</div>
+              <pre class="code sm">ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">1</span>)
+ch <span class="t-key">&lt;-</span> <span class="t-num">1</span> <span class="t-cm">// buffer is full</span>
+
+<span class="t-key">select</span> {
+<span class="t-key">case</span> ch <span class="t-key">&lt;-</span> <span class="t-num">2</span>:
+    fmt.<span class="t-fn">Println</span>(<span class="t-str">"sent"</span>)
+<span class="t-key">default</span>:
+    fmt.<span class="t-fn">Println</span>(<span class="t-str">"buffer full"</span>)
+}</pre>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">mnemonic</span>
+            <b>default = "if it can't happen now, skip it"</b>. Use it where a value must be received and you get code that silently drops data.
+          </div>
+        </div>
+        <div class="notes-src">The send example is the more useful one — dropping instead of blocking on a full queue is common (metrics, log shipping). Advise asking "is this data safe to drop?" first.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 11 The five shapes ═══════════ -->
+    <div class="holder" data-n="11">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">02 · default</span><span class="stamp">one-page recap</span></div>
+        <h2 class="slide-title">Five faces, <span class="em">by what you attach</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Shape</th><th>Behavior</th><th>Where</th></tr></thead>
+              <tbody>
+                <tr><td><code class="inl">case</code> only</td><td>Blocks until one is ready</td><td>the basic form</td></tr>
+                <tr class="on"><td>+ <code class="inl">default</code></td><td>Returns at once if nothing is ready</td><td>polling · drop-tolerant send</td></tr>
+                <tr><td>+ <code class="inl">time.After</code></td><td>Wakes up when the time is up</td><td>timeout</td></tr>
+                <tr><td><code class="inl">case &lt;-nilCh</code></td><td>That case is never chosen</td><td>dynamic disabling</td></tr>
+                <tr><td><code class="inl">select {}</code></td><td>Blocks forever</td><td class="faint">deadlock — almost always a bug</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">most common mistake</span>
+            Put a select with <code class="inl">default</code> inside a <code class="inl">for</code> loop and you have <b>busy-wait</b>. Nothing is happening, yet one CPU core spins at 100%. Where you must wait, drop default and add a <b>timeout case</b>.
+          </div>
+        </div>
+        <div class="notes-src">This table is the summary of today's syntax part. Do not read it row by row — point only at row 2 (default) and row 4 (nil); row 4 also teases Chapter 5. If you have a real busy-wait story, add it briefly.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 12 Chapter 3 ═══════════ -->
+    <div class="holder" data-n="12" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">03</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Handling Timeouts</h2>
+            <p class="chap-d">Go has no separate timeout syntax. You just add one more case — <b>a channel that delivers a value once the time passes</b>.
+            Where that channel comes from is the difference between <code class="inl">time.After</code> and <code class="inl">context</code>.</p>
+          </div>
+        </div>
+        <div class="notes-src">Production territory starts here. Three slides (13 · 14 · 15), and the comparison table on 15 is the conclusion. Even if time is tight, keep 15.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 13 time.After ═══════════ -->
+    <div class="holder" data-n="13">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · timeout</span><span class="stamp">time.After</span></div>
+        <h2 class="slide-title">Timeout is not special syntax — it is <span class="em">one more case</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm">ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">string</span>)
+
+<span class="t-key">go</span> <span class="t-key">func</span>() {
+    time.<span class="t-fn">Sleep</span>(<span class="t-num">200</span> * time.Millisecond) <span class="t-cm">// slow work</span>
+    ch <span class="t-key">&lt;-</span> <span class="t-str">"result"</span>
+}()
+
+<span class="t-key">select</span> {
+<span class="t-key">case</span> msg := <span class="t-key">&lt;-</span>ch: <span class="t-cm">// result first: normal path</span>
+    t.<span class="t-fn">Log</span>(<span class="t-str">"received:"</span>, msg)
+<span class="t-key">case</span> <span class="t-key">&lt;-</span>time.<span class="t-fn">After</span>(<span class="t-num">50</span> * time.Millisecond): <span class="t-cm">// over 50ms</span>
+    t.<span class="t-fn">Log</span>(<span class="t-str">"timeout!"</span>)
+}
+<span class="t-cm">// → timeout!  (work 200ms &gt; limit 50ms)</span></pre>
+          <div class="callout">
+            <span class="lbl">what actually happens</span>
+            <code class="inl">time.After(d)</code> returns <b>a channel that receives one value after d</b>. To select it is simply one more ordinary receive case.
+          </div>
+        </div>
+        <div class="notes-src">If someone says "I expected a timeout keyword, and it's just a channel", you have succeeded. One caveat — before Go 1.23 the timer was not reclaimed until it fired, even if you left through the timeout. Used in a loop at short intervals it piled up memory. It is better now, but worth knowing.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 14 context.WithTimeout ═══════════ -->
+    <div class="holder" data-n="14">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · timeout</span><span class="stamp">the production default</span></div>
+        <h2 class="slide-title">In production you use <span class="em">context.WithTimeout</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">simulateAPICall</span>(ctx context.Context, d time.Duration) (<span class="t-key">string</span>, <span class="t-key">error</span>) {
+    ch := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">string</span>, <span class="t-num">1</span>) <span class="t-cm">// buffer 1 — reason below</span>
+
+    <span class="t-key">go</span> <span class="t-key">func</span>() {
+        time.<span class="t-fn">Sleep</span>(d)
+        ch <span class="t-key">&lt;-</span> <span class="t-str">"api response"</span>
+    }()
+
+    <span class="t-key">select</span> {
+    <span class="t-key">case</span> result := <span class="t-key">&lt;-</span>ch:  <span class="t-cm">// if the response wins</span>
+        <span class="t-key">return</span> result, <span class="t-key">nil</span>
+    <span class="t-key">case</span> <span class="t-key">&lt;-</span>ctx.<span class="t-fn">Done</span>(): <span class="t-cm">// deadline hit · cancelled upstream</span>
+        <span class="t-key">return</span> <span class="t-str">""</span>, ctx.<span class="t-fn">Err</span>() <span class="t-cm">// context.DeadlineExceeded</span>
+    }
+}</pre>
+          <div class="callout">
+            <span class="lbl">buffer 1 is the point</span>
+            Even after we leave on timeout, the goroutine stores its value and <b>exits cleanly</b>. Unbuffered, nobody would receive it and the send would block forever — a <b>goroutine leak</b>.
+          </div>
+        </div>
+        <div class="notes-src">The caller side is <code>ctx, cancel := context.WithTimeout(...)</code> + <code>defer cancel()</code>. Point out that forgetting cancel leaves the timer alive even when the work finishes early. The buffer-1 story connects to the leak slide in part 1 — a concrete case of "build the exit path when you build the thing".</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 15 The two compared ═══════════ -->
+    <div class="holder" data-n="15">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">03 · timeout</span><span class="stamp">A vs B</span></div>
+        <h2 class="slide-title">Which one, and when</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Aspect</th><th>time.After</th><th>context.WithTimeout</th></tr></thead>
+              <tbody>
+                <tr><td>Cancel propagation</td><td class="faint">None — only I bail out</td><td>Reaches child goroutines</td></tr>
+                <tr><td>Scope</td><td>one select</td><td>the whole call chain</td></tr>
+                <tr><td>Cleanup</td><td>None needed</td><td><code class="inl">defer cancel()</code> required</td></tr>
+                <tr><td>Reason</td><td class="faint">None</td><td><code class="inl">ctx.Err()</code> — deadline or cancel</td></tr>
+                <tr class="on"><td>Where</td><td>tests · one-off waits</td><td>API calls · server handlers</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">how to choose</span>
+            <b>If you alone can stop waiting</b>, <code class="inl">time.After</code>. <b>If everyone you called must stop too</b>, <code class="inl">context</code>. Production code is mostly the latter.
+          </div>
+        </div>
+        <div class="notes-src">If only one line survives: "do you bail out alone, or do you tell others?" Announce that context itself gets a whole part (5) and do not go deeper here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 16 Chapter 4 ═══════════ -->
+    <div class="holder" data-n="16" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">04</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Fan-out / Fan-in</h2>
+            <p class="chap-d">Hand the work out <b>to many</b> (fan-out), then gather the scattered results <b>back into one</b> (fan-in).
+            Join the two and that is a concurrent pipeline.</p>
+          </div>
+        </div>
+        <div class="notes-src">The most practical chapter today. Five slides (17–21), so it runs long. Leave the two code slides (18 · 20) on screen and talk through the comments — that keeps the timing.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 17 Fan-out concept ═══════════ -->
+    <div class="holder" data-n="17">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · patterns</span><span class="stamp">fan-out</span></div>
+        <h2 class="slide-title">Fan-out — <span class="em">many share</span> one queue</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">jobs</span><span class="n-p">chan int, shared</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">pull from</span><span class="l-line"></span><span class="l-lbl">range jobs</span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Worker 1</span><span class="n-p">go func()</span></div>
+              <div class="node"><span class="n-t">Worker 2</span><span class="n-p">go func()</span></div>
+              <div class="node"><span class="n-t">Worker 3</span><span class="n-p">go func()</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">results</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">results[0]</span><span class="n-p">chan int</span></div>
+              <div class="node"><span class="n-t">results[1]</span><span class="n-p">chan int</span></div>
+              <div class="node"><span class="n-t">results[2]</span><span class="n-p">chan int</span></div>
+            </div>
+          </div>
+          <p class="cap">The arrows show <b>where the data flows</b>. All three workers compete to pull from the <b>same</b> jobs channel,
+          and who takes how many is not fixed — whoever finishes sooner takes more (load balancing for free).</p>
+        </div>
+        <div class="notes-src">The key is not "split the work into three" but "everyone drinks from one queue". With the former a slow worker holds up its whole share; with the latter it does not. Worker count usually follows the CPU count or how many concurrent requests the downstream system tolerates.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 18 Fan-out code ═══════════ -->
+    <div class="holder" data-n="18">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · patterns</span><span class="stamp">fan-out code</span></div>
+        <h2 class="slide-title">What stops the workers is one <span class="em">close(jobs)</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code xs">jobs, results := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">10</span>), <span class="t-fn">make</span>([]<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">3</span>)
+<span class="t-key">for</span> i := <span class="t-key">range</span> results { results[i] = <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">int</span>, <span class="t-num">10</span>) }
+<span class="t-key">var</span> wg sync.WaitGroup
+<span class="t-key">for</span> i := <span class="t-key">range</span> results {
+    wg.<span class="t-fn">Add</span>(<span class="t-num">1</span>)
+    <span class="t-key">go</span> <span class="t-key">func</span>() {                   <span class="t-cm">// all three share one jobs</span>
+        <span class="t-key">defer</span> wg.<span class="t-fn">Done</span>()
+        <span class="t-key">for</span> job := <span class="t-key">range</span> jobs {   <span class="t-cm">// pulls until jobs is closed</span>
+            results[i] <span class="t-key">&lt;-</span> job * job
+        }
+        <span class="t-fn">close</span>(results[i])
+    }()
+}
+<span class="t-key">for</span> i := <span class="t-num">1</span>; i <span class="t-key">&lt;=</span> <span class="t-num">9</span>; i++ { jobs <span class="t-key">&lt;-</span> i }
+<span class="t-fn">close</span>(jobs)                        <span class="t-cm">// without it, workers wait forever</span>
+wg.<span class="t-fn">Wait</span>()</pre>
+          <div class="callout teal">
+            <span class="lbl">two things easy to miss</span>
+            ① Without <code class="inl">close(jobs)</code> the <code class="inl">range</code> never ends and all three workers stay alive.
+            ② Capturing the loop variable <code class="inl">i</code> straight into the goroutine is only safe on <b>Go 1.22+</b>.
+          </div>
+        </div>
+        <div class="notes-src">Do not read line by line — point at three blocks: setup / launching workers / pushing jobs and closing. The 1.22 loop-variable note matters most to people on older codebases. Mention the old style of passing <code>func(i int)</code> once.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 19 Fan-in concept ═══════════ -->
+    <div class="holder" data-n="19">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · patterns</span><span class="stamp">fan-in</span></div>
+        <h2 class="slide-title">Fan-in — scattered results back into <span class="em">one stream</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">source1</span><span class="n-p">chan string</span></div>
+              <div class="node"><span class="n-t">source2</span><span class="n-p">chan string</span></div>
+              <div class="node"><span class="n-t">source3</span><span class="n-p">chan string</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">1 goroutine per source</span><span class="l-line"></span><span class="l-lbl">range ch</span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">merged</span><span class="n-p">chan string</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">consumed in one place</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">consumer</span><span class="n-p">for v := range merged</span></div>
+            </div>
+          </div>
+          <p class="cap">One goroutine per source forwards values into merged. The consumer only has to watch <b>one</b> channel.
+          In exchange, arrival order is <b>not guaranteed</b> — if you need order, pick a design other than fan-in.</p>
+        </div>
+        <div class="notes-src">The real gain of fan-in is that the consumer code gets simple. Compare it with handling three channels directly in a select — with fan-in you never touch the select cases as sources are added.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 20 fanIn code ═══════════ -->
+    <div class="holder" data-n="20">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · patterns</span><span class="stamp">fan-in code</span></div>
+        <h2 class="slide-title">The WaitGroup decides when to <span class="em">close</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code xs"><span class="t-key">func</span> <span class="t-fn">fanIn</span>(channels ...&lt;-<span class="t-key">chan</span> <span class="t-key">string</span>) &lt;-<span class="t-key">chan</span> <span class="t-key">string</span> {
+    <span class="t-key">var</span> wg sync.WaitGroup
+    merged := <span class="t-fn">make</span>(<span class="t-key">chan</span> <span class="t-key">string</span>)
+    <span class="t-key">for</span> _, ch := <span class="t-key">range</span> channels {
+        wg.<span class="t-fn">Add</span>(<span class="t-num">1</span>)
+        <span class="t-key">go</span> <span class="t-key">func</span>() {              <span class="t-cm">// one goroutine per source</span>
+            <span class="t-key">defer</span> wg.<span class="t-fn">Done</span>()
+            <span class="t-key">for</span> v := <span class="t-key">range</span> ch { merged <span class="t-key">&lt;-</span> v } <span class="t-cm">// ends on close</span>
+        }()
+    }
+    <span class="t-key">go</span> <span class="t-key">func</span>() {
+        wg.<span class="t-fn">Wait</span>()                 <span class="t-cm">// wait for all of them, then</span>
+        <span class="t-fn">close</span>(merged)            <span class="t-cm">// close merged at that point</span>
+    }()
+    <span class="t-key">return</span> merged
+}</pre>
+          <div class="callout">
+            <span class="lbl">why wg.Wait() sits in a goroutine</span>
+            Waiting right here means <code class="inl">fanIn</code> <b>never returns</b>. Values only drain once the caller runs <code class="inl">range merged</code>, and the function is stuck before that — deadlock.
+          </div>
+        </div>
+        <div class="notes-src">This slide asks one question — "who closes?" Answer: <b>the sender</b>. But there are many senders, so none can close alone. That is why the WaitGroup acts as the referee that rules "everyone is done".</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 21 Pipeline ═══════════ -->
+    <div class="holder" data-n="21">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">04 · patterns</span><span class="stamp">pipeline</span></div>
+        <h2 class="slide-title">Join the two and you get a <span class="em">pipeline</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">input</span><span class="n-p">chan Job</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">fan-out</span><span class="l-line"></span><span class="l-lbl">distribute</span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">Worker 1</span><span class="n-p">process</span></div>
+              <div class="node"><span class="n-t">Worker 2</span><span class="n-p">process</span></div>
+              <div class="node"><span class="n-t">Worker 3</span><span class="n-p">process</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">fan-in</span><span class="l-line"></span><span class="l-lbl">merge</span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">output</span><span class="n-p">chan Result</span></div>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">different jobs</span>
+            Fan-out raises <b>throughput</b>; fan-in folds the scattered results <b>back into one</b>. Joined, from the outside it becomes a plain function that <b>takes one channel and returns one channel</b>.
+          </div>
+        </div>
+        <div class="notes-src">In practice you wrap this whole picture in a single function — <code>func Process(in &lt;-chan Job) &lt;-chan Result</code>. Then you can chain several such blocks into a multi-stage pipeline and tune the worker count of each stage separately. Say part 6 covers more.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 22 Chapter 5 ═══════════ -->
+    <div class="holder" data-n="22" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">05</div>
+          <div class="chap-l">
+            <h2 class="chap-t">The Nil Channel Trick</h2>
+            <p class="chap-d">A nil channel can do nothing — send blocks, receive blocks.
+            Inside a select, that bug-looking property becomes <b>a switch that turns a case off</b>.</p>
+          </div>
+        </div>
+        <div class="notes-src">Today's highlight. Two slides (23 · 24), but spend generous time on the code in 24. If "ah, that's why we took ok" clicks here, the talk is complete.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 23 Nil channel behavior ═══════════ -->
+    <div class="holder" data-n="23">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · nil channel</span><span class="stamp">behavior</span></div>
+        <h2 class="slide-title">Blocking forever turns out to be <span class="em">useful here</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><b>Send</b> to a nil channel blocks forever</li>
+              <li><b>Receive</b> from a nil channel blocks forever too</li>
+              <li>So inside a select that case is <b>never ready</b> — effectively ignored</li>
+              <li>Meaning: assigning <code class="inl">nil</code> to the variable alone <b>turns the case off</b></li>
+            </ul>
+            <pre class="code sm"><span class="t-key">var</span> ch <span class="t-key">chan</span> <span class="t-key">int</span> <span class="t-cm">// nil</span>
+
+<span class="t-key">&lt;-</span>ch      <span class="t-cm">// blocks forever</span>
+ch <span class="t-key">&lt;-</span> <span class="t-num">1</span>  <span class="t-cm">// blocks forever</span>
+
+<span class="t-key">select</span> {
+<span class="t-key">case</span> <span class="t-key">&lt;-</span>ch:    <span class="t-cm">// never chosen</span>
+<span class="t-key">case</span> <span class="t-key">&lt;-</span>other: <span class="t-cm">// only this one lives</span>
+}</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">flip it around</span>
+            You <b>cannot delete</b> a case from a select — the code is fixed. Instead set the <b>variable it reads to nil</b> and it is as good as deleted.
+          </div>
+        </div>
+        <div class="notes-src">"Doesn't sending on a nil channel panic?" is the standard question — panic is for sending on a <b>closed</b> channel. A nil one stops quietly. Separate the two clearly right here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 24 Nil channel in use ═══════════ -->
+    <div class="holder" data-n="24">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">05 · nil channel</span><span class="stamp">dynamic disabling</span></div>
+        <h2 class="slide-title">Drained sources get <span class="em">switched off with nil</span></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code xs"><span class="t-key">var</span> a, b = (&lt;-<span class="t-key">chan</span> <span class="t-key">int</span>)(ch1), (&lt;-<span class="t-key">chan</span> <span class="t-key">int</span>)(ch2) <span class="t-cm">// hold them as receive-only</span>
+<span class="t-key">for</span> a != <span class="t-key">nil</span> || b != <span class="t-key">nil</span> {   <span class="t-cm">// both nil = all drained</span>
+    <span class="t-key">select</span> {
+    <span class="t-key">case</span> v, ok := <span class="t-key">&lt;-</span>a:
+        <span class="t-key">if</span> !ok {
+            a = <span class="t-key">nil</span>              <span class="t-cm">// closed → turn this case off</span>
+            <span class="t-key">continue</span>
+        }
+        results = <span class="t-fn">append</span>(results, v)
+    <span class="t-key">case</span> v, ok := <span class="t-key">&lt;-</span>b:
+        <span class="t-key">if</span> !ok {
+            b = <span class="t-key">nil</span>
+            <span class="t-key">continue</span>
+        }
+        results = <span class="t-fn">append</span>(results, v)
+    }
+}</pre>
+          <div class="callout">
+            <span class="lbl">if you skip the nil</span>
+            <b>A closed channel hands out zero values instantly, forever.</b> That case keeps winning, the loop piles up <code class="inl">0</code>s and burns CPU. Turning it off is the only way.
+          </div>
+        </div>
+        <div class="notes-src">This is today's climax. First ask "what happens if we delete the two nil assignments?" and then open the callout. Two places it is used — ① merging sources and switching off the ones that finish ② turning specific channel handling on and off by condition. In both, the select structure stays and only the variable changes.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 25 Recap ═══════════ -->
+    <div class="holder" data-n="25">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">wrap-up</span><span class="stamp">recap</span></div>
+        <h2 class="slide-title">What to take away</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <ul class="bul" style="font-size:20px;gap:16px;">
+            <li>select picks <b>one ready case</b>. Several ready means <b>random</b> — never rely on source order</li>
+            <li>Adding <code class="inl">default</code> makes it non-blocking. Put that in a loop and you get <b>busy-wait</b></li>
+            <li>Timeout is not syntax but <b>one more case</b> — <code class="inl">time.After</code> or <code class="inl">ctx.Done()</code></li>
+            <li>Need cancel to <b>propagate</b>? <code class="inl">context.WithTimeout</code>, and give the result channel <b>buffer 1</b></li>
+            <li>Fan-out for throughput, fan-in to merge. <b>The sender closes</b>, and <code class="inl">WaitGroup</code> sets the moment</li>
+            <li>Assign <code class="inl">nil</code> to a channel variable and its case turns off — the idiom for drained sources</li>
+          </ul>
+        </div>
+        <div class="notes-src">Reading the six lines out loud is the whole recap. If only one survives, take the last — the nil channel trick has no counterpart in other languages. Questions are welcome from here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 26 Quiz ═══════════ -->
+    <div class="holder" data-n="26">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Answer for yourself</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>Two cases are ready at once. Does the one written first run?</span></button>
+              <div class="q-a">No. The runtime picks <b>at random</b>. If you need priority, build it outside select. <span class="ref">→ Slide 08</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>A select with <code class="inl">default</code> inside a <code class="inl">for</code> pins one CPU at 100%. Why?</span></button>
+              <div class="q-a">With nothing ready it drops to default at once, so the loop never rests — <b>busy-wait</b>. If you must wait, drop default and add a <code class="inl">time.After</code> case. <span class="ref">→ Slide 11</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>Timing out an API call — <code class="inl">time.After</code> or <code class="inl">context</code>?</span></button>
+              <div class="q-a">context. Cancel propagates through <b>the whole call chain</b> and <code class="inl">ctx.Err()</code> tells deadline from cancel. time.After binds to that one select. <span class="ref">→ Slide 15</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>After you bail out on timeout, what happens to the goroutine sending the result?</span></button>
+              <div class="q-a">If the result channel is <b>unbuffered</b>, nobody receives and the send blocks forever — a goroutine leak. Give it <b>buffer 1</b> and it stores the value and exits. <span class="ref">→ Slide 14</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>What happens if a closed channel stays in a select case?</span></button>
+              <div class="q-a">A closed channel <b>always returns immediately</b> with a zero value. That case keeps winning and the loop spins. Set the variable to <code class="inl">nil</code> when <code class="inl">ok == false</code> to turn the case off. <span class="ref">→ Slide 23 · 24</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Let the audience answer first, then click to open. If time is short, Q4 and Q5 alone are enough — both are mines people really step on in production.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 27 Next part ═══════════ -->
+    <div class="holder" data-n="27">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">next</span><span class="stamp">part 4</span></div>
+        <h2 class="slide-title">Next — the sync package</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="stack">
+              <p class="dim" style="margin:0;font-size:18px;line-height:1.6;">So far it has all been about <b>passing values</b>. But moments come when many goroutines
+              must touch <b>the same memory</b>. There, a lock beats a channel.
+              Next up is the tool outside CSP — the <code class="inl">sync</code> package.</p>
+              <div class="callout">
+                <span class="lbl">left for later</span>
+                We used <code class="inl">WaitGroup</code> three times today and never explained it.
+                <code class="inl">Mutex</code> · <code class="inl">RWMutex</code> · <code class="inl">Once</code> get a proper look next time.
+              </div>
+            </div>
+            <div class="card">
+              <p class="card-t">References</p>
+              <ul class="bul" style="font-size:16.5px;gap:9px;">
+                <li>Full code — <code class="inl">github.com/kenshin579/tutorials-go</code> <span class="faint">/golang/concurrency</span></li>
+                <li>Go Tour — Select <span class="faint">go.dev/tour/concurrency/5</span></li>
+                <li>Go Blog — Pipelines and cancellation <span class="faint">go.dev/blog/pipelines</span></li>
+                <li>Previous part — Channels in Depth <span class="faint">advenoh.pe.kr</span></li>
+              </ul>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">Thank you</span>
+            Questions welcome — <code class="inl">advenoh.pe.kr</code>
+          </div>
+        </div>
+        <div class="notes-src">Take Q&amp;A with the GitHub repo address on screen. If "channel or mutex?" comes up, answer that the first slide of the next part is exactly that.</div>
+      </section>
+    </div>
+    </div><!-- /stage -->
+  </div><!-- /stage-wrap -->
+
+  <div class="notes" id="notes" aria-live="polite">
+    <div class="n-h">Speaker notes</div>
+    <div id="notesBody"></div>
+  </div>
+
+  <div class="chrome">
+    <span class="deck-id">Select &amp; Channels · Go Concurrency 3</span>
+    <div class="rail" id="rail"></div>
+    <span class="counter" id="counter"><span class="cur">01</span> / 27</span>
+    <div class="keys">
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="Overview (O)">Overview</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="Speaker notes (N)">Notes</button>
+      <button class="kbtn" id="btnTheme" type="button" title="Toggle theme (T)">Theme</button>
+      <button class="kbtn" id="btnHelp" type="button" title="Shortcuts (?)">?</button>
+    </div>
+  </div>
+
+  <div class="help" id="help">
+    <div class="help-box">
+      <h3>Shortcuts</h3>
+      <dl>
+        <dt>→ · Space · PgDn</dt><dd>Next slide</dd>
+        <dt>← · PgUp</dt><dd>Previous slide</dd>
+        <dt>Home · End</dt><dd>First · Last</dd>
+        <dt>O</dt><dd>Slide overview</dd>
+        <dt>N</dt><dd>Speaker notes</dd>
+        <dt>T</dt><dd>Light / dark theme</dd>
+        <dt>F</dt><dd>Fullscreen</dd>
+        <dt>Esc</dt><dd>Close</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var deck     = document.getElementById("deck");
+  var stage    = document.getElementById("stage");
+  var wrap     = document.getElementById("stageWrap");
+  var rail     = document.getElementById("rail");
+  var counter  = document.getElementById("counter");
+  var notesEl  = document.getElementById("notes");
+  var notesBody= document.getElementById("notesBody");
+  var helpEl   = document.getElementById("help");
+  var holders  = Array.prototype.slice.call(stage.querySelectorAll(".holder"));
+  var total    = holders.length;
+  var idx      = 0;
+  var overview = false;
+  var reduce   = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ── 눈금 레일 ─────────────────────────────────── */
+  var ticks = holders.map(function (h, i) {
+    var t = document.createElement("span");
+    t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
+    t.title = "Slide " + (i + 1);
+    t.addEventListener("click", function () { go(i); });
+    rail.appendChild(t);
+    return t;
+  });
+
+  function pad(n) { return (n < 10 ? "0" : "") + n; }
+
+  /* ── 무대 스케일 ───────────────────────────────── */
+  /* 무대는 stage-wrap 의 좌상단에 고정(place-items:start)해 두고,
+     축소한 뒤 남는 여백만큼 직접 translate 해서 가운데로 옮긴다.
+     transform-origin 을 center 로 두고 grid 중앙 정렬에 맡기면,
+     뷰포트가 1280x720 보다 작을 때 브라우저가 넘치는 항목을
+     좌상단에 고정(safe alignment)해 버려서 축소 결과가 오른쪽 아래로 쏠린다. */
+  function fit() {
+    if (overview) { stage.style.transform = ""; return; }
+    var k = Math.min(wrap.clientWidth / 1280, wrap.clientHeight / 720);
+    var tx = (wrap.clientWidth - 1280 * k) / 2;
+    var ty = (wrap.clientHeight - 720 * k) / 2;
+    stage.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + k + ")";
+  }
+
+  /* ── 이동 ──────────────────────────────────────── */
+  function go(n, silent) {
+    n = Math.max(0, Math.min(total - 1, n));
+    idx = n;
+    holders.forEach(function (h, i) { h.classList.toggle("is-active", i === n); });
+    ticks.forEach(function (t, i) {
+      t.classList.toggle("done", i < n);
+      t.classList.toggle("now", i === n);
+    });
+    counter.innerHTML = '<span class="cur">' + pad(n + 1) + "</span> / " + total;
+    var src = holders[n].querySelector(".notes-src");
+    notesBody.textContent = src ? src.textContent.trim() : "—";
+    if (!silent) { history.replaceState(null, "", "#" + (n + 1)); }
+    runOdometers(holders[n]);
+    if (overview) {
+      holders[n].scrollIntoView({ block: "nearest", behavior: reduce ? "auto" : "smooth" });
+    }
+  }
+
+  /* ── 카디널리티 카운터 ─────────────────────────── */
+  function runOdometers(holder) {
+    var list = holder.querySelectorAll("[data-odo]");
+    Array.prototype.forEach.call(list, function (el, i) {
+      var to = parseInt(el.getAttribute("data-odo"), 10);
+      if (reduce) { el.textContent = to.toLocaleString("en-US"); return; }
+      var dur = 900, delay = i * 420, t0 = null;
+      el.textContent = "0";
+      function frame(ts) {
+        if (t0 === null) { t0 = ts; }
+        var p = (ts - t0 - delay) / dur;
+        if (p < 0) { requestAnimationFrame(frame); return; }
+        if (p > 1) { p = 1; }
+        var e = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(to * e).toLocaleString("en-US");
+        if (p < 1) { requestAnimationFrame(frame); }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
+  /* ── 개요 모드 ─────────────────────────────────── */
+  function setOverview(on) {
+    overview = on;
+    deck.classList.toggle("is-overview", on);
+    document.getElementById("btnOverview").setAttribute("aria-pressed", String(on));
+    fit();
+    if (on) { holders[idx].scrollIntoView({ block: "center" }); }
+  }
+
+  holders.forEach(function (h, i) {
+    h.addEventListener("click", function () { if (overview) { setOverview(false); go(i); } });
+  });
+
+  /* ── 노트 · 테마 · 도움말 ──────────────────────── */
+  function setNotes(on) {
+    notesEl.classList.toggle("on", on);
+    document.getElementById("btnNotes").setAttribute("aria-pressed", String(on));
+  }
+  function toggleTheme() {
+    var cur = document.documentElement.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try { localStorage.setItem("deck-theme", next); } catch (e) {}
+    drawHero();
+  }
+  try {
+    var saved = localStorage.getItem("deck-theme");
+    if (saved) { document.documentElement.setAttribute("data-theme", saved); }
+  } catch (e) {}
+
+  document.getElementById("btnOverview").addEventListener("click", function () { setOverview(!overview); });
+  document.getElementById("btnNotes").addEventListener("click", function () { setNotes(!notesEl.classList.contains("on")); });
+  document.getElementById("btnTheme").addEventListener("click", toggleTheme);
+  document.getElementById("btnHelp").addEventListener("click", function () { helpEl.classList.toggle("on"); });
+  helpEl.addEventListener("click", function () { helpEl.classList.remove("on"); });
+
+  /* ── 클릭 리빌 · 이미지 토글 ───────────────────── */
+  document.addEventListener("click", function (e) {
+    var qb = e.target.closest ? e.target.closest(".q-btn") : null;
+    if (qb) { qb.parentNode.classList.toggle("is-open"); return; }
+
+    var tg = e.target.closest ? e.target.closest(".tg") : null;
+    if (tg) {
+      var group = tg.getAttribute("data-swap");
+      var target = tg.getAttribute("data-target");
+      Array.prototype.forEach.call(document.querySelectorAll('.tg[data-swap="' + group + '"]'), function (b) {
+        b.setAttribute("aria-pressed", String(b === tg));
+      });
+      Array.prototype.forEach.call(document.querySelectorAll('[data-swap-group="' + group + '"] > .swap-i'), function (item) {
+        item.classList.toggle("on", item.getAttribute("data-swap-item") === target);
+      });
+    }
+  });
+
+  /* ── 키보드 ────────────────────────────────────── */
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) { return; }
+    var k = e.key;
+    if (k === "ArrowRight" || k === "PageDown" || k === " " || k === "Spacebar") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowLeft" || k === "PageUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "ArrowDown") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "Home") { e.preventDefault(); go(0); }
+    else if (k === "End") { e.preventDefault(); go(total - 1); }
+    else if (k === "o" || k === "O" || k === "ㅐ") { setOverview(!overview); }
+    else if (k === "n" || k === "N" || k === "ㅜ") { setNotes(!notesEl.classList.contains("on")); }
+    else if (k === "t" || k === "T" || k === "ㅅ") { toggleTheme(); }
+    else if (k === "f" || k === "F" || k === "ㄹ") {
+      if (document.fullscreenElement) { document.exitFullscreen(); }
+      else if (document.documentElement.requestFullscreen) { document.documentElement.requestFullscreen(); }
+    }
+    else if (k === "?" || k === "/") { helpEl.classList.toggle("on"); }
+    else if (k === "Escape") {
+      if (helpEl.classList.contains("on")) { helpEl.classList.remove("on"); }
+      else if (overview) { setOverview(false); }
+    }
+  });
+
+  /* ── 표지 스파크라인 ───────────────────────────── */
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  function drawHero() {
+    var cv = document.getElementById("heroCanvas");
+    if (!cv) { return; }
+    var ctx = cv.getContext("2d");
+    var W = cv.width, H = cv.height;
+    ctx.clearRect(0, 0, W, H);
+
+    var accent = css("--accent") || "#4FD3F4";
+    var line   = css("--line") || "#272F3A";
+    var faint  = css("--ink-faint") || "#6B7688";
+
+    /* 격자 */
+    ctx.strokeStyle = line;
+    ctx.lineWidth = 1;
+    var i, y, x;
+    for (i = 1; i <= 4; i++) {
+      y = Math.round((H / 5) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    for (i = 1; i <= 5; i++) {
+      x = Math.round((W / 6) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+    }
+
+    /* 결정적인 CPU 곡선 (난수 없이 재현 가능하게) */
+    var N = 180, pts = [];
+    for (i = 0; i < N; i++) {
+      var t = i / (N - 1);
+      var v = 0.42
+        + 0.16 * Math.sin(t * 8.1 + 0.6)
+        + 0.09 * Math.sin(t * 21.3 + 1.9)
+        + 0.05 * Math.sin(t * 47.7 + 4.2)
+        + 0.10 * Math.exp(-Math.pow((t - 0.68) * 9, 2));
+      v = Math.max(0.08, Math.min(0.92, v));
+      pts.push([6 + t * (W - 12), H - v * H]);
+    }
+
+    var steps = reduce ? N : 0;
+    function render(n) {
+      ctx.clearRect(0, 0, W, H);
+      ctx.strokeStyle = line;
+      for (i = 1; i <= 4; i++) {
+        y = Math.round((H / 5) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+      }
+      for (i = 1; i <= 5; i++) {
+        x = Math.round((W / 6) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+      }
+
+      var m = Math.max(2, n);
+      var grad = ctx.createLinearGradient(0, 0, 0, H);
+      grad.addColorStop(0, accent + "55");
+      grad.addColorStop(1, accent + "00");
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], H);
+      for (i = 0; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.lineTo(pts[m - 1][0], H);
+      ctx.closePath();
+      ctx.fillStyle = grad;
+      ctx.fill();
+
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (i = 1; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.strokeStyle = accent;
+      ctx.lineWidth = 2.4;
+      ctx.lineJoin = "round";
+      ctx.stroke();
+
+      /* 마지막 점 강조 */
+      ctx.beginPath();
+      ctx.arc(pts[m - 1][0], pts[m - 1][1], 4.5, 0, Math.PI * 2);
+      ctx.fillStyle = accent;
+      ctx.fill();
+
+      ctx.font = "500 20px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = faint;
+      ctx.textAlign = "left";
+      ctx.fillText("100%", 8, 22);
+      ctx.fillText("0", 8, H - 8);
+    }
+
+    if (reduce) { render(N); return; }
+    var n0 = 2, t0 = null;
+    function frame(ts) {
+      if (t0 === null) { t0 = ts; }
+      var p = Math.min(1, (ts - t0) / 1100);
+      var e = 1 - Math.pow(1 - p, 3);
+      render(Math.max(n0, Math.round(N * e)));
+      if (p < 1) { requestAnimationFrame(frame); }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  /* ── 초기화 ────────────────────────────────────── */
+  window.addEventListener("resize", fit);
+  window.addEventListener("hashchange", function () {
+    var n = parseInt(location.hash.replace("#", ""), 10);
+    if (!isNaN(n)) { go(n - 1, true); }
+  });
+
+  var start = parseInt(location.hash.replace("#", ""), 10);
+  fit();
+  go(isNaN(start) ? 0 : start - 1, true);
+  drawHero();
+})();
+</script>
+</body>
+</html>

--- a/contents/go/golang-generics-1-개요와-기본-문법/index_en.md
+++ b/contents/go/golang-generics-1-개요와-기본-문법/index_en.md
@@ -24,6 +24,8 @@ Generics is a programming technique that lets you define functions or types **wi
 
 The biggest reason generics are needed is **eliminating code duplication**. It solves the problem of having to write the same logic multiple times for functions that differ only in type.
 
+<!-- slides -->
+
 # 2. The Background of Generics' Introduction in Go
 
 Go is a language designed from the start with **simplicity** as its core philosophy. The Go designers, including Rob Pike, deliberately left out many features to keep the language's complexity low, and generics was long among them.

--- a/contents/go/golang-generics-1-개요와-기본-문법/slides_en.html
+++ b/contents/go/golang-generics-1-개요와-기본-문법/slides_en.html
@@ -1,0 +1,1770 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Golang Generics Part 1 — Overview and Basic Syntax</title>
+<style>
+/* ─────────────────────────────────────────────────────────────
+   계기판(instrument panel) — 차가운 슬레이트 바탕 위 따뜻한 표시등
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0A6E8A;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(10, 110, 138, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+
+  --f-display: "Avenir Next", "Apple SD Gothic Neo", "Helvetica Neue", system-ui, sans-serif;
+  --f-body:    "Apple SD Gothic Neo", -apple-system, "Helvetica Neue", "Noto Sans KR", sans-serif;
+  --f-mono:    "MesloLGS NF", "SF Mono", ui-monospace, Menlo, "D2Coding", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0E1117;
+    --surface:   #161B23;
+    --surface-2: #1B212A;
+    --ink:       #E6E9EE;
+    --ink-dim:   #98A2B0;
+    --ink-faint: #6B7688;
+    --line:      #272F3A;
+    --line-soft: #1E252E;
+    --grid:      rgba(255, 255, 255, .038);
+    --accent:    #3FC7EF;
+    --accent-ink:#031A20;
+    --accent-soft: rgba(63, 199, 239, .14);
+    --teal:      #46C7B0;
+    --teal-soft: rgba(70, 199, 176, .13);
+    --amber:     #E8B84B;
+    --red:       #F0625E;
+    --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg:        #0E1117;
+  --surface:   #161B23;
+  --surface-2: #1B212A;
+  --ink:       #E6E9EE;
+  --ink-dim:   #98A2B0;
+  --ink-faint: #6B7688;
+  --line:      #272F3A;
+  --line-soft: #1E252E;
+  --grid:      rgba(255, 255, 255, .038);
+  --accent:    #3FC7EF;
+  --accent-ink:#031A20;
+  --accent-soft: rgba(63, 199, 239, .14);
+  --teal:      #46C7B0;
+  --teal-soft: rgba(70, 199, 176, .13);
+  --amber:     #E8B84B;
+  --red:       #F0625E;
+  --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+}
+
+:root[data-theme="light"] {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #0A6E8A;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(10, 110, 138, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ── 무대: 1280×720 고정, 뷰포트에 맞춰 축소 ───────────────── */
+.stage-wrap {
+  position: fixed;
+  inset: 0 0 52px 0;
+  display: grid;
+  /* 가운데 정렬은 fit() 이 translate 로 직접 한다. grid 중앙 정렬에 맡기면
+     무대가 뷰포트보다 클 때 safe alignment 로 좌상단에 고정되어 계산이 어긋난다. */
+  place-items: start;
+  overflow: hidden;
+}
+.stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  transform-origin: 0 0;
+  flex: none;
+}
+.holder {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .22s ease;
+}
+.holder.is-active { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .holder { transition: none; } }
+
+.slide {
+  width: 1280px;
+  height: 720px;
+  padding: 52px 68px 56px;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 40px,
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px) 0 0 / 40px 100%,
+    var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.slide::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0 34%, var(--line) 34% 100%);
+  opacity: .55;
+}
+
+/* ── 슬라이드 머리 ─────────────────────────────────────────── */
+.slide-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  flex: none;
+}
+.eyebrow {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+}
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+}
+.slide-title {
+  font-family: var(--f-display);
+  font-size: 42px;
+  line-height: 1.16;
+  font-weight: 700;
+  letter-spacing: -.022em;
+  margin: 0 0 6px;
+  text-wrap: balance;
+}
+.slide-title .em { color: var(--accent); }
+.slide-lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0 0 4px;
+  max-width: 72ch;
+}
+.rule {
+  height: 1px;
+  background: var(--line);
+  margin: 18px 0 22px;
+  flex: none;
+}
+.slide-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  font-size: 19px;
+  line-height: 1.6;
+}
+.slide-body.top { justify-content: flex-start; }
+
+/* ── 공용 조판 ─────────────────────────────────────────────── */
+.cols { display: grid; gap: 30px; align-items: start; }
+.c-2  { grid-template-columns: 1fr 1fr; }
+.c-2a { grid-template-columns: 1.15fr .85fr; }
+.c-2b { grid-template-columns: .82fr 1.18fr; }
+.c-3  { grid-template-columns: repeat(3, 1fr); }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.stack.tight { gap: 10px; }
+.grow { flex: 1; min-height: 0; }
+/* 높이를 채우는 2단 조판에서는 각 열이 늘어나고, 내용은 열 안에서 세로 중앙에 놓인다 */
+.cols.grow { align-items: stretch; }
+.cols.grow > .stack { justify-content: center; }
+
+ul.bul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 13px; }
+ul.bul > li { position: relative; padding-left: 26px; }
+ul.bul > li::before {
+  content: "";
+  position: absolute;
+  left: 4px; top: .62em;
+  width: 9px; height: 2px;
+  background: var(--accent);
+}
+ul.bul.teal > li::before { background: var(--teal); }
+.dim { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.hl { color: var(--accent); font-weight: 600; }
+.hl-teal { color: var(--teal); font-weight: 600; }
+b, strong { font-weight: 700; }
+
+/* ── 표 ────────────────────────────────────────────────────── */
+.tbl-wrap { overflow-x: auto; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink-faint);
+  padding: 0 14px 9px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: 11px 14px 11px 0;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  line-height: 1.45;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td:first-child { font-weight: 600; white-space: nowrap; }
+table.tbl.sm { font-size: 15.5px; }
+table.tbl.sm td { padding: 8px 12px 8px 0; }
+table.tbl tr.on td { background: var(--accent-soft); }
+table.tbl tr.on td:first-child { color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); padding-left: 12px; }
+.num-col { font-family: var(--f-mono); }
+
+/* ── 코드 ──────────────────────────────────────────────────── */
+.code {
+  font-family: var(--f-mono);
+  font-size: 15.5px;
+  line-height: 1.72;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+  padding: 14px 18px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+  tab-size: 2;
+}
+.code.sm { font-size: 14px; line-height: 1.66; padding: 12px 15px; }
+.code.xs { font-size: 12.6px; line-height: 1.6; padding: 11px 14px; }
+.code.plain { border-left-color: var(--line); }
+.code.teal { border-left-color: var(--teal); }
+.t-fn  { color: var(--accent); }
+.t-str { color: var(--teal); }
+.t-cm  { color: var(--ink-faint); }
+.t-num { color: var(--ink); font-weight: 600; }
+.t-key { color: var(--accent); font-weight: 600; }
+.t-bad { color: var(--red); }
+code.inl {
+  font-family: var(--f-mono);
+  font-size: .88em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  white-space: nowrap;
+}
+
+/* ── 카드 / 콜아웃 ─────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.card-t {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+.callout {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 14px 20px;
+  border-radius: 0 3px 3px 0;
+  font-size: 18px;
+  line-height: 1.55;
+}
+.callout.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+.callout .lbl {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.callout.teal .lbl { color: var(--teal); }
+
+/* ── 그림 ──────────────────────────────────────────────────── */
+.figure { display: flex; flex-direction: column; justify-content: center; gap: 10px; min-height: 0; }
+.figure img {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: var(--shadow);
+  background: var(--surface-2);
+}
+.figure figcaption, .cap {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.fit img { max-height: 100%; }
+
+/* ── 아키텍처 다이어그램 ───────────────────────────────────── */
+.arch {
+  display: grid;
+  grid-template-columns: 1fr 104px 1.02fr 104px 1fr;
+  align-items: center;
+  gap: 0;
+}
+.arch-col { display: flex; flex-direction: column; gap: 11px; }
+.node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 4px;
+  padding: 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.node .n-t { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.node .n-p { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-faint); }
+.node.hero {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  padding: 20px 18px;
+}
+.node.hero .n-t { font-size: 22px; color: var(--accent); }
+.node.hero .n-p { color: var(--ink-dim); }
+.node.mute { border-style: dashed; background: transparent; }
+.arch-link { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.arch-link .l-lbl {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.arch-link .l-line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  position: relative;
+}
+.arch-link .l-line::after {
+  content: "";
+  position: absolute;
+  right: 8px; top: -4px;
+  border: 4.5px solid transparent;
+  border-left-color: var(--accent);
+}
+
+/* ── 트리 ──────────────────────────────────────────────────── */
+.tree { font-family: var(--f-mono); font-size: 15px; line-height: 2.05; }
+.tree .lv { display: block; white-space: pre; }
+.tree .k { color: var(--accent); font-weight: 600; }
+.tree .v { color: var(--ink-dim); }
+
+/* ── 쿼리 해부도 ───────────────────────────────────────────── */
+.anat { display: flex; flex-direction: column; gap: 14px; }
+.anat-q {
+  font-family: var(--f-mono);
+  font-size: 24px;
+  letter-spacing: -.01em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.anat-q .p { padding: 3px 2px; border-bottom: 2px solid transparent; }
+.anat-q .p1 { border-bottom-color: var(--accent); }
+.anat-q .p2 { border-bottom-color: var(--teal); }
+.anat-q .p3 { border-bottom-color: var(--amber); }
+.anat-q .p4 { border-bottom-color: var(--ink-faint); }
+.legend { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.legend .lg-i { display: flex; flex-direction: column; gap: 4px; }
+.legend .lg-b { height: 3px; width: 34px; }
+.legend .lg-n { font-size: 15px; font-weight: 700; }
+.legend .lg-d { font-size: 14px; color: var(--ink-dim); line-height: 1.42; }
+
+/* ── 카디널리티 계산기 ─────────────────────────────────────── */
+.odo-row { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.odo {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 62px;
+  font-weight: 700;
+  letter-spacing: -.03em;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.odo.sm { font-size: 34px; color: var(--ink); }
+.odo-cap { font-size: 15px; color: var(--ink-dim); }
+.factor {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-family: var(--f-mono);
+  font-size: 19px;
+  color: var(--ink-dim);
+}
+.factor b { color: var(--ink); font-size: 22px; }
+
+/* ── 단계 목록 ─────────────────────────────────────────────── */
+.steps { display: flex; flex-direction: column; gap: 0; }
+.step {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.step:last-child { border-bottom: none; }
+.step .s-n {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 600;
+  padding-top: 3px;
+}
+.step .s-c { font-family: var(--f-mono); font-size: 14.5px; color: var(--ink); }
+.step .s-d { font-size: 15.5px; color: var(--ink-dim); line-height: 1.45; margin-top: 3px; }
+
+/* ── 표지 ──────────────────────────────────────────────────── */
+.cover { display: grid; grid-template-columns: 1.06fr .94fr; gap: 46px; align-items: center; height: 100%; }
+.cover-title {
+  font-family: var(--f-display);
+  font-size: 62px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -.032em;
+  margin: 14px 0 18px;
+  text-wrap: balance;
+}
+.cover-sub { font-size: 21px; color: var(--ink-dim); line-height: 1.5; margin: 0 0 30px; }
+.cover-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .06em;
+}
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+.panel-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+.panel-body { padding: 12px 8px 8px; }
+.panel canvas { display: block; width: 100%; height: 232px; }
+.panel-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 9px 15px 13px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 챕터 구분 ─────────────────────────────────────────────── */
+.slide[data-kind="chapter"] { justify-content: center; }
+.chap { display: grid; grid-template-columns: auto 1fr; gap: 46px; align-items: center; }
+.chap-n {
+  font-family: var(--f-mono);
+  font-size: 168px;
+  font-weight: 700;
+  line-height: .82;
+  letter-spacing: -.06em;
+  color: var(--accent);
+}
+.chap-t {
+  font-family: var(--f-display);
+  font-size: 50px;
+  font-weight: 700;
+  letter-spacing: -.028em;
+  line-height: 1.12;
+  margin: 0 0 14px;
+}
+.chap-d { font-size: 19px; color: var(--ink-dim); line-height: 1.55; margin: 0; max-width: 56ch; }
+.chap-l { border-left: 1px solid var(--line); padding-left: 46px; }
+
+/* ── 퀴즈 ──────────────────────────────────────────────────── */
+.quiz { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 20px; }
+.q {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.q-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 16.5px;
+  line-height: 1.42;
+  font-weight: 600;
+}
+.q-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+.q-btn .q-n { font-family: var(--f-mono); font-size: 12.5px; color: var(--accent); flex: none; }
+.q-a {
+  display: none;
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line-soft);
+  padding-top: 9px;
+}
+.q.is-open .q-a { display: block; }
+.q-a .ref { font-family: var(--f-mono); font-size: 12px; color: var(--ink-faint); }
+
+/* ── 토글 (Counter 슬라이드) ───────────────────────────────── */
+.toggle { display: flex; gap: 8px; }
+.tg {
+  all: unset;
+  cursor: pointer;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.tg[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.tg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.swap > .swap-i { display: none; }
+.swap > .swap-i.on { display: flex; }
+.swap > img.swap-i.on { display: block; }
+
+/* ── 하단 크롬 ─────────────────────────────────────────────── */
+.chrome {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  background: var(--bg);
+  border-top: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.chrome .deck-id { text-transform: uppercase; white-space: nowrap; }
+.rail { flex: 1; display: flex; gap: 2px; align-items: center; height: 22px; min-width: 0; }
+.tick { flex: 1; height: 4px; background: var(--line); border-radius: 1px; transition: background .18s ease, height .18s ease; }
+.tick.done { background: var(--ink-faint); }
+.tick.now  { background: var(--accent); height: 14px; }
+.tick.chap { height: 10px; }
+.counter { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--ink-dim); }
+.counter .cur { color: var(--accent); font-weight: 600; }
+.keys { display: flex; gap: 6px; }
+.kbtn {
+  all: unset;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 4px 8px;
+  color: var(--ink-dim);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+}
+.kbtn:hover { border-color: var(--accent); color: var(--accent); }
+.kbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.kbtn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+/* ── 발표자 노트 ───────────────────────────────────────────── */
+.notes-src { display: none; }
+.notes {
+  position: fixed;
+  left: 0; right: 0; bottom: 52px;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 16px 22px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  display: none;
+  z-index: 19;
+}
+.notes.on { display: block; }
+.notes .n-h {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+/* ── 개요(썸네일) 모드 ─────────────────────────────────────── */
+.deck.is-overview .stage-wrap { place-items: start center; overflow: auto; padding: 24px 18px; }
+.deck.is-overview .stage {
+  width: 100%; height: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 256px);
+  gap: 16px;
+  justify-content: center;
+}
+.deck.is-overview .holder {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  visibility: visible;
+  width: 256px;
+  height: 144px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deck.is-overview .holder.is-active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.deck.is-overview .holder::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 5px; bottom: 4px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  color: var(--ink-faint);
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.deck.is-overview .slide {
+  position: absolute;
+  top: 0; left: 0;
+  transform: scale(.2);
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+/* ── 도움말 ────────────────────────────────────────────────── */
+.help {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  display: none;
+  place-items: center;
+  z-index: 40;
+  padding: 24px;
+}
+.help.on { display: grid; }
+.help-box {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  padding: 26px 30px;
+  min-width: 360px;
+}
+.help-box h3 {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.help-box dl { display: grid; grid-template-columns: auto 1fr; gap: 9px 20px; margin: 0; font-size: 15px; }
+.help-box dt { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.help-box dd { margin: 0; color: var(--ink-dim); }
+
+/* ── 인쇄 ──────────────────────────────────────────────────── */
+@media print {
+  @page { size: 1280px 720px; margin: 0; }
+  body { overflow: visible; background: #fff; }
+  .chrome, .notes, .help { display: none !important; }
+  .stage-wrap { position: static; display: block; inset: auto; overflow: visible; }
+  .stage { width: auto; height: auto; transform: none !important; display: block; }
+  .holder { position: static; opacity: 1; visibility: visible; break-after: page; }
+  .slide { box-shadow: none; }
+}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+  <div class="stage-wrap" id="stageWrap">
+    <div class="stage" id="stage">
+    <!-- ═══════════ 01 Cover ═══════════ -->
+    <div class="holder" data-n="01">
+      <section class="slide" data-kind="cover">
+        <div class="cover">
+          <div>
+            <div class="eyebrow">Go · Language Features</div>
+            <h1 class="cover-title">Golang Generics<br />Part 1 — Overview and Basic Syntax</h1>
+            <p class="cover-sub">Write a function without fixing its types up front<br />— what Go 1.18 changed</p>
+            <div class="cover-meta">
+              <span class="chip on">type parameter</span>
+              <span class="chip">constraint</span>
+              <span class="chip">generic struct</span>
+              <span class="chip">type inference</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-head">
+              <span><span class="dot"></span>The syntax we cover today</span>
+              <span>Go 1.18+</span>
+            </div>
+            <div class="panel-body" style="display:block;padding:22px 20px;">
+              <div class="tree">
+                <span class="lv"><span class="k">Generics</span></span>
+                <span class="lv">├─ type parameters <span class="v">[T any]</span></span>
+                <span class="lv">│  ├─ <span class="v">generic functions</span></span>
+                <span class="lv">│  └─ <span class="v">generic structs</span></span>
+                <span class="lv">├─ constraints <span class="v">any · union · interface</span></span>
+                <span class="lv">└─ <span class="k">type inference</span> <span class="v">usually omittable</span></span>
+              </div>
+            </div>
+            <div class="panel-foot">
+              <span>Part 2 digs into constraints</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">We look at Generics, which landed in Go 1.18 (March 2022), starting from "what problem did it come to solve" rather than memorizing syntax. Say up front that Part 1 covers the overview and basic syntax, and that constraints themselves are Part 2. Asking for a show of hands on who wrote pre-1.18 code makes the rest land much better.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 02 [CH 01] ═══════════ -->
+    <div class="holder" data-n="02" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">01</div>
+          <div class="chap-l">
+            <h2 class="chap-t">What Generics Are</h2>
+            <p class="chap-d">When the type gets decided — that single thing is what changes.
+            And why Go held this feature back for twelve years.</p>
+          </div>
+        </div>
+        <div class="notes-src">Three to four minutes. Keep the definition itself short and spend more time on "why was Go so late." That background is what makes the simplicity of Go Generics read as a choice rather than a shortfall.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 03 Concept ═══════════ -->
+    <div class="holder" data-n="03">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">concept</span><span class="stamp">definition</span></div>
+        <h2 class="slide-title">Generics defer the type decision to the call site</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>The type is fixed <b>when used</b>, not when defined</li>
+              <li>Java · C++ · Rust have had this for years</li>
+              <li>Go got it officially in <b>1.18</b> (March 2022)</li>
+              <li>The case for it was one thing — <b>removing duplication</b></li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">// T is a type that has not been decided yet</span>
+<span class="t-key">func</span> <span class="t-fn">printAny</span>[T <span class="t-key">any</span>](a T) {
+    fmt.<span class="t-fn">Println</span>(a)
+}
+
+<span class="t-cm">// decided at the moment of the call</span>
+<span class="t-fn">printAny</span>(<span class="t-num">10</span>)      <span class="t-cm">// T = int</span>
+<span class="t-fn">printAny</span>(<span class="t-str">"hello"</span>) <span class="t-cm">// T = string</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">in one line</span>
+            A device that stops you from writing the same logic <b>over and over</b> just because the types differ.
+          </div>
+        </div>
+        <div class="notes-src">"Generics" sounds heavy but the essence is one line — leave the type slot blank and fill it in later. Do not explain the syntax in detail here. Just note that brackets appear, and move on. Syntax gets proper treatment in chapter 03.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 04 Background ═══════════ -->
+    <div class="holder" data-n="04">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">background</span><span class="stamp">why only now</span></div>
+        <h2 class="slide-title">Go held out for a long time to protect simplicity</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">Why they deferred it</div>
+              <p>Go's core philosophy is <b>simplicity</b>. Rob Pike and the other designers deliberately left many features out to keep language complexity down.</p>
+              <p class="dim">Generics were on that list for years</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Why they finally added it</div>
+              <p>It was the <b>most requested feature</b> from the community. Ian Lance Taylor's Type Parameters Proposal was accepted and shipped in 1.18.</p>
+              <p class="dim">The <code class="inl">interface{}</code> workaround had clear limits</p>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">design direction</span>
+            C++ template metaprogramming and Haskell's higher-kinded types were <b>left out on purpose</b>; only pragmatic type parameters went in.
+          </div>
+        </div>
+        <div class="notes-src">Plenty of people compare Go Generics to other languages and call them anemic, but that is an explicit choice, not a defect. Nailing this down here makes the later "why can't I do X?" questions easy to answer. Expect: "what happens to pre-1.18 code?" → backward compatibility is fully preserved.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 05 [CH 02] ═══════════ -->
+    <div class="holder" data-n="05" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">02</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Two Pains From the Pre-Generics Era</h2>
+            <p class="chap-d"><code class="inl">interface{}</code>, which defers type checking to runtime,
+            and copy-pasted functions that multiply with every type. These two were the real case for adoption.</p>
+          </div>
+        </div>
+        <div class="notes-src">This chapter is the persuasion segment. Lead with syntax and you get "so what is it good for?"; lead with the pain and the syntax reads as the answer. Budget five to six minutes.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 06 The interface{} problem ═══════════ -->
+    <div class="holder" data-n="06">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">limits</span><span class="stamp">before → after</span></div>
+        <h2 class="slide-title">interface{} defers type checking until runtime</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm">// interface{} based — the return is interface{}, so an assertion is required</span>
+<span class="t-key">func</span> <span class="t-fn">foo1</span>(a <span class="t-key">interface</span>{}) <span class="t-key">interface</span>{} { <span class="t-key">return</span> a }
+
+<span class="t-cm">// generics based — the return is T, so no assertion is needed</span>
+<span class="t-key">func</span> <span class="t-fn">foo2</span>[T <span class="t-key">any</span>](a T) T { <span class="t-key">return</span> a }
+
+<span class="t-key">func</span> <span class="t-fn">main</span>() {
+    <span class="t-key">var</span> a, b <span class="t-key">int</span> = <span class="t-num">10</span>, <span class="t-num">20</span>
+    <span class="t-key">var</span> c <span class="t-key">int</span>
+
+    c = <span class="t-fn">foo1</span>(a).(<span class="t-key">int</span>)  <span class="t-bad">// assertion required — can fail at runtime</span>
+    c = <span class="t-fn">foo2</span>(b)         <span class="t-cm">// type decided automatically — safe at compile time</span>
+}</pre>
+          <div class="callout">
+            <span class="lbl">what changed</span>
+            One fragment, <code class="inl">.(int)</code>, disappeared. But what disappeared is not syntax — it is <b>the possibility of a runtime panic</b>.
+          </div>
+        </div>
+        <div class="notes-src">Point at exactly one line here: `.(int)`. foo1 passes the compiler without it knowing "this is an int," and you pay the cost at runtime when you are wrong. foo2, the compiler knows. If time is short, keep this slide and skip the next two.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 07 Type assertion ═══════════ -->
+    <div class="holder" data-n="07">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">aside</span><span class="stamp">type assertion</span></div>
+        <h2 class="slide-title">A type assertion is "unwrap it, and blow up if it's wrong"</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>The operation that <b>pulls a concrete type</b> out of <code class="inl">interface{}</code></li>
+              <li>Written as <code class="inl">value.(Type)</code></li>
+              <li>Wrong type means a <b>runtime panic</b></li>
+              <li>The second return value <code class="inl">ok</code> makes it safe</li>
+            </ul>
+            <pre class="code sm"><span class="t-key">var</span> val <span class="t-key">interface</span>{} = <span class="t-str">"hello"</span>
+
+s := val.(<span class="t-key">string</span>) <span class="t-cm">// OK</span>
+i := val.(<span class="t-key">int</span>)    <span class="t-bad">// panic!</span>
+
+<span class="t-cm">// the safe form</span>
+s, ok := val.(<span class="t-key">string</span>) <span class="t-cm">// true</span>
+i, ok := val.(<span class="t-key">int</span>)    <span class="t-cm">// false, 0</span></pre>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">with Generics</span>
+            The type is fixed at compile time, so <b>the assertion itself becomes unnecessary</b>.
+          </div>
+        </div>
+        <div class="notes-src">If the audience already knows this, spend thirty seconds. If some do not, stress that `i := val.(int)` compiles fine — that is the heart of the problem. Add that the `, ok` form only prevents the panic; the type-branching code stays.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 08 Three costs ═══════════ -->
+    <div class="holder" data-n="08">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">summary</span><span class="stamp">three costs</span></div>
+        <h2 class="slide-title">The flexibility of interface{} has a price tag</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-3">
+            <div class="card">
+              <div class="card-t">Weak type safety</div>
+              <p>A wrong assertion surfaces as a <b>runtime panic</b>, not a compile error.</p>
+              <p class="dim">If tests miss it, you meet it after deploy</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Casting overhead</div>
+              <p>You repeat <code class="inl">.(Type)</code> every time you use the value.</p>
+              <p class="dim">Call sites get noisy</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Poor IDE support</div>
+              <p>The return type is <code class="inl">interface{}</code>, so completion and type checking are blocked.</p>
+              <p class="dim">The editor cannot help you</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">one shared cause</span>
+            All three come from <b>not telling the compiler the type</b>.
+          </div>
+        </div>
+        <div class="notes-src">Do not read the three cards one by one — say only the closing callout: three symptoms, one cause. A war story helps here (an outage caused by a type-assertion panic in production, for instance).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 09 Duplication ═══════════ -->
+    <div class="holder" data-n="09">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">limits</span><span class="stamp">copy-paste hell</span></div>
+        <h2 class="slide-title">Writing the same function three times for three types</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">minInt</span>(a, b <span class="t-key">int</span>) <span class="t-key">int</span> {
+    <span class="t-key">if</span> a &lt; b { <span class="t-key">return</span> a }
+    <span class="t-key">return</span> b
+}
+
+<span class="t-key">func</span> <span class="t-fn">minInt16</span>(a, b <span class="t-key">int16</span>) <span class="t-key">int16</span> {
+    <span class="t-key">if</span> a &lt; b { <span class="t-key">return</span> a }   <span class="t-bad">// logic is completely identical</span>
+    <span class="t-key">return</span> b
+}
+
+<span class="t-key">func</span> <span class="t-fn">minFloat64</span>(a, b <span class="t-key">float64</span>) <span class="t-key">float64</span> {
+    <span class="t-key">if</span> a &lt; b { <span class="t-key">return</span> a }   <span class="t-bad">// the same logic again...</span>
+    <span class="t-key">return</span> b
+}</pre>
+          <div class="callout">
+            <span class="lbl">the real problem</span>
+            Fixing a bug means <b>fixing all three</b>. It grows linearly with every type you support.
+          </div>
+        </div>
+        <div class="notes-src">Mentioning that the Go standard library carried plenty of these traces resonates. The real-world pain is not the duplication itself but forgetting one when you fix something. This slide is the hook into the next chapter — "let's cut this down to one."</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 10 [CH 03] ═══════════ -->
+    <div class="holder" data-n="10" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">03</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Basic Generics Syntax</h2>
+            <p class="chap-d">From declaring type parameters to generic functions, constraints, and generic structs.
+            We follow how the <code class="inl">min</code> duplication we just saw collapses into one.</p>
+          </div>
+        </div>
+        <div class="notes-src">The main body of the talk. Budget ten minutes or more. Do not enumerate syntax — attach "what earlier problem does this solve" to every slide as you move.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 11 Syntax anatomy ═══════════ -->
+    <div class="holder" data-n="11">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">syntax</span><span class="stamp">anatomy</span></div>
+        <h2 class="slide-title">Type parameters are declared inside square brackets</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="steps">
+            <div class="step"><span class="s-n">1</span><div><div class="s-c">func name[T constraint](param T) T</div><div class="s-d">The brackets come right after the function name, before the parentheses</div></div></div>
+            <div class="step"><span class="s-n">2</span><div><div class="s-c">T</div><div class="s-d">The type parameter's name. By convention a single uppercase letter</div></div></div>
+            <div class="step"><span class="s-n">3</span><div><div class="s-c">constraint</div><div class="s-d">The condition limiting which types may appear. <code class="inl">any</code> is the loosest</div></div></div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">only one thing to memorize</span>
+            Parentheses take <b>values</b>; brackets take <b>types</b>.
+          </div>
+        </div>
+        <div class="notes-src">Go used brackets instead of Java's &lt;T&gt; because of parsing ambiguity (angle brackets collide with comparison operators). Someone always asks, so have it ready. The callout is the whole slide.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 12 any ═══════════ -->
+    <div class="holder" data-n="12">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">syntax</span><span class="stamp">generic function</span></div>
+        <h2 class="slide-title">any accepts everything, and so can do nothing</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">any</code> is the constraint that allows <b>every type</b></li>
+              <li>Fits work that <b>ignores the type</b>, like printing or passing along</li>
+              <li>In exchange, operations like <code class="inl">&lt;</code> and <code class="inl">+</code> are unavailable</li>
+              <li>If you need operations, you must <b>narrow the allowed types</b></li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">// any = every type allowed</span>
+<span class="t-key">func</span> <span class="t-fn">printAny</span>[T <span class="t-key">any</span>](a T) {
+    fmt.<span class="t-fn">Println</span>(a)
+}
+
+<span class="t-key">func</span> <span class="t-fn">main</span>() {
+    <span class="t-fn">printAny</span>(<span class="t-num">10</span>)      <span class="t-cm">// T = int</span>
+    <span class="t-fn">printAny</span>(<span class="t-num">3.14</span>)    <span class="t-cm">// T = float64</span>
+    <span class="t-fn">printAny</span>(<span class="t-str">"hello"</span>) <span class="t-cm">// T = string</span>
+}</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">the rule</span>
+            <b>The looser the constraint, the more types you accept and the less you can do inside</b>.
+          </div>
+        </div>
+        <div class="notes-src">This trade-off is the whole of constraint design. Get a feel for it here and Part 2 is far easier. Mention in one line that `any` was added in Go 1.18 as an alias for `interface{}`.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 13 union constraint ═══════════ -->
+    <div class="holder" data-n="13">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">solution</span><span class="stamp">union type</span></div>
+        <h2 class="slide-title">Three mins collapse into one</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm">// list the allowed types with | (union type constraint)</span>
+<span class="t-key">func</span> <span class="t-fn">minType</span>[T <span class="t-key">int</span> | <span class="t-key">int16</span> | <span class="t-key">int32</span> | <span class="t-key">int64</span> | <span class="t-key">float32</span> | <span class="t-key">float64</span>](a, b T) T {
+    <span class="t-key">if</span> a &lt; b {
+        <span class="t-key">return</span> a
+    }
+    <span class="t-key">return</span> b
+}
+
+<span class="t-key">func</span> <span class="t-fn">main</span>() {
+    fmt.<span class="t-fn">Println</span>(<span class="t-fn">minType</span>(<span class="t-num">10</span>, <span class="t-num">20</span>))                 <span class="t-cm">// int: 10</span>
+    fmt.<span class="t-fn">Println</span>(<span class="t-fn">minType</span>(<span class="t-key">int16</span>(<span class="t-num">10</span>), <span class="t-key">int16</span>(<span class="t-num">20</span>)))  <span class="t-cm">// int16: 10</span>
+    fmt.<span class="t-fn">Println</span>(<span class="t-fn">minType</span>(<span class="t-num">3.14</span>, <span class="t-num">1.14</span>))             <span class="t-cm">// float64: 1.14</span>
+}</pre>
+          <div class="callout">
+            <span class="lbl">why not any</span>
+            <code class="inl">any</code> does not guarantee the <code class="inl">&lt;</code> operation. To compare, you must accept <b>only comparable types</b>.
+          </div>
+        </div>
+        <div class="notes-src">Pulling slide 09 (the three copies) back up for contrast works well. Union syntax itself gets proper treatment in Part 2 including tilde (~), so here just "you list them with |". Being honest that Go 1.21 added built-in min/max, making this example purely didactic, is worth a line.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 14 Custom constraint ═══════════ -->
+    <div class="holder" data-n="14">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">syntax</span><span class="stamp">custom constraint</span></div>
+        <h2 class="slide-title">Name a constraint and it becomes reusable</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>Listing types inline every time is wasteful</li>
+              <li>The <code class="inl">interface</code> keyword makes a <b>named constraint</b></li>
+              <li>Constraints can also be <b>composed</b></li>
+              <li>Here it defines a <b>type set</b>, not a method set</li>
+            </ul>
+            <pre class="code sm"><span class="t-key">type</span> IntegerType <span class="t-key">interface</span> {
+    <span class="t-key">int</span> | <span class="t-key">int16</span> | <span class="t-key">int32</span> | <span class="t-key">int64</span>
+}
+
+<span class="t-key">type</span> Float <span class="t-key">interface</span> {
+    <span class="t-key">float32</span> | <span class="t-key">float64</span>
+}
+
+<span class="t-cm">// composition works too</span>
+<span class="t-key">type</span> ComparableNumbers <span class="t-key">interface</span> {
+    IntegerType | Float
+}</pre>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">using it</span>
+            <code class="inl">func minComparableNumbers[T ComparableNumbers](a, b T) T</code>
+          </div>
+        </div>
+        <div class="notes-src">"Wasn't interface a set of methods?" always comes up. Answer that Go 1.18 widened the meaning of interface to a type set. Worth adding the caveat that this widened interface cannot be used as a variable type — only in constraint position.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 15 generic struct ═══════════ -->
+    <div class="holder" data-n="15">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">syntax</span><span class="stamp">generic struct</span></div>
+        <h2 class="slide-title">Structs can take type parameters too</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">type</span> Node[T <span class="t-key">any</span>] <span class="t-key">struct</span> {
+    val  T
+    next *Node[T]      <span class="t-cm">// it references itself through T as well</span>
+}
+
+<span class="t-key">func</span> <span class="t-fn">NewNode</span>[T <span class="t-key">any</span>](v T) *Node[T] {
+    <span class="t-key">return</span> &amp;Node[T]{val: v}
+}
+
+<span class="t-cm">// usage</span>
+node := <span class="t-fn">NewNode</span>(<span class="t-num">1</span>)          <span class="t-cm">// *Node[int]</span>
+node.<span class="t-fn">Push</span>(<span class="t-num">2</span>).<span class="t-fn">Push</span>(<span class="t-num">3</span>).<span class="t-fn">Push</span>(<span class="t-num">4</span>)
+
+strNode := <span class="t-fn">NewNode</span>(<span class="t-str">"hello"</span>) <span class="t-cm">// *Node[string]</span>
+strNode.<span class="t-fn">Push</span>(<span class="t-str">"world"</span>)</pre>
+          <div class="callout">
+            <span class="lbl">what you gain</span>
+            No need to define <code class="inl">IntNode</code> and <code class="inl">StringNode</code> separately. <b>Data-structure duplication disappears</b>.
+          </div>
+        </div>
+        <div class="notes-src">Data structures — linked lists, stacks, queues — are the most natural home for Generics. Point out that a type can reference itself recursively, as in `*Node[T]`. Drawing attention to the missing [int] at the NewNode call site sets up chapter 04 (inference) nicely.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 16 Method restriction ═══════════ -->
+    <div class="holder" data-n="16">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">careful</span><span class="stamp">restriction</span></div>
+        <h2 class="slide-title">Methods cannot declare new type parameters</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">Allowed — using the struct's T</div>
+              <p><code class="inl">func (n *Node[T]) Push(v T) *Node[T]</code></p>
+              <p class="dim">Type parameters declared on the struct are free to use in methods</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Not allowed — a new T on the method</div>
+              <p><code class="inl">func (n *Node[T]) Push[F any](f F)</code></p>
+              <p class="dim">Compile error. Go does not permit this syntax</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">the workaround</span>
+            When you need a new type parameter, <b>pull it out into a plain function</b> instead of a method.
+          </div>
+        </div>
+        <div class="notes-src">The wall people hit most often in practice. Java and C# folks assume it works and get stuck. The reason is that the method set would grow without bound per type, making interface satisfaction undecidable — that much is enough if asked. The Map function on the next slide is exactly the "pulled out into a function" case.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 17 Map ═══════════ -->
+    <div class="holder" data-n="17">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">applied</span><span class="stamp">two type parameters</span></div>
+        <h2 class="slide-title">Two parameters let you express a transformation</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm">// F: input element type, T: output element type</span>
+<span class="t-key">func</span> <span class="t-fn">Map</span>[F, T <span class="t-key">any</span>](s []F, f <span class="t-key">func</span>(F) T) []T {
+    rst := <span class="t-fn">make</span>([]T, <span class="t-fn">len</span>(s))
+    <span class="t-key">for</span> i, v := <span class="t-key">range</span> s {
+        rst[i] = <span class="t-fn">f</span>(v)
+    }
+    <span class="t-key">return</span> rst
+}
+
+doubled := <span class="t-fn">Map</span>([]<span class="t-key">int</span>{<span class="t-num">1</span>, <span class="t-num">2</span>, <span class="t-num">3</span>}, <span class="t-key">func</span>(i <span class="t-key">int</span>) <span class="t-key">int</span> {
+    <span class="t-key">return</span> i * <span class="t-num">2</span>
+})                                   <span class="t-cm">// [2 4 6]</span>
+
+uppered := <span class="t-fn">Map</span>([]<span class="t-key">string</span>{<span class="t-str">"Hello"</span>, <span class="t-str">"world"</span>}, strings.ToUpper)
+                                     <span class="t-cm">// [HELLO WORLD]</span></pre>
+          <div class="callout teal">
+            <span class="lbl">the point</span>
+            What matters is that <code class="inl">F</code> and <code class="inl">T</code> <b>are allowed to differ</b>. That is what lets one function also do <code class="inl">[]int → []string</code>.
+          </div>
+        </div>
+        <div class="notes-src">Functional utilities were simply impossible before Generics. Note that if F and T are always the same type, there is no reason to have two. Mentioning that golang.org/x/exp/slices and maps were built this way, and that much of it landed in the Go 1.21+ standard library, connects it to real work.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 18 [CH 04] ═══════════ -->
+    <div class="holder" data-n="18" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">04</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Type Inference</h2>
+            <p class="chap-d">So far we have barely written <code class="inl">[int]</code> at any call site.
+            The compiler works the type out from the arguments — we look at when it can and when it cannot.</p>
+          </div>
+        </div>
+        <div class="notes-src">Three to four minutes. This is why Generics syntax does not actually feel heavy in practice. Open by having people recall the call sites from earlier slides.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 19 Explicit vs inferred ═══════════ -->
+    <div class="holder" data-n="19">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">inference</span><span class="stamp">explicit vs inferred</span></div>
+        <h2 class="slide-title">With arguments present, you can skip the type</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>The compiler infers type parameters <b>from the arguments</b></li>
+              <li>Explicit and inferred forms produce <b>exactly the same result</b></li>
+              <li>When inference works, <b>the inferred form is preferred</b></li>
+              <li>Be explicit only when the reader cannot see the type</li>
+            </ul>
+            <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">identity</span>[T <span class="t-key">any</span>](v T) T { <span class="t-key">return</span> v }
+
+<span class="t-cm">// explicit type argument</span>
+r1 := <span class="t-fn">identity</span>[<span class="t-key">int</span>](<span class="t-num">42</span>)
+r2 := <span class="t-fn">identity</span>[<span class="t-key">string</span>](<span class="t-str">"hello"</span>)
+
+<span class="t-cm">// type inference — taken from the arguments</span>
+r3 := <span class="t-fn">identity</span>(<span class="t-num">42</span>)      <span class="t-cm">// T = int</span>
+r4 := <span class="t-fn">identity</span>(<span class="t-str">"hello"</span>) <span class="t-cm">// T = string</span></pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">how it feels</span>
+            Look only at the call site and it is <b>indistinguishable from a plain function</b>. That is why Generics do not weigh the code down.
+          </div>
+        </div>
+        <div class="notes-src">Anyone who has suffered Java generics' angle-bracket noise appreciates this point. To "so when do I write it explicitly?" there are two answers — when inference fails (slide 21), and when being explicit simply reads better.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 20 Multiple parameters ═══════════ -->
+    <div class="holder" data-n="20">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">inference</span><span class="stamp">multiple parameters</span></div>
+        <h2 class="slide-title">Several parameters are each inferred separately</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>Each type parameter is decided from <b>its matching argument</b></li>
+              <li>Mixing different types is no problem</li>
+              <li>If one infers and another does not, <b>you must write them all</b></li>
+            </ul>
+            <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">pair</span>[T, U <span class="t-key">any</span>](a T, b U) <span class="t-key">string</span> {
+    <span class="t-key">return</span> fmt.<span class="t-fn">Sprintf</span>(<span class="t-str">"(%v, %v)"</span>, a, b)
+}
+
+<span class="t-cm">// all inferable</span>
+<span class="t-fn">pair</span>(<span class="t-num">1</span>, <span class="t-str">"hello"</span>) <span class="t-cm">// T=int, U=string</span>
+<span class="t-fn">pair</span>(<span class="t-num">3.14</span>, <span class="t-key">true</span>)  <span class="t-cm">// T=float64, U=bool</span></pre>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">careful</span>
+            Type parameters <b>cannot be partially specified</b>. To be explicit, write them all, as in <code class="inl">pair[int, string](...)</code>.
+          </div>
+        </div>
+        <div class="notes-src">The no-partial-specification rule is a genuine stumbling block. Go has no syntax for writing the leading parameter and inferring the rest. Briefly revisiting slide 17's Map, where both F and T come from arguments, connects well.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 21 Inference failure ═══════════ -->
+    <div class="holder" data-n="21">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">inference</span><span class="stamp">failure cases</span></div>
+        <h2 class="slide-title">Inference comes only from arguments — no arguments, no inference</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-key">func</span> <span class="t-fn">toSlice</span>[T <span class="t-key">any</span>](args ...T) []T {
+    <span class="t-key">return</span> args
+}
+
+<span class="t-cm">// inference succeeds — type comes from the arguments</span>
+ints := <span class="t-fn">toSlice</span>(<span class="t-num">1</span>, <span class="t-num">2</span>, <span class="t-num">3</span>)          <span class="t-cm">// T = int</span>
+
+<span class="t-cm">// inference fails — no arguments, so it must be explicit</span>
+emptyInts := <span class="t-fn">toSlice</span>[<span class="t-key">int</span>]()
+emptyStrings := <span class="t-fn">toSlice</span>[<span class="t-key">string</span>]()
+
+result := <span class="t-fn">toSlice</span>()   <span class="t-bad">// compile error: cannot infer T</span></pre>
+          <div class="callout">
+            <span class="lbl">three failing cases</span>
+            No arguments · when <b>the return type alone</b> cannot decide it · when argument types are ambiguous
+          </div>
+        </div>
+        <div class="notes-src">"It does not infer from the return type" is what surprises people most. The Go compiler does not look at the assignment target to decide T. Asking whether anyone has actually seen `cannot infer T` gets a reaction. The fix is always the same — write it in brackets.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 22 Summary table ═══════════ -->
+    <div class="holder" data-n="22">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">summary</span><span class="stamp">before vs after</span></div>
+        <h2 class="slide-title">What changed, in one table</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>Aspect</th><th>Before Generics</th><th>After Generics</th></tr></thead>
+              <tbody>
+                <tr><td>Supporting many types</td><td><code class="inl">interface{}</code> + assertions</td><td>Type parameters <code class="inl">[T any]</code></td></tr>
+                <tr class="on"><td>Type safety</td><td>Risk of runtime panic</td><td>Verified at compile time</td></tr>
+                <tr><td>Code duplication</td><td>One function per type</td><td>A single generic function</td></tr>
+                <tr><td>Data structures</td><td>One struct per type</td><td>Generic struct <code class="inl">[T any]</code></td></tr>
+                <tr><td>IDE support</td><td class="faint">limited</td><td>Full type inference</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">how to choose</span>
+            Do not read the table — just one line: <b>does the compiler know the type or not</b>. Everything else follows.
+          </div>
+        </div>
+        <div class="notes-src">Do not read all five rows; point only at the highlighted "type safety" row. Saying the other four are consequences of that one compresses the table into a sentence.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 23 Quiz ═══════════ -->
+    <div class="holder" data-n="23">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Check yourself</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span><code class="inl">interface{}</code> can also accept many types — so what do Generics actually remove?</span></button>
+              <div class="q-a">The type assertion and the runtime panic that rides along with it. The return type is <code class="inl">T</code>, so the type is settled at compile time. <span class="ref">→ Slide 06 · 08</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>Why does <code class="inl">func min[T any](a, b T) T</code> fail to compile?</span></button>
+              <div class="q-a"><code class="inl">any</code> does not guarantee the <code class="inl">&lt;</code> operation. To compare, narrow it with a union type so only comparable types are accepted. <span class="ref">→ Slide 12 · 13</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>Can a method declare a new type parameter?</span></button>
+              <div class="q-a">No. It can only use type parameters declared on the struct; if you need a new one, pull it out into a plain function. <span class="ref">→ Slide 16</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>Why does <code class="inl">toSlice()</code> give a <code class="inl">cannot infer T</code> error?</span></button>
+              <div class="q-a">Inference happens only from arguments, and there are none. You have to be explicit, as in <code class="inl">toSlice[int]()</code>. <span class="ref">→ Slide 21</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>With two type parameters, can you specify only the first one?</span></button>
+              <div class="q-a">Partial specification is not allowed. To be explicit, write them all, as in <code class="inl">pair[int, string](...)</code>. <span class="ref">→ Slide 20</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Wait five to ten seconds per question before opening it. Q2 and Q4 are where people actually get stuck in practice, so spend more time there. If short on time, skip Q1, Q3, and Q5 and leave them as takeaways.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 24 Closing ═══════════ -->
+    <div class="holder" data-n="24">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">closing</span><span class="stamp">next part</span></div>
+        <h2 class="slide-title">Next up: a deep dive into Type Constraints</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">Today's takeaway</div>
+              <p>Leave the type slot open with brackets, and let the constraint decide how wide that slot stays.</p>
+              <p class="dim">Call sites stay almost unchanged, thanks to inference</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Coming in Part 2</div>
+              <p><code class="inl">any</code> · <code class="inl">comparable</code> · union (<code class="inl">|</code>) · tilde (<code class="inl">~</code>) · designing custom constraints.</p>
+              <p class="dim">The questions we left open today get answered there</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">references</span>
+            go.dev/doc/tutorial/generics · go.dev/blog/intro-generics · go.dev/ref/spec#Type_parameter_declarations
+          </div>
+        </div>
+        <div class="notes-src">Part 1 was "how do you use it"; Part 2 is "how wide do you leave it open." Close by flagging that constraint design is the real difficulty of Generics. Leave about three minutes for questions.</div>
+      </section>
+    </div>
+    </div><!-- /stage -->
+  </div><!-- /stage-wrap -->
+
+  <div class="notes" id="notes" aria-live="polite">
+    <div class="n-h">Speaker notes</div>
+    <div id="notesBody"></div>
+  </div>
+
+  <div class="chrome">
+    <span class="deck-id">Go Generics · Part 1</span>
+    <div class="rail" id="rail"></div>
+    <span class="counter" id="counter"><span class="cur">01</span> / 24</span>
+    <div class="keys">
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="Overview (O)">Overview</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="Speaker notes (N)">Notes</button>
+      <button class="kbtn" id="btnTheme" type="button" title="Toggle theme (T)">Theme</button>
+      <button class="kbtn" id="btnHelp" type="button" title="Shortcuts (?)">?</button>
+    </div>
+  </div>
+
+  <div class="help" id="help">
+    <div class="help-box">
+      <h3>Shortcuts</h3>
+      <dl>
+        <dt>→ · Space · PgDn</dt><dd>Next slide</dd>
+        <dt>← · PgUp</dt><dd>Previous slide</dd>
+        <dt>Home · End</dt><dd>First · Last</dd>
+        <dt>O</dt><dd>Slide overview</dd>
+        <dt>N</dt><dd>Speaker notes</dd>
+        <dt>T</dt><dd>Light / dark theme</dd>
+        <dt>F</dt><dd>Fullscreen</dd>
+        <dt>Esc</dt><dd>Close</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var deck     = document.getElementById("deck");
+  var stage    = document.getElementById("stage");
+  var wrap     = document.getElementById("stageWrap");
+  var rail     = document.getElementById("rail");
+  var counter  = document.getElementById("counter");
+  var notesEl  = document.getElementById("notes");
+  var notesBody= document.getElementById("notesBody");
+  var helpEl   = document.getElementById("help");
+  var holders  = Array.prototype.slice.call(stage.querySelectorAll(".holder"));
+  var total    = holders.length;
+  var idx      = 0;
+  var overview = false;
+  var reduce   = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ── 눈금 레일 ─────────────────────────────────── */
+  var ticks = holders.map(function (h, i) {
+    var t = document.createElement("span");
+    t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
+    t.title = "Slide " + (i + 1);
+    t.addEventListener("click", function () { go(i); });
+    rail.appendChild(t);
+    return t;
+  });
+
+  function pad(n) { return (n < 10 ? "0" : "") + n; }
+
+  /* ── 무대 스케일 ───────────────────────────────── */
+  /* 무대는 stage-wrap 의 좌상단에 고정(place-items:start)해 두고,
+     축소한 뒤 남는 여백만큼 직접 translate 해서 가운데로 옮긴다.
+     transform-origin 을 center 로 두고 grid 중앙 정렬에 맡기면,
+     뷰포트가 1280x720 보다 작을 때 브라우저가 넘치는 항목을
+     좌상단에 고정(safe alignment)해 버려서 축소 결과가 오른쪽 아래로 쏠린다. */
+  function fit() {
+    if (overview) { stage.style.transform = ""; return; }
+    var k = Math.min(wrap.clientWidth / 1280, wrap.clientHeight / 720);
+    var tx = (wrap.clientWidth - 1280 * k) / 2;
+    var ty = (wrap.clientHeight - 720 * k) / 2;
+    stage.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + k + ")";
+  }
+
+  /* ── 이동 ──────────────────────────────────────── */
+  function go(n, silent) {
+    n = Math.max(0, Math.min(total - 1, n));
+    idx = n;
+    holders.forEach(function (h, i) { h.classList.toggle("is-active", i === n); });
+    ticks.forEach(function (t, i) {
+      t.classList.toggle("done", i < n);
+      t.classList.toggle("now", i === n);
+    });
+    counter.innerHTML = '<span class="cur">' + pad(n + 1) + "</span> / " + total;
+    var src = holders[n].querySelector(".notes-src");
+    notesBody.textContent = src ? src.textContent.trim() : "—";
+    if (!silent) { history.replaceState(null, "", "#" + (n + 1)); }
+    runOdometers(holders[n]);
+    if (overview) {
+      holders[n].scrollIntoView({ block: "nearest", behavior: reduce ? "auto" : "smooth" });
+    }
+  }
+
+  /* ── 카디널리티 카운터 ─────────────────────────── */
+  function runOdometers(holder) {
+    var list = holder.querySelectorAll("[data-odo]");
+    Array.prototype.forEach.call(list, function (el, i) {
+      var to = parseInt(el.getAttribute("data-odo"), 10);
+      if (reduce) { el.textContent = to.toLocaleString("en-US"); return; }
+      var dur = 900, delay = i * 420, t0 = null;
+      el.textContent = "0";
+      function frame(ts) {
+        if (t0 === null) { t0 = ts; }
+        var p = (ts - t0 - delay) / dur;
+        if (p < 0) { requestAnimationFrame(frame); return; }
+        if (p > 1) { p = 1; }
+        var e = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(to * e).toLocaleString("en-US");
+        if (p < 1) { requestAnimationFrame(frame); }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
+  /* ── 개요 모드 ─────────────────────────────────── */
+  function setOverview(on) {
+    overview = on;
+    deck.classList.toggle("is-overview", on);
+    document.getElementById("btnOverview").setAttribute("aria-pressed", String(on));
+    fit();
+    if (on) { holders[idx].scrollIntoView({ block: "center" }); }
+  }
+
+  holders.forEach(function (h, i) {
+    h.addEventListener("click", function () { if (overview) { setOverview(false); go(i); } });
+  });
+
+  /* ── 노트 · 테마 · 도움말 ──────────────────────── */
+  function setNotes(on) {
+    notesEl.classList.toggle("on", on);
+    document.getElementById("btnNotes").setAttribute("aria-pressed", String(on));
+  }
+  function toggleTheme() {
+    var cur = document.documentElement.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try { localStorage.setItem("deck-theme", next); } catch (e) {}
+    drawHero();
+  }
+  try {
+    var saved = localStorage.getItem("deck-theme");
+    if (saved) { document.documentElement.setAttribute("data-theme", saved); }
+  } catch (e) {}
+
+  document.getElementById("btnOverview").addEventListener("click", function () { setOverview(!overview); });
+  document.getElementById("btnNotes").addEventListener("click", function () { setNotes(!notesEl.classList.contains("on")); });
+  document.getElementById("btnTheme").addEventListener("click", toggleTheme);
+  document.getElementById("btnHelp").addEventListener("click", function () { helpEl.classList.toggle("on"); });
+  helpEl.addEventListener("click", function () { helpEl.classList.remove("on"); });
+
+  /* ── 클릭 리빌 · 이미지 토글 ───────────────────── */
+  document.addEventListener("click", function (e) {
+    var qb = e.target.closest ? e.target.closest(".q-btn") : null;
+    if (qb) { qb.parentNode.classList.toggle("is-open"); return; }
+
+    var tg = e.target.closest ? e.target.closest(".tg") : null;
+    if (tg) {
+      var group = tg.getAttribute("data-swap");
+      var target = tg.getAttribute("data-target");
+      Array.prototype.forEach.call(document.querySelectorAll('.tg[data-swap="' + group + '"]'), function (b) {
+        b.setAttribute("aria-pressed", String(b === tg));
+      });
+      Array.prototype.forEach.call(document.querySelectorAll('[data-swap-group="' + group + '"] > .swap-i'), function (item) {
+        item.classList.toggle("on", item.getAttribute("data-swap-item") === target);
+      });
+    }
+  });
+
+  /* ── 키보드 ────────────────────────────────────── */
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) { return; }
+    var k = e.key;
+    if (k === "ArrowRight" || k === "PageDown" || k === " " || k === "Spacebar") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowLeft" || k === "PageUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "ArrowDown") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "Home") { e.preventDefault(); go(0); }
+    else if (k === "End") { e.preventDefault(); go(total - 1); }
+    else if (k === "o" || k === "O" || k === "ㅐ") { setOverview(!overview); }
+    else if (k === "n" || k === "N" || k === "ㅜ") { setNotes(!notesEl.classList.contains("on")); }
+    else if (k === "t" || k === "T" || k === "ㅅ") { toggleTheme(); }
+    else if (k === "f" || k === "F" || k === "ㄹ") {
+      if (document.fullscreenElement) { document.exitFullscreen(); }
+      else if (document.documentElement.requestFullscreen) { document.documentElement.requestFullscreen(); }
+    }
+    else if (k === "?" || k === "/") { helpEl.classList.toggle("on"); }
+    else if (k === "Escape") {
+      if (helpEl.classList.contains("on")) { helpEl.classList.remove("on"); }
+      else if (overview) { setOverview(false); }
+    }
+  });
+
+  /* ── 표지 스파크라인 ───────────────────────────── */
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  function drawHero() {
+    var cv = document.getElementById("heroCanvas");
+    if (!cv) { return; }
+    var ctx = cv.getContext("2d");
+    var W = cv.width, H = cv.height;
+    ctx.clearRect(0, 0, W, H);
+
+    var accent = css("--accent") || "#3FC7EF";
+    var line   = css("--line") || "#272F3A";
+    var faint  = css("--ink-faint") || "#6B7688";
+
+    /* 격자 */
+    ctx.strokeStyle = line;
+    ctx.lineWidth = 1;
+    var i, y, x;
+    for (i = 1; i <= 4; i++) {
+      y = Math.round((H / 5) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    for (i = 1; i <= 5; i++) {
+      x = Math.round((W / 6) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+    }
+
+    /* 결정적인 CPU 곡선 (난수 없이 재현 가능하게) */
+    var N = 180, pts = [];
+    for (i = 0; i < N; i++) {
+      var t = i / (N - 1);
+      var v = 0.42
+        + 0.16 * Math.sin(t * 8.1 + 0.6)
+        + 0.09 * Math.sin(t * 21.3 + 1.9)
+        + 0.05 * Math.sin(t * 47.7 + 4.2)
+        + 0.10 * Math.exp(-Math.pow((t - 0.68) * 9, 2));
+      v = Math.max(0.08, Math.min(0.92, v));
+      pts.push([6 + t * (W - 12), H - v * H]);
+    }
+
+    var steps = reduce ? N : 0;
+    function render(n) {
+      ctx.clearRect(0, 0, W, H);
+      ctx.strokeStyle = line;
+      for (i = 1; i <= 4; i++) {
+        y = Math.round((H / 5) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+      }
+      for (i = 1; i <= 5; i++) {
+        x = Math.round((W / 6) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+      }
+
+      var m = Math.max(2, n);
+      var grad = ctx.createLinearGradient(0, 0, 0, H);
+      grad.addColorStop(0, accent + "55");
+      grad.addColorStop(1, accent + "00");
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], H);
+      for (i = 0; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.lineTo(pts[m - 1][0], H);
+      ctx.closePath();
+      ctx.fillStyle = grad;
+      ctx.fill();
+
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (i = 1; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.strokeStyle = accent;
+      ctx.lineWidth = 2.4;
+      ctx.lineJoin = "round";
+      ctx.stroke();
+
+      /* 마지막 점 강조 */
+      ctx.beginPath();
+      ctx.arc(pts[m - 1][0], pts[m - 1][1], 4.5, 0, Math.PI * 2);
+      ctx.fillStyle = accent;
+      ctx.fill();
+
+      ctx.font = "500 20px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = faint;
+      ctx.textAlign = "left";
+      ctx.fillText("100%", 8, 22);
+      ctx.fillText("0", 8, H - 8);
+    }
+
+    if (reduce) { render(N); return; }
+    var n0 = 2, t0 = null;
+    function frame(ts) {
+      if (t0 === null) { t0 = ts; }
+      var p = Math.min(1, (ts - t0) / 1100);
+      var e = 1 - Math.pow(1 - p, 3);
+      render(Math.max(n0, Math.round(N * e)));
+      if (p < 1) { requestAnimationFrame(frame); }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  /* ── 초기화 ────────────────────────────────────── */
+  window.addEventListener("resize", fit);
+  window.addEventListener("hashchange", function () {
+    var n = parseInt(location.hash.replace("#", ""), 10);
+    if (!isNaN(n)) { go(n - 1, true); }
+  });
+
+  var start = parseInt(location.hash.replace("#", ""), 10);
+  fit();
+  go(isNaN(start) ? 0 : start - 1, true);
+  drawHero();
+})();
+</script>
+</body>
+</html>

--- a/contents/ros/urdf를-이용한-로봇-모델링/index_en.md
+++ b/contents/ros/urdf를-이용한-로봇-모델링/index_en.md
@@ -35,6 +35,8 @@ In addition to `URDF`, several other file formats exist for robot modeling, simu
     - Used together with `URDF`, this is an XML file that defines information such as the robot's groups, path planning, and collision checking, and is used by [MoveIt](https://moveit.ros.org/)
     - You can easily convert URDF → SRDF through the Setup Assistant program
 
+<!-- slides -->
+
 # 2. The Robot to Model — Manipulator
 
 > A manipulator is a type of robot that performs motions similar to a human arm.

--- a/contents/ros/urdf를-이용한-로봇-모델링/slides_en.html
+++ b/contents/ros/urdf를-이용한-로봇-모델링/slides_en.html
@@ -1,0 +1,1985 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Robot Modeling with URDF</title>
+<style>
+/* ─────────────────────────────────────────────────────────────
+   계기판(instrument panel) — 차가운 슬레이트 바탕 위 따뜻한 표시등
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #6A34B0;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(106, 52, 176, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+
+  --f-display: "Avenir Next", "Apple SD Gothic Neo", "Helvetica Neue", system-ui, sans-serif;
+  --f-body:    "Apple SD Gothic Neo", -apple-system, "Helvetica Neue", "Noto Sans KR", sans-serif;
+  --f-mono:    "MesloLGS NF", "SF Mono", ui-monospace, Menlo, "D2Coding", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0E1117;
+    --surface:   #161B23;
+    --surface-2: #1B212A;
+    --ink:       #E6E9EE;
+    --ink-dim:   #98A2B0;
+    --ink-faint: #6B7688;
+    --line:      #272F3A;
+    --line-soft: #1E252E;
+    --grid:      rgba(255, 255, 255, .038);
+    --accent:    #B98CF7;
+    --accent-ink:#140A22;
+    --accent-soft: rgba(185, 140, 247, .14);
+    --teal:      #46C7B0;
+    --teal-soft: rgba(70, 199, 176, .13);
+    --amber:     #E8B84B;
+    --red:       #F0625E;
+    --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg:        #0E1117;
+  --surface:   #161B23;
+  --surface-2: #1B212A;
+  --ink:       #E6E9EE;
+  --ink-dim:   #98A2B0;
+  --ink-faint: #6B7688;
+  --line:      #272F3A;
+  --line-soft: #1E252E;
+  --grid:      rgba(255, 255, 255, .038);
+  --accent:    #B98CF7;
+  --accent-ink:#140A22;
+  --accent-soft: rgba(185, 140, 247, .14);
+  --teal:      #46C7B0;
+  --teal-soft: rgba(70, 199, 176, .13);
+  --amber:     #E8B84B;
+  --red:       #F0625E;
+  --shadow:    0 1px 2px rgba(0, 0, 0, .4), 0 16px 34px -18px rgba(0, 0, 0, .8);
+}
+
+:root[data-theme="light"] {
+  --bg:        #EFF1F4;
+  --surface:   #FFFFFF;
+  --surface-2: #F4F6F9;
+  --ink:       #14181E;
+  --ink-dim:   #525C6B;
+  --ink-faint: #8B95A3;
+  --line:      #D5DCE4;
+  --line-soft: #E5EAF0;
+  --grid:      rgba(20, 24, 30, .05);
+  --accent:    #6A34B0;
+  --accent-ink:#FFFFFF;
+  --accent-soft: rgba(106, 52, 176, .09);
+  --teal:      #0B7264;
+  --teal-soft: rgba(11, 114, 100, .10);
+  --amber:     #8F6205;
+  --red:       #BC322F;
+  --shadow:    0 1px 2px rgba(16, 22, 30, .06), 0 12px 28px -14px rgba(16, 22, 30, .30);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ── 무대: 1280×720 고정, 뷰포트에 맞춰 축소 ───────────────── */
+.stage-wrap {
+  position: fixed;
+  inset: 0 0 52px 0;
+  display: grid;
+  /* 가운데 정렬은 fit() 이 translate 로 직접 한다. grid 중앙 정렬에 맡기면
+     무대가 뷰포트보다 클 때 safe alignment 로 좌상단에 고정되어 계산이 어긋난다. */
+  place-items: start;
+  overflow: hidden;
+}
+.stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  transform-origin: 0 0;
+  flex: none;
+}
+.holder {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .22s ease;
+}
+.holder.is-active { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .holder { transition: none; } }
+
+.slide {
+  width: 1280px;
+  height: 720px;
+  padding: 52px 68px 56px;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 40px,
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px) 0 0 / 40px 100%,
+    var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.slide::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0 34%, var(--line) 34% 100%);
+  opacity: .55;
+}
+
+/* ── 슬라이드 머리 ─────────────────────────────────────────── */
+.slide-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  flex: none;
+}
+.eyebrow {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 600;
+}
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+}
+.slide-title {
+  font-family: var(--f-display);
+  font-size: 42px;
+  line-height: 1.16;
+  font-weight: 700;
+  letter-spacing: -.022em;
+  margin: 0 0 6px;
+  text-wrap: balance;
+}
+.slide-title .em { color: var(--accent); }
+.slide-lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  margin: 0 0 4px;
+  max-width: 72ch;
+}
+.rule {
+  height: 1px;
+  background: var(--line);
+  margin: 18px 0 22px;
+  flex: none;
+}
+.slide-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  font-size: 19px;
+  line-height: 1.6;
+}
+.slide-body.top { justify-content: flex-start; }
+
+/* ── 공용 조판 ─────────────────────────────────────────────── */
+.cols { display: grid; gap: 30px; align-items: start; }
+.c-2  { grid-template-columns: 1fr 1fr; }
+.c-2a { grid-template-columns: 1.15fr .85fr; }
+.c-2b { grid-template-columns: .82fr 1.18fr; }
+.c-3  { grid-template-columns: repeat(3, 1fr); }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.stack.tight { gap: 10px; }
+.grow { flex: 1; min-height: 0; }
+/* 높이를 채우는 2단 조판에서는 각 열이 늘어나고, 내용은 열 안에서 세로 중앙에 놓인다 */
+.cols.grow { align-items: stretch; }
+.cols.grow > .stack { justify-content: center; }
+
+ul.bul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 13px; }
+ul.bul > li { position: relative; padding-left: 26px; }
+ul.bul > li::before {
+  content: "";
+  position: absolute;
+  left: 4px; top: .62em;
+  width: 9px; height: 2px;
+  background: var(--accent);
+}
+ul.bul.teal > li::before { background: var(--teal); }
+.dim { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.hl { color: var(--accent); font-weight: 600; }
+.hl-teal { color: var(--teal); font-weight: 600; }
+b, strong { font-weight: 700; }
+
+/* ── 표 ────────────────────────────────────────────────────── */
+.tbl-wrap { overflow-x: auto; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink-faint);
+  padding: 0 14px 9px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: 11px 14px 11px 0;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  line-height: 1.45;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td:first-child { font-weight: 600; white-space: nowrap; }
+table.tbl.sm { font-size: 15.5px; }
+table.tbl.sm td { padding: 8px 12px 8px 0; }
+table.tbl tr.on td { background: var(--accent-soft); }
+table.tbl tr.on td:first-child { color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); padding-left: 12px; }
+.num-col { font-family: var(--f-mono); }
+
+/* ── 코드 ──────────────────────────────────────────────────── */
+.code {
+  font-family: var(--f-mono);
+  font-size: 15.5px;
+  line-height: 1.72;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+  padding: 14px 18px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+  tab-size: 2;
+}
+.code.sm { font-size: 14px; line-height: 1.66; padding: 12px 15px; }
+.code.xs { font-size: 12.6px; line-height: 1.6; padding: 11px 14px; }
+.code.plain { border-left-color: var(--line); }
+.code.teal { border-left-color: var(--teal); }
+.t-fn  { color: var(--accent); }
+.t-str { color: var(--teal); }
+.t-cm  { color: var(--ink-faint); }
+.t-num { color: var(--ink); font-weight: 600; }
+.t-key { color: var(--accent); font-weight: 600; }
+.t-bad { color: var(--red); }
+code.inl {
+  font-family: var(--f-mono);
+  font-size: .88em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  white-space: nowrap;
+}
+
+/* ── 카드 / 콜아웃 ─────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.card-t {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+.callout {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 14px 20px;
+  border-radius: 0 3px 3px 0;
+  font-size: 18px;
+  line-height: 1.55;
+}
+.callout.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+.callout .lbl {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.callout.teal .lbl { color: var(--teal); }
+
+/* ── 그림 ──────────────────────────────────────────────────── */
+.figure { display: flex; flex-direction: column; justify-content: center; gap: 10px; min-height: 0; }
+.figure img {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: var(--shadow);
+  background: var(--surface-2);
+}
+.figure figcaption, .cap {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.fit img { max-height: 100%; }
+
+/* ── 아키텍처 다이어그램 ───────────────────────────────────── */
+.arch {
+  display: grid;
+  grid-template-columns: 1fr 104px 1.02fr 104px 1fr;
+  align-items: center;
+  gap: 0;
+}
+.arch-col { display: flex; flex-direction: column; gap: 11px; }
+.node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 4px;
+  padding: 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.node .n-t { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.node .n-p { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-faint); }
+.node.hero {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  padding: 20px 18px;
+}
+.node.hero .n-t { font-size: 22px; color: var(--accent); }
+.node.hero .n-p { color: var(--ink-dim); }
+.node.mute { border-style: dashed; background: transparent; }
+.arch-link { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.arch-link .l-lbl {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.arch-link .l-line {
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  position: relative;
+}
+.arch-link .l-line::after {
+  content: "";
+  position: absolute;
+  right: 8px; top: -4px;
+  border: 4.5px solid transparent;
+  border-left-color: var(--accent);
+}
+
+/* ── 트리 ──────────────────────────────────────────────────── */
+.tree { font-family: var(--f-mono); font-size: 15px; line-height: 2.05; }
+.tree .lv { display: block; white-space: pre; }
+.tree .k { color: var(--accent); font-weight: 600; }
+.tree .v { color: var(--ink-dim); }
+
+/* ── 쿼리 해부도 ───────────────────────────────────────────── */
+.anat { display: flex; flex-direction: column; gap: 14px; }
+.anat-q {
+  font-family: var(--f-mono);
+  font-size: 24px;
+  letter-spacing: -.01em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 18px 20px;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.anat-q .p { padding: 3px 2px; border-bottom: 2px solid transparent; }
+.anat-q .p1 { border-bottom-color: var(--accent); }
+.anat-q .p2 { border-bottom-color: var(--teal); }
+.anat-q .p3 { border-bottom-color: var(--amber); }
+.anat-q .p4 { border-bottom-color: var(--ink-faint); }
+.legend { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.legend .lg-i { display: flex; flex-direction: column; gap: 4px; }
+.legend .lg-b { height: 3px; width: 34px; }
+.legend .lg-n { font-size: 15px; font-weight: 700; }
+.legend .lg-d { font-size: 14px; color: var(--ink-dim); line-height: 1.42; }
+
+/* ── 카디널리티 계산기 ─────────────────────────────────────── */
+.odo-row { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.odo {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 62px;
+  font-weight: 700;
+  letter-spacing: -.03em;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.odo.sm { font-size: 34px; color: var(--ink); }
+.odo-cap { font-size: 15px; color: var(--ink-dim); }
+.factor {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-family: var(--f-mono);
+  font-size: 19px;
+  color: var(--ink-dim);
+}
+.factor b { color: var(--ink); font-size: 22px; }
+
+/* ── 단계 목록 ─────────────────────────────────────────────── */
+.steps { display: flex; flex-direction: column; gap: 0; }
+.step {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.step:last-child { border-bottom: none; }
+.step .s-n {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 600;
+  padding-top: 3px;
+}
+.step .s-c { font-family: var(--f-mono); font-size: 14.5px; color: var(--ink); }
+.step .s-d { font-size: 15.5px; color: var(--ink-dim); line-height: 1.45; margin-top: 3px; }
+
+/* ── 표지 ──────────────────────────────────────────────────── */
+.cover { display: grid; grid-template-columns: 1.06fr .94fr; gap: 46px; align-items: center; height: 100%; }
+.cover-title {
+  font-family: var(--f-display);
+  font-size: 62px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -.032em;
+  margin: 14px 0 18px;
+  text-wrap: balance;
+}
+.cover-sub { font-size: 21px; color: var(--ink-dim); line-height: 1.5; margin: 0 0 30px; }
+.cover-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--f-mono);
+  font-size: 12.5px;
+  letter-spacing: .06em;
+}
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+.panel-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--teal); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+.panel-body { padding: 12px 8px 8px; }
+.panel canvas { display: block; width: 100%; height: 232px; }
+.panel-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 9px 15px 13px;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 챕터 구분 ─────────────────────────────────────────────── */
+.slide[data-kind="chapter"] { justify-content: center; }
+.chap { display: grid; grid-template-columns: auto 1fr; gap: 46px; align-items: center; }
+.chap-n {
+  font-family: var(--f-mono);
+  font-size: 168px;
+  font-weight: 700;
+  line-height: .82;
+  letter-spacing: -.06em;
+  color: var(--accent);
+}
+.chap-t {
+  font-family: var(--f-display);
+  font-size: 50px;
+  font-weight: 700;
+  letter-spacing: -.028em;
+  line-height: 1.12;
+  margin: 0 0 14px;
+}
+.chap-d { font-size: 19px; color: var(--ink-dim); line-height: 1.55; margin: 0; max-width: 56ch; }
+.chap-l { border-left: 1px solid var(--line); padding-left: 46px; }
+
+/* ── 퀴즈 ──────────────────────────────────────────────────── */
+.quiz { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 20px; }
+.q {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.q-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 16.5px;
+  line-height: 1.42;
+  font-weight: 600;
+}
+.q-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+.q-btn .q-n { font-family: var(--f-mono); font-size: 12.5px; color: var(--accent); flex: none; }
+.q-a {
+  display: none;
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line-soft);
+  padding-top: 9px;
+}
+.q.is-open .q-a { display: block; }
+.q-a .ref { font-family: var(--f-mono); font-size: 12px; color: var(--ink-faint); }
+
+/* ── 토글 (Counter 슬라이드) ───────────────────────────────── */
+.toggle { display: flex; gap: 8px; }
+.tg {
+  all: unset;
+  cursor: pointer;
+  font-family: var(--f-mono);
+  font-size: 13.5px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-dim);
+  background: var(--surface);
+}
+.tg[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+.tg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.swap > .swap-i { display: none; }
+.swap > .swap-i.on { display: flex; }
+.swap > img.swap-i.on { display: block; }
+
+/* ── 하단 크롬 ─────────────────────────────────────────────── */
+.chrome {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  background: var(--bg);
+  border-top: 1px solid var(--line);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  letter-spacing: .08em;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.chrome .deck-id { text-transform: uppercase; white-space: nowrap; }
+.rail { flex: 1; display: flex; gap: 2px; align-items: center; height: 22px; min-width: 0; }
+.tick { flex: 1; height: 4px; background: var(--line); border-radius: 1px; transition: background .18s ease, height .18s ease; }
+.tick.done { background: var(--ink-faint); }
+.tick.now  { background: var(--accent); height: 14px; }
+.tick.chap { height: 10px; }
+.counter { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--ink-dim); }
+.counter .cur { color: var(--accent); font-weight: 600; }
+.keys { display: flex; gap: 6px; }
+.kbtn {
+  all: unset;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 4px 8px;
+  color: var(--ink-dim);
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+}
+.kbtn:hover { border-color: var(--accent); color: var(--accent); }
+.kbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.kbtn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+/* ── 발표자 노트 ───────────────────────────────────────────── */
+.notes-src { display: none; }
+.notes {
+  position: fixed;
+  left: 0; right: 0; bottom: 52px;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 16px 22px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  display: none;
+  z-index: 19;
+}
+.notes.on { display: block; }
+.notes .n-h {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+/* ── 개요(썸네일) 모드 ─────────────────────────────────────── */
+.deck.is-overview .stage-wrap { place-items: start center; overflow: auto; padding: 24px 18px; }
+.deck.is-overview .stage {
+  width: 100%; height: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 256px);
+  gap: 16px;
+  justify-content: center;
+}
+.deck.is-overview .holder {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  visibility: visible;
+  width: 256px;
+  height: 144px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deck.is-overview .holder.is-active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.deck.is-overview .holder::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 5px; bottom: 4px;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  color: var(--ink-faint);
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.deck.is-overview .slide {
+  position: absolute;
+  top: 0; left: 0;
+  transform: scale(.2);
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+/* ── 도움말 ────────────────────────────────────────────────── */
+.help {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  display: none;
+  place-items: center;
+  z-index: 40;
+  padding: 24px;
+}
+.help.on { display: grid; }
+.help-box {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  padding: 26px 30px;
+  min-width: 360px;
+}
+.help-box h3 {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.help-box dl { display: grid; grid-template-columns: auto 1fr; gap: 9px 20px; margin: 0; font-size: 15px; }
+.help-box dt { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.help-box dd { margin: 0; color: var(--ink-dim); }
+
+/* ── 인쇄 ──────────────────────────────────────────────────── */
+@media print {
+  @page { size: 1280px 720px; margin: 0; }
+  body { overflow: visible; background: #fff; }
+  .chrome, .notes, .help { display: none !important; }
+  .stage-wrap { position: static; display: block; inset: auto; overflow: visible; }
+  .stage { width: auto; height: auto; transform: none !important; display: block; }
+  .holder { position: static; opacity: 1; visibility: visible; break-after: page; }
+  .slide { box-shadow: none; }
+}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+  <div class="stage-wrap" id="stageWrap">
+    <div class="stage" id="stage">
+
+    <!-- ═══════════ 01 Cover ═══════════ -->
+    <div class="holder" data-n="01">
+      <section class="slide" data-kind="cover">
+        <div class="cover">
+          <div>
+            <div class="eyebrow">ROS 2 · Robot Modeling</div>
+            <h1 class="cover-title">Draw a robot<br />with URDF</h1>
+            <p class="cover-sub">Write links and joints in XML, then see it in RViz<br />— building one manipulator from scratch</p>
+            <div class="cover-meta">
+              <span class="chip on">URDF</span>
+              <span class="chip">link · joint</span>
+              <span class="chip">RViz</span>
+              <span class="chip">xacro</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-head">
+              <span><span class="dot"></span>testbot.urdf</span>
+              <span>5 links · 4 joints</span>
+            </div>
+            <div class="panel-body" style="display:block;padding:22px 20px;">
+              <div class="tree">
+                <span class="lv"><span class="k">&lt;robot name="testbot"&gt;</span></span>
+                <span class="lv">├─ &lt;material&gt;  <span class="v">green · orange</span></span>
+                <span class="lv">├─ &lt;link&gt;  <span class="k">base</span>  <span class="v">root</span></span>
+                <span class="lv">├─ &lt;link&gt;  <span class="k">link1 … link4</span></span>
+                <span class="lv">│     └─ <span class="v">visual · collision · inertial</span></span>
+                <span class="lv">└─ &lt;joint&gt;  <span class="k">base_joint</span></span>
+                <span class="lv">      └─ <span class="v">link1_link2 · link2_link3 · …</span></span>
+              </div>
+            </div>
+            <div class="panel-foot">
+              <span>A URDF is just a list of links and a list of joints</span>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">To work with a robot in ROS 2 you first have to write down "what this robot looks like" in a form a machine can read. URDF is that standard format. Today we write one manipulator (a robot arm) in XML, put it in RViz, and move its joints by hand. In a 40-minute slot, spend the first half on tag syntax and the second half on running it and on tooling. If the audience is new to ROS, confirm the workspace (~/robot_ws) idea here before moving on.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 02 Chapter 01 ═══════════ -->
+    <div class="holder" data-n="02" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">01</div>
+          <div class="chap-l">
+            <h2 class="chap-t">What URDF is</h2>
+            <p class="chap-d">A file that records a robot's shape in a machine-readable form.
+            Several similar formats exist, so we sort out what each is for — and what URDF <b>cannot</b> express.</p>
+          </div>
+        </div>
+        <div class="notes-src">The goal of this chapter is a shared sense of "what kind of thing URDF is." If time is short, cut the SDF·SRDF comparison (04) to one line and go straight to the limits (05).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 03 ═══════════ -->
+    <div class="holder" data-n="03">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">definition</span><span class="stamp">Unified Robot Description Format</span></div>
+        <h2 class="slide-title">URDF is a robot spec written in XML</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>An XML file holding the robot's geometry, joints and sensor data</li>
+              <li>Parts are <b><code class="inl">&lt;link&gt;</code></b>, motion is <b><code class="inl">&lt;joint&gt;</code></b></li>
+              <li>Stitch those two together and you have one robot</li>
+              <li>The finished model runs straight in RViz and Gazebo</li>
+            </ul>
+            <pre class="code sm">&lt;?xml version=<span class="t-str">"1.0"</span> ?&gt;
+&lt;<span class="t-key">robot</span> name=<span class="t-str">"testbot"</span>&gt;
+
+  &lt;<span class="t-key">link</span> name=<span class="t-str">"base"</span>/&gt;
+  &lt;<span class="t-key">link</span> name=<span class="t-str">"link1"</span>&gt; ... &lt;/<span class="t-key">link</span>&gt;
+
+  &lt;<span class="t-key">joint</span> name=<span class="t-str">"base_joint"</span> type=<span class="t-str">"fixed"</span>&gt;
+    &lt;<span class="t-key">parent</span> link=<span class="t-str">"base"</span>/&gt;
+    &lt;<span class="t-key">child</span>  link=<span class="t-str">"link1"</span>/&gt;
+  &lt;/<span class="t-key">joint</span>&gt;
+
+&lt;/<span class="t-key">robot</span>&gt;</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">in one line</span>
+            Links say <b>what exists</b>; joints say <b>how it attaches and how it moves</b>.
+          </div>
+        </div>
+        <div class="notes-src">Point out here that there is no reason to fear the XML. There are barely ten tags, and half of them can be left out and the robot still shows up in RViz. The code on the right is the skeleton we keep extending, so read it aloud once: "there is a robot, there are links, and there are joints connecting the links."</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 04 ═══════════ -->
+    <div class="holder" data-n="04">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">compare</span><span class="stamp">URDF · SDF · SRDF</span></div>
+        <h2 class="slide-title">Three lookalike formats, three different tools</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>format</th><th>what it describes</th><th>main tool</th></tr></thead>
+              <tbody>
+                <tr class="on"><td><code class="inl">URDF</code></td><td>links · joints — shape and motion</td><td>RViz</td></tr>
+                <tr><td><code class="inl">SDF</code></td><td>simulation data, physics and world included</td><td>Gazebo</td></tr>
+                <tr><td><code class="inl">SRDF</code></td><td>groups, path planning, collision checks</td><td>MoveIt</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">URDF is always the start</span>
+            <code class="inl">gz sdf -p model.urdf &gt; model.sdf</code> gives you SDF, and Setup Assistant generates SRDF.
+          </div>
+        </div>
+        <div class="notes-src">Don't read the table row by row — give the rule of thumb: "just display it, URDF; run physics, SDF; plan arm motion, SRDF." The key point is that almost nobody hand-writes SDF or SRDF in practice; they are converted from URDF.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 05 ═══════════ -->
+    <div class="holder" data-n="05">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">limits</span><span class="stamp">not every robot fits</span></div>
+        <h2 class="slide-title">URDF can only draw trees</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">Tree structures only</div>
+              <p>A link has exactly one parent. Closed loops — parallel mechanisms such as a delta robot — cannot be expressed in URDF.</p>
+              <p class="dim">that is why check_urdf prints a tree</p>
+            </div>
+            <div class="card">
+              <div class="card-t">Links are assumed rigid</div>
+              <p>Linked bodies are taken never to bend or stretch. Flexible parts like cables and springs are not supported.</p>
+              <p class="dim">solve those on the Gazebo plugin side</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">know it up front</span>
+            The spec is as general as it can be, but it <b>cannot describe every robot.</b> Most arms and mobile robots are fine as trees.
+          </div>
+        </div>
+        <div class="notes-src">The reason to state the limits early is so nobody burns time later on "why won't this work?" If someone in the room works on parallel mechanisms, point them at SDF or MuJoCo. Don't linger here — 30 seconds is enough.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 06 Chapter 02 ═══════════ -->
+    <div class="holder" data-n="06" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">02</div>
+          <div class="chap-l">
+            <h2 class="chap-t">What we model — a manipulator</h2>
+            <p class="chap-d">A robot that moves like a human arm is called a manipulator.
+            Before writing XML, we look at how it splits into parts and which of them URDF actually cares about.</p>
+          </div>
+        </div>
+        <div class="notes-src">This is a vocabulary chapter. If many in the audience have no robotics background, spend a bit more time here; if most do robotics, skip both slides quickly.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 07 ═══════════ -->
+    <div class="holder" data-n="07">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">structure</span><span class="stamp">manipulator</span></div>
+        <h2 class="slide-title">A manipulator splits into four parts</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">base</span><span class="n-p">where the robot is anchored — the floor, or a mobile robot</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">fixed</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">link</span><span class="n-p">rigid frame joining base, joints and tip</span></div>
+              <div class="node hero"><span class="n-t">joint</span><span class="n-p">rotation · translation — where motion comes from</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">repeat</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">end effector</span><span class="n-p">the hand — gripper, suction cup, spray nozzle</span></div>
+            </div>
+          </div>
+          <p class="cap">Arrows run parent → child. The side nearer the base is always the parent, and links and joints alternate as the arm gets longer.</p>
+        </div>
+        <div class="notes-src">Explain why the middle two boxes are marked hero — URDF really only describes links and joints, and even the base and the end effector end up expressed as links. So the four parts are a conceptual split that collapses into two kinds of tag in the file.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 08 ═══════════ -->
+    <div class="holder" data-n="08">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">core</span><span class="stamp">link vs joint</span></div>
+        <h2 class="slide-title">In the end it is links and joints</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">&lt;link&gt; — what exists</div>
+              <p>Name · shape · mass (kg) · moment of inertia (kg·m²).</p>
+              <p class="dim">Shapes default to primitives — cylinder, cone, box. Complex bodies come from <code class="inl">stl</code>·<code class="inl">dae</code> meshes.</p>
+            </div>
+            <div class="card">
+              <div class="card-t">&lt;joint&gt; — how it attaches and moves</div>
+              <p>Name · type · axis of motion · min/max values · effort and velocity.</p>
+              <p class="dim">It always describes the <b>relation between two links</b>. A joint alone means nothing.</p>
+            </div>
+          </div>
+          <div class="callout">
+            <span class="lbl">the rest is detail</span>
+            Get these two tags right and the robot shows up in RViz. Every other tag is a detail of one of them.
+          </div>
+        </div>
+        <div class="notes-src">This slide is the map for the whole talk. Nail down in advance that visual·collision·inertial·origin·material all live under link, and axis·limit·parent·child all live under joint — then the audience never loses the thread.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 09 Chapter 03 ═══════════ -->
+    <div class="holder" data-n="09" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">03</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Create the package, raise the skeleton</h2>
+            <p class="chap-d">By convention a ROS robot model lives in a <code class="inl">robotname_description</code> package.
+            We create <code class="inl">testbot_description</code> and put the outermost URDF skeleton inside it.</p>
+          </div>
+        </div>
+        <div class="notes-src">Hands start moving from here. If you are doing a live demo, switch to the terminal at this chapter. Without a demo, reading the commands out loud is enough.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 10 ═══════════ -->
+    <div class="holder" data-n="10">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">steps</span><span class="stamp">ros2 pkg create</span></div>
+        <h2 class="slide-title">The convention is <code class="inl">robotname_description</code></h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="steps">
+            <div class="step"><span class="s-n">1</span><div><div class="s-c">cd ~/robot_ws/src</div><div class="s-d">move into the workspace source folder</div></div></div>
+            <div class="step"><span class="s-n">2</span><div><div class="s-c">ros2 pkg create testbot_description --build-type ament_cmake --dependencies urdf</div><div class="s-d">create a package holding only modeling data</div></div></div>
+            <div class="step"><span class="s-n">3</span><div><div class="s-c">mkdir urdf &amp;&amp; vim urdf/testbot.urdf</div><div class="s-d">make a home for the URDF file</div></div></div>
+            <div class="step"><span class="s-n">4</span><div><div class="s-c">search "description" on index.ros.org</div><div class="s-d">open someone else's polished URDF as an example</div></div></div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">why this name</span>
+            It is a community convention, so the same rule finds other people's robot packages too.
+          </div>
+        </div>
+        <div class="notes-src">Stress step 4. Rather than writing URDF from nothing, it is far faster to open a similar robot's description package and edit it. If there is time, actually open ROS Index and show the URDF of a turtlebot or a UR robot.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 11 ═══════════ -->
+    <div class="holder" data-n="11">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">skeleton</span><span class="stamp">&lt;robot&gt;</span></div>
+        <h2 class="slide-title"><code class="inl">&lt;robot&gt;</code> is a list of links and a list of joints</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm">&lt;?xml version=<span class="t-str">"1.0"</span> ?&gt;
+&lt;<span class="t-key">robot</span> name=<span class="t-str">"testbot"</span>&gt;
+
+  <span class="t-cm">&lt;!-- parts: what exists --&gt;</span>
+  &lt;<span class="t-key">link</span> name=<span class="t-str">"base"</span>/&gt;
+  &lt;<span class="t-key">link</span> name=<span class="t-str">"link1"</span>&gt; ... &lt;/<span class="t-key">link</span>&gt;
+  &lt;<span class="t-key">link</span> name=<span class="t-str">"link2"</span>&gt; ... &lt;/<span class="t-key">link</span>&gt;
+
+  <span class="t-cm">&lt;!-- connections: how they attach and move --&gt;</span>
+  &lt;<span class="t-key">joint</span> name=<span class="t-str">"base_joint"</span>  type=<span class="t-str">"fixed"</span>&gt;    ... &lt;/<span class="t-key">joint</span>&gt;
+  &lt;<span class="t-key">joint</span> name=<span class="t-str">"link1_link2"</span> type=<span class="t-str">"revolute"</span>&gt; ... &lt;/<span class="t-key">joint</span>&gt;
+
+&lt;/<span class="t-key">robot</span>&gt;</pre>
+          <div class="callout">
+            <span class="lbl">one root</span>
+            <code class="inl">&lt;robot&gt;</code> is declared first as the document root. Links connect <b>only through joints</b>.
+          </div>
+        </div>
+        <div class="notes-src">Ordering comes up often — mixing links and joints still parses, but listing all links first and then all joints reads better. The real testbot.urdf goes material → four links → four joints as well.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 12 Chapter 04 ═══════════ -->
+    <div class="holder" data-n="12" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">04</div>
+          <div class="chap-l">
+            <h2 class="chap-t">&lt;link&gt; — the robot's parts</h2>
+            <p class="chap-d">How to write one link properly. The shape you see, the shape that collides, and the mass and inertia used for physics —
+            what each is, and why they are kept apart.</p>
+          </div>
+        </div>
+        <div class="notes-src">This is the densest chapter of the talk. Five slides follow, so keep signalling priority — "you don't need this just to see it in RViz" — so the audience doesn't wear out.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 13 ═══════════ -->
+    <div class="holder" data-n="13">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">parts</span><span class="stamp">visual · collision · inertial</span></div>
+        <h2 class="slide-title">One link wears three faces</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><b><code class="inl">&lt;visual&gt;</code></b> — the shape drawn on screen</li>
+              <li><b><code class="inl">&lt;collision&gt;</code></b> — the volume used for collision checks</li>
+              <li><b><code class="inl">&lt;inertial&gt;</code></b> — mass and inertia tensor, for physics</li>
+              <li>All three carry their own <code class="inl">&lt;origin&gt;</code> and <code class="inl">&lt;geometry&gt;</code></li>
+            </ul>
+            <pre class="code sm">&lt;<span class="t-key">link</span> name=<span class="t-str">"link1"</span>&gt;
+  &lt;<span class="t-key">visual</span>&gt;
+    &lt;<span class="t-key">origin</span> xyz=<span class="t-str">"0 0 0.25"</span> rpy=<span class="t-str">"0 0 0"</span>/&gt;
+    &lt;<span class="t-key">geometry</span>&gt;&lt;<span class="t-key">box</span> size=<span class="t-str">"0.1 0.1 0.5"</span>/&gt;&lt;/<span class="t-key">geometry</span>&gt;
+    &lt;<span class="t-key">material</span> name=<span class="t-str">"green"</span>/&gt;
+  &lt;/<span class="t-key">visual</span>&gt;
+  &lt;<span class="t-key">collision</span>&gt; ... &lt;/<span class="t-key">collision</span>&gt;
+  &lt;<span class="t-key">inertial</span>&gt; ... &lt;/<span class="t-key">inertial</span>&gt;
+&lt;/<span class="t-key">link</span>&gt;</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">the three are independent</span>
+            The shape you see need not match the shape that collides. For RViz alone, <code class="inl">&lt;visual&gt;</code> is enough.
+          </div>
+        </div>
+        <div class="notes-src">"For RViz alone, visual is enough" is a big relief to beginners. inertial matters once you run physics in Gazebo, and it sticks if you add the anecdote that bad values make the robot fly apart as if it exploded.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 14 ═══════════ -->
+    <div class="holder" data-n="14">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">concept</span><span class="stamp">why keep them apart</span></div>
+        <h2 class="slide-title">The body you see and the body that collides differ</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">&lt;visual&gt; — display volume</div>
+              <p><code class="inl">box</code>·<code class="inl">cylinder</code>·<code class="inl">sphere</code> by default. Awkward shapes load from CAD files such as STL or DAE.</p>
+              <p class="dim">the point is looking right</p>
+            </div>
+            <div class="card">
+              <div class="card-t">&lt;collision&gt; — interference volume</div>
+              <p>Same tags, different purpose. It is sometimes made <b>larger</b> than the visual to leave a safety margin.</p>
+              <p class="dim">the point is being fast and safe</p>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">practical tip</span>
+            Detailed meshes in <code class="inl">&lt;visual&gt;</code>, plain boxes and cylinders in <code class="inl">&lt;collision&gt;</code>. It looks good and collision stays cheap.
+          </div>
+        </div>
+        <div class="notes-src">This tip really does decide simulation performance. Run collision checks against a mesh with tens of thousands of triangles and the simulation stops keeping up with real time. Anyone with Gazebo experience will nod along here.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 15 ═══════════ -->
+    <div class="holder" data-n="15">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">frames</span><span class="stamp">&lt;origin&gt;</span></div>
+        <h2 class="slide-title">Position is xyz (meters), orientation is rpy (radians)</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><b>xyz</b> — position in 3D space, in <b>meters (m)</b></li>
+              <li><b>rpy</b> — roll·pitch·yaw Euler angles, in <b>radians (rad)</b></li>
+              <li>roll about x, pitch about y, yaw about z</li>
+              <li>Always <b>relative to the parent frame</b></li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">&lt;!-- lift a 0.5-long box by half in z --&gt;</span>
+&lt;<span class="t-key">origin</span> xyz=<span class="t-str">"0.0 0.0 0.25"</span> rpy=<span class="t-str">"0.0 0.0 0.0"</span>/&gt;
+&lt;<span class="t-key">geometry</span>&gt;
+  &lt;<span class="t-key">box</span> size=<span class="t-str">"0.1 0.1 0.5"</span>/&gt;
+&lt;/<span class="t-key">geometry</span>&gt;
+
+<span class="t-cm">&lt;!-- yaw 90 deg = pi/2 = 1.5708 rad --&gt;</span>
+&lt;<span class="t-key">origin</span> xyz=<span class="t-str">"0 0 0"</span> rpy=<span class="t-str">"0 0 1.5708"</span>/&gt;</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">common mistake</span>
+            <span class="t-bad">Putting degrees straight into rpy.</span> Write 90 and you get 90 radians — about fourteen and a half turns.
+          </div>
+        </div>
+        <div class="notes-src">Explain why the box is raised by 0.25 — a geometry's origin sits at the <b>center</b> of the shape, so a 0.5-long box has to be lifted by half to start at the ground. Miss this and links render half-buried in the floor. Best of all is showing it live in RViz.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 16 ═══════════ -->
+    <div class="holder" data-n="16">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">physics</span><span class="stamp">&lt;inertial&gt;</span></div>
+        <h2 class="slide-title">The inertia tensor is symmetric — six values suffice</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>3×3 inertia matrix</th><th>x</th><th>y</th><th>z</th></tr></thead>
+              <tbody>
+                <tr class="on"><td><b>x</b></td><td><code class="inl">ixx</code></td><td><code class="inl">ixy</code></td><td><code class="inl">ixz</code></td></tr>
+                <tr><td><b>y</b></td><td class="faint">ixy</td><td><code class="inl">iyy</code></td><td><code class="inl">iyz</code></td></tr>
+                <tr><td><b>z</b></td><td class="faint">ixz</td><td class="faint">iyz</td><td><code class="inl">izz</code></td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">symmetric, so upper triangle only</span>
+            Since <code class="inl">ixy = iyx</code>, the six values <b>ixx · ixy · ixz · iyy · iyz · izz</b> are enough. <code class="inl">&lt;mass&gt;</code> in kg, <code class="inl">&lt;inertia&gt;</code> in kg·m².
+          </div>
+        </div>
+        <div class="notes-src">Somebody always asks where the values come from. Answer: Wikipedia's "List of 3D inertia tensors" collects formulas per shape, and CAD tools compute them too. Setting everything to 1.0 like the example and just opening RViz is a common early choice as well.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 17 ═══════════ -->
+    <div class="holder" data-n="17">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">looks</span><span class="stamp">&lt;material&gt;</span></div>
+        <h2 class="slide-title">Color is rgba between 0 and 1</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm">&lt;!-- define once near the top of the robot --&gt;</span>
+&lt;<span class="t-key">material</span> name=<span class="t-str">"green"</span>&gt;
+  &lt;<span class="t-key">color</span> rgba=<span class="t-str">"0 0.6 0 1"</span> /&gt;
+&lt;/<span class="t-key">material</span>&gt;
+&lt;<span class="t-key">material</span> name=<span class="t-str">"orange"</span>&gt;
+  &lt;<span class="t-key">color</span> rgba=<span class="t-str">"1.0 0.4 0.0 1.0"</span>/&gt;
+&lt;/<span class="t-key">material</span>&gt;
+
+<span class="t-cm">&lt;!-- a link refers to it by name --&gt;</span>
+&lt;<span class="t-key">visual</span>&gt;
+  ...
+  &lt;<span class="t-key">material</span> name=<span class="t-str">"green"</span>/&gt;
+&lt;/<span class="t-key">visual</span>&gt;</pre>
+          <div class="callout teal">
+            <span class="lbl">the last number is alpha</span>
+            Red, green, blue and alpha, each 0.0–1.0. Alpha <b>1.0 means opaque</b>. <code class="inl">&lt;texture&gt;</code> can map a png instead.
+          </div>
+        </div>
+        <div class="notes-src">Point out that the range is 0–1, not 0–255. People used to web colors put in 255 and everything turns white. Giving each link a different color makes it easy to see which link moves how in RViz — that is why the example alternates green and orange.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 18 Chapter 05 ═══════════ -->
+    <div class="holder" data-n="18" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">05</div>
+          <div class="chap-l">
+            <h2 class="chap-t">&lt;joint&gt; — what creates motion</h2>
+            <p class="chap-d">A joint connects two links and decides <b>how that connection may move</b>.
+            We look at the six types, plus the axis and limit values that shape the real motion.</p>
+          </div>
+        </div>
+        <div class="notes-src">This is the peak of URDF. The link chapter was the static story; this one is the dynamic story. If you have an RViz demo, placing it at the end of this chapter is the dramatic choice.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 19 ═══════════ -->
+    <div class="holder" data-n="19">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">types</span><span class="stamp">type="..."</span></div>
+        <h2 class="slide-title">There are six kinds of joint</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>type</th><th>motion</th><th>analogy</th></tr></thead>
+              <tbody>
+                <tr><td><code class="inl">fixed</code></td><td>does not move</td><td>base bolted to link1</td></tr>
+                <tr class="on"><td><code class="inl">revolute</code></td><td>rotation with angle limits</td><td>a fan panning side to side</td></tr>
+                <tr><td><code class="inl">continuous</code></td><td>unlimited continuous rotation</td><td>a car wheel</td></tr>
+                <tr><td><code class="inl">prismatic</code></td><td>straight travel along one axis</td><td>a sliding drawer</td></tr>
+                <tr><td><code class="inl">floating</code></td><td>6-DoF travel + rotation</td><td class="faint">a free-floating body</td></tr>
+                <tr><td><code class="inl">planar</code></td><td>travel + rotation on one plane</td><td class="faint">an object gliding on a plane</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="notes-src">In practice only four get used: fixed · revolute · continuous · prismatic. Saying that floating and planar are in the standard but rare in real robot URDFs takes memorization pressure off the audience. The revolute vs continuous difference (limits or not) shows up in the quiz too.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 20 ═══════════ -->
+    <div class="holder" data-n="20">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">wiring</span><span class="stamp">parent · child</span></div>
+        <h2 class="slide-title">Joints tie parent to child and build the tree</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">&lt;parent&gt;</code>·<code class="inl">&lt;child&gt;</code> — <b>the side nearer the base is the parent</b></li>
+              <li>The tree is built here: base → link1 → link2 → …</li>
+              <li><code class="inl">&lt;origin&gt;</code> — joint position relative to the parent link</li>
+              <li><code class="inl">type</code> decides how this connection moves</li>
+            </ul>
+            <pre class="code sm">&lt;<span class="t-key">joint</span> name=<span class="t-str">"link1_link2"</span> type=<span class="t-str">"revolute"</span>&gt;
+  &lt;<span class="t-key">origin</span> xyz=<span class="t-str">"0.0 0.0 0.5"</span> rpy=<span class="t-str">"0.0 0.0 0.0"</span>/&gt;
+  &lt;<span class="t-key">parent</span> link=<span class="t-str">"link1"</span>/&gt;
+  &lt;<span class="t-key">child</span>  link=<span class="t-str">"link2"</span>/&gt;
+  &lt;<span class="t-key">axis</span> xyz=<span class="t-str">"0 0 1"</span>/&gt;
+  &lt;<span class="t-key">limit</span> lower=<span class="t-num">"-2.617"</span> upper=<span class="t-num">"2.617"</span>
+         effort=<span class="t-num">"30.0"</span> velocity=<span class="t-num">"1.571"</span>/&gt;
+&lt;/<span class="t-key">joint</span>&gt;</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">naming rule</span>
+            Put both linked names in the joint name, like <code class="inl">link1_link2</code>, and you can read the tree by eye.
+          </div>
+        </div>
+        <div class="notes-src">Point out why origin z is 0.5 — link1 is 0.5 long, so the next joint sits at its end. In other words a joint's origin says "where on the parent link do I mount this joint." Once that clicks, time lost wandering through URDF coordinates drops sharply.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 21 ═══════════ -->
+    <div class="holder" data-n="21">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">motion</span><span class="stamp">axis · limit</span></div>
+        <h2 class="slide-title"><code class="inl">&lt;axis&gt;</code> and <code class="inl">&lt;limit&gt;</code> decide the real motion</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li><code class="inl">axis xyz="0 0 1"</code> — <b>rotates about z.</b> Pans like a fan's neck</li>
+              <li><code class="inl">axis xyz="0 1 0"</code> — <b>rotates about y.</b> Bends up and down like an elbow</li>
+              <li><code class="inl">lower</code>·<code class="inl">upper</code> — rotation range, in radians</li>
+              <li><code class="inl">effort</code> — force at the joint (N), <code class="inl">velocity</code> — speed (rad/s)</li>
+            </ul>
+            <pre class="code sm"><span class="t-cm">&lt;!-- joint that turns like a neck --&gt;</span>
+&lt;<span class="t-key">axis</span> xyz=<span class="t-str">"0.0 0.0 1.0"</span>/&gt;
+
+<span class="t-cm">&lt;!-- joint that bends like an elbow --&gt;</span>
+&lt;<span class="t-key">axis</span> xyz=<span class="t-str">"0.0 1.0 0.0"</span>/&gt;
+
+&lt;<span class="t-key">limit</span> lower=<span class="t-num">"-2.617"</span> upper=<span class="t-num">"2.617"</span>
+       effort=<span class="t-num">"30.0"</span> velocity=<span class="t-num">"1.571"</span>/&gt;</pre>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">2.617 rad ≈ 150°</span>
+            Changing values and turning the joint yourself in RViz is the fastest way to understand URDF.
+          </div>
+        </div>
+        <div class="notes-src">What matters is that the axis follows the <b>robot's reference frame</b>. In the example link1_link2 uses z while link2_link3 and link3_link4 use y, so the first joint swings the whole arm sideways and the other two fold and unfold it. Move them one at a time with the joint_state_publisher GUI sliders in RViz and it lands immediately.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 22 Chapter 06 ═══════════ -->
+    <div class="holder" data-n="22" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">06</div>
+          <div class="chap-l">
+            <h2 class="chap-t">Show it in RViz and move the joints</h2>
+            <p class="chap-d">The file alone tells you little. Launch three nodes and the robot appears
+            on screen, with sliders to turn its joints by hand.</p>
+          </div>
+        </div>
+        <div class="notes-src">Results start here. If you prepared a demo video or screenshots, use them in this chapter. Spend the most time making the node structure (23) land, and move fast through the launch file code (24).</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 23 ═══════════ -->
+    <div class="holder" data-n="23">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">structure</span><span class="stamp">node &amp; topic</span></div>
+        <h2 class="slide-title">The launch file starts three nodes</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="arch">
+            <div class="arch-col">
+              <div class="node"><span class="n-t">joint_state_publisher_gui</span><span class="n-p">produces joint values from sliders</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">/joint_states</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node hero"><span class="n-t">robot_state_publisher</span><span class="n-p">URDF + joint values → transforms (TF)</span></div>
+            </div>
+            <div class="arch-link"><span class="l-lbl">/tf · /tf_static</span><span class="l-line"></span></div>
+            <div class="arch-col">
+              <div class="node"><span class="n-t">rviz2</span><span class="n-p">draws the robot in 3D from the TF it receives</span></div>
+            </div>
+          </div>
+          <p class="cap">Arrows show which way topics flow. The URDF itself is handed to robot_state_publisher up front via the <code class="inl">robot_description</code> parameter.</p>
+        </div>
+        <div class="notes-src">This one picture replaces five slides. The key is that "the side producing joint values" and "the side computing frames from them" are separated. Always add that on a real robot a driver node reading encoders takes the place of the GUI on the left — that is what makes the split make sense.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 24 ═══════════ -->
+    <div class="holder" data-n="24">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">hands-on</span><span class="stamp">testbot.launch.py</span></div>
+        <h2 class="slide-title">The launch file really does just one thing</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code xs"><span class="t-key">def</span> <span class="t-fn">generate_launch_description</span>():
+    urdf_file = os.path.<span class="t-fn">join</span>(
+        <span class="t-fn">get_package_share_directory</span>(<span class="t-str">'testbot_description'</span>),
+        <span class="t-str">'urdf'</span>, <span class="t-str">'testbot.urdf'</span>)
+    <span class="t-key">with</span> <span class="t-fn">open</span>(urdf_file, <span class="t-str">'r'</span>) <span class="t-key">as</span> infp:
+        robot_description_file = infp.<span class="t-fn">read</span>()
+
+    robot_state_publisher = <span class="t-fn">Node</span>(
+        package=<span class="t-str">'robot_state_publisher'</span>, executable=<span class="t-str">'robot_state_publisher'</span>,
+        parameters=[{<span class="t-str">'robot_description'</span>: robot_description_file}])
+    joint_state_publisher_gui = <span class="t-fn">Node</span>(
+        package=<span class="t-str">'joint_state_publisher_gui'</span>, executable=<span class="t-str">'joint_state_publisher_gui'</span>)
+    rviz2 = <span class="t-fn">Node</span>(
+        package=<span class="t-str">'rviz2'</span>, executable=<span class="t-str">'rviz2'</span>,
+        arguments=[<span class="t-str">'-d'</span>, rviz_display_config_file])
+
+    <span class="t-key">return</span> <span class="t-fn">LaunchDescription</span>([robot_state_publisher, joint_state_publisher_gui, rviz2])</pre>
+          <div class="callout teal">
+            <span class="lbl">this is the point</span>
+            Read the URDF file and pass it as the <code class="inl">robot_description</code> parameter. The rest is boilerplate that starts nodes.
+          </div>
+        </div>
+        <div class="notes-src">The code is trimmed to fit the slide (the original also carries output='screen', use_sim_time and more). Don't dwell — stress the one line and move on. rviz_display_config_file is the path to a .rviz file storing the RViz layout, used so you don't re-add displays every time.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 25 ═══════════ -->
+    <div class="holder" data-n="25">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">roles</span><span class="stamp">who passes what to whom</span></div>
+        <h2 class="slide-title">The two publishers do different jobs</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>node</th><th>subscribes</th><th>publishes</th></tr></thead>
+              <tbody>
+                <tr><td><code class="inl">joint_state_publisher</code></td><td class="faint">—</td><td><code class="inl">/joint_states</code></td></tr>
+                <tr class="on"><td><code class="inl">robot_state_publisher</code></td><td><code class="inl">/joint_states</code></td><td><code class="inl">/tf</code> · <code class="inl">/tf_static</code> · <code class="inl">/robot_description</code></td></tr>
+                <tr><td><code class="inl">rviz2</code></td><td><code class="inl">/tf</code> · <code class="inl">/robot_description</code></td><td class="faint">—</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            <span class="lbl">the flow in one line</span>
+            Joint values come in, get <b>combined with the URDF into transforms</b>, and go back out. RViz only draws the result.
+          </div>
+        </div>
+        <div class="notes-src">/joint_states is sensor_msgs/msg/JointState and /tf is tf2_msgs/msg/TFMessage. Nobody needs to memorize message types, but mention that ros2 topic echo lets you watch the URDF turn into numbers. /tf_static holds only transforms that never change, such as fixed joints.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 26 ═══════════ -->
+    <div class="holder" data-n="26">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">steps</span><span class="stamp">install → build → launch</span></div>
+        <h2 class="slide-title">Install it, build it, launch it</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="steps">
+            <div class="step"><span class="s-n">1</span><div><div class="s-c">sudo apt install ros-humble-joint-state-publisher-gui ros-humble-robot-state-publisher</div><div class="s-d">install the packages behind the nodes the launch file starts</div></div></div>
+            <div class="step"><span class="s-n">2</span><div><div class="s-c">cd ~/robot_ws &amp;&amp; colcon build --symlink-install</div><div class="s-d">build the workspace</div></div></div>
+            <div class="step"><span class="s-n">3</span><div><div class="s-c">ros2 launch testbot_description testbot.launch.py</div><div class="s-d">RViz and the joint slider GUI come up together</div></div></div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">set an alias</span>
+            Shorten it with <code class="inl">alias cba='colcon build --symlink-install'</code> and the loop gets much lighter.
+          </div>
+        </div>
+        <div class="notes-src">--symlink-install matters. With it, edits to urdf or launch files take effect without rebuilding. URDF work means changing values and rechecking constantly, so this one option shortens the loop a lot. Remind people not to forget source install/local_setup.bash after building.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 27 ═══════════ -->
+    <div class="holder" data-n="27">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">shortcut</span><span class="stamp">urdf_tutorial</span></div>
+        <h2 class="slide-title">You can look without a launch file at all</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <pre class="code sm"><span class="t-cm"># install the urdf_tutorial package</span>
+$ sudo apt install ros-humble-urdf-tutorial
+
+<span class="t-cm"># pass only the model path and RViz opens</span>
+$ ros2 launch urdf_tutorial display.launch.py \
+    model:=/home/parallels/robot_ws/src/testbot_description/urdf/testbot.urdf</pre>
+          <div class="callout">
+            <span class="lbl">when to use it</span>
+            The <b>early stage</b>, while you are still changing tag values. Lean on it until you have a launch file and a .rviz config.
+          </div>
+        </div>
+        <div class="notes-src">You get exactly the same screen as with your own launch file. In the end the urdf_tutorial package just contains a launch file like the one we saw. Recommend starting here while learning URDF and writing your own package's launch file once the robot is reasonably complete.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 28 Chapter 07 ═══════════ -->
+    <div class="holder" data-n="28" data-chapter="1">
+      <section class="slide" data-kind="chapter">
+        <div class="chap">
+          <div class="chap-n">07</div>
+          <div class="chap-l">
+            <h2 class="chap-t">How to verify, and the tooling</h2>
+            <p class="chap-d">Commands that check syntax and the tree before RViz ever opens,
+            plus <code class="inl">xacro</code>, which cuts repetition once a URDF gets long.</p>
+          </div>
+        </div>
+        <div class="notes-src">The closing chapter. If time runs out, show check_urdf (29) only and jump to xacro (31). The tool table (30) can be left as reference material.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 29 ═══════════ -->
+    <div class="holder" data-n="29">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">verify</span><span class="stamp">$ check_urdf testbot.urdf</span></div>
+        <h2 class="slide-title"><code class="inl">check_urdf</code> — syntax and link tree at once</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tree">
+            <span class="lv"><span class="k">robot name is: testbot</span></span>
+            <span class="lv"><span class="v">---------- Successfully Parsed XML ---------------</span></span>
+            <span class="lv"><span class="k">root Link: base</span> has 1 child(ren)</span>
+            <span class="lv">    child(1):  link1</span>
+            <span class="lv">        child(1):  link2</span>
+            <span class="lv">            child(1):  link3</span>
+            <span class="lv">                child(1):  <span class="v">link4</span></span>
+          </div>
+          <div class="callout">
+            <span class="lbl">what it catches</span>
+            Misspelled link names, links with no parent, breaks in the tree. Run it <b>before opening RViz</b>.
+          </div>
+        </div>
+        <div class="notes-src">The staircase indentation in the output is the tree structure. If it differs from what you intended, a joint's parent/child is wrong. RViz sometimes silently draws nothing when a URDF is broken, so running this command first is a good habit for finding problems fast.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 30 ═══════════ -->
+    <div class="holder" data-n="30">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">tools</span><span class="stamp">what each shows</span></div>
+        <h2 class="slide-title">Tools to reach for when you are stuck</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="tbl-wrap">
+            <table class="tbl">
+              <thead><tr><th>tool</th><th>what it shows</th></tr></thead>
+              <tbody>
+                <tr><td><code class="inl">check_urdf</code></td><td>syntax errors and the link tree</td></tr>
+                <tr><td><code class="inl">urdf_to_graphiz</code></td><td>link · joint relations and relative transforms as a PDF diagram</td></tr>
+                <tr><td><code class="inl">ros2 run tf2_tools view_frames</code></td><td>the running TF tree as a PDF</td></tr>
+                <tr><td><code class="inl">rqt</code></td><td>how nodes and topics are actually wired</td></tr>
+                <tr class="on"><td>URDF for VSCode</td><td>syntax highlighting and snippets for <code class="inl">.urdf</code>·<code class="inl">.xacro</code></td></tr>
+                <tr><td><code class="inl">rviz2</code></td><td>the final render — where you really check</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="notes-src">JetBrains PyCharm has no usable URDF plugin, so VSCode plus the URDF extension is effectively the standard. Don't count on VSCode's "ROS: Preview URDF" — it works on ROS 1 but sometimes shows a blank screen on ROS 2. urdf_to_graphiz produces both a .gv and a .pdf.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 31 ═══════════ -->
+    <div class="holder" data-n="31">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">scaling</span><span class="stamp">XML Macro</span></div>
+        <h2 class="slide-title"><code class="inl">xacro</code> turns repeated XML into macros</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2a">
+            <ul class="bul">
+              <li>Short for XML Macro. A macro language that <b>generates</b> URDF</li>
+              <li><code class="inl">&lt;xacro:property&gt;</code> — manage a value by name</li>
+              <li>Expressions like <code class="inl">pi</code>·<code class="inl">radians(x)</code>·<code class="inl">sqrt(x)</code> are available</li>
+              <li><code class="inl">&lt;xacro:macro&gt;</code> — link · joint templates taking arguments</li>
+              <li><code class="inl">&lt;xacro:if&gt;</code> — insert a different block by condition</li>
+            </ul>
+            <pre class="code xs">&lt;<span class="t-key">xacro:property</span> name=<span class="t-str">"the_radius"</span> value=<span class="t-str">"2.1"</span> /&gt;
+&lt;<span class="t-key">geometry</span> type=<span class="t-str">"cylinder"</span> radius=<span class="t-str">"${the_radius}"</span> /&gt;
+
+<span class="t-cm">&lt;!-- no need to compute radians by hand --&gt;</span>
+&lt;<span class="t-key">xacro:property</span> name=<span class="t-str">"upper"</span> value=<span class="t-str">"${radians(150)}"</span>/&gt;
+
+&lt;<span class="t-key">xacro:macro</span> name=<span class="t-str">"link_box"</span> params=<span class="t-str">"suffix"</span>&gt;
+  &lt;<span class="t-key">link</span> name=<span class="t-str">"link_${suffix}"</span>&gt; ... &lt;/<span class="t-key">link</span>&gt;
+&lt;/<span class="t-key">xacro:macro</span>&gt;
+
+&lt;<span class="t-key">xacro:link_box</span> suffix=<span class="t-str">"1"</span> /&gt;</pre>
+          </div>
+          <div class="callout">
+            <span class="lbl">when to switch</span>
+            Plain URDF is fine up to four or five links. <b>Once you start copying blocks</b>, it is time for xacro.
+          </div>
+        </div>
+        <div class="notes-src">The testbot we built today repeats nearly identical content four times across link1–link4 — exactly where xacro is needed. Saying that being able to write radians(150) is reason enough to switch gets a lot of nods. Most real robot packages ship .urdf.xacro rather than .urdf.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 32 ═══════════ -->
+    <div class="holder" data-n="32">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">summary</span><span class="stamp">what to take away</span></div>
+        <h2 class="slide-title">Only two things to remember</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="cols c-2">
+            <div class="card">
+              <div class="card-t">A model is links and joints</div>
+              <p><code class="inl">&lt;link&gt;</code> for parts, <code class="inl">&lt;joint&gt;</code> for connection and motion.</p>
+              <p class="dim">visual·collision·inertial·origin·axis·limit are all details of those two</p>
+            </div>
+            <div class="card">
+              <div class="card-t">You check it in RViz</div>
+              <p>Changing values and relaunching is the fastest way to understand URDF.</p>
+              <p class="dim">but check the tree with check_urdf first</p>
+            </div>
+          </div>
+          <div class="callout teal">
+            <span class="lbl">next steps</span>
+            Control the robot you modeled · physics simulation in Gazebo · Navigation.
+          </div>
+        </div>
+        <div class="notes-src">You can close the talk here, or continue into the quiz. The three next steps come straight from the article's "next study topics," so this is a good place to trail a follow-up talk. Take questions while staying on this slide.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 33 ═══════════ -->
+    <div class="holder" data-n="33">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check ①</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Answer for yourself — formats and links</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>Which tool uses URDF, SDF and SRDF?</span></button>
+              <div class="q-a">URDF in RViz (modeling), SDF in Gazebo (simulation), SRDF in MoveIt (planning, collision). All three are XML, and URDF is the starting point. <span class="ref">→ Slide 04</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>Which robot structure can URDF not express?</span></button>
+              <div class="q-a">Closed-loop (parallel) structures. URDF only expresses trees, one parent per link. Flexible parts that bend or stretch are out too. <span class="ref">→ Slide 05</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>Why keep <code class="inl">&lt;visual&gt;</code> and <code class="inl">&lt;collision&gt;</code> apart?</span></button>
+              <div class="q-a">Because the shape shown and the collision volume may differ. Enlarge collision for a safety margin, or use simple shapes instead of heavy meshes to keep it cheap. <span class="ref">→ Slide 13 · 14</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>What does <code class="inl">&lt;origin rpy="0 0 1.5708"/&gt;</code> mean?</span></button>
+              <div class="q-a">1.5708 radians about z (yaw), roughly 90°. rpy is in radians and xyz in meters. Put degrees in raw and it faces somewhere else. <span class="ref">→ Slide 15</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>Why write only six values in <code class="inl">&lt;inertia&gt;</code>?</span></button>
+              <div class="q-a">The 3×3 inertia matrix is symmetric: ixy=iyx, ixz=izx, iyz=izy. The upper triangle ixx·ixy·ixz·iyy·iyz·izz fixes the rest. <span class="ref">→ Slide 16</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">Read one question, wait 5–10 seconds, then open the answer. Q3 and Q5 split the room best. If time is short, Q2 and Q4 alone still cover the core of the earlier slides.</div>
+      </section>
+    </div>
+
+    <!-- ═══════════ 34 ═══════════ -->
+    <div class="holder" data-n="34">
+      <section class="slide">
+        <div class="slide-head"><span class="eyebrow">check ②</span><span class="stamp">click to reveal</span></div>
+        <h2 class="slide-title">Answer for yourself — joints and running it</h2>
+        <div class="rule"></div>
+        <div class="slide-body">
+          <div class="quiz">
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q1</span><span>How do <code class="inl">revolute</code> and <code class="inl">continuous</code> differ?</span></button>
+              <div class="q-a">Both rotate, but revolute has lower·upper angle limits while continuous spins without any. A car wheel is continuous. <span class="ref">→ Slide 19</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q2</span><span>Which link is a joint's <code class="inl">&lt;parent&gt;</code>?</span></button>
+              <div class="q-a">The one nearer the base. That is how the tree base → link1 → link2 → … is built, and check_urdf prints exactly that tree. <span class="ref">→ Slide 20</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q3</span><span>How wide is <code class="inl">&lt;limit lower="-2.617" upper="2.617"/&gt;</code> in degrees?</span></button>
+              <div class="q-a">About ±150°. limit angles are radians; effort next to it is newtons (N) and velocity is rad/s. <span class="ref">→ Slide 21</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q4</span><span>What does <code class="inl">robot_state_publisher</code> take in and send out?</span></button>
+              <div class="q-a">It subscribes to <code class="inl">/joint_states</code>, combines it with the URDF into transforms, and publishes <code class="inl">/tf</code>·<code class="inl">/tf_static</code>. The joint values themselves come from joint_state_publisher. <span class="ref">→ Slide 23 · 25</span></div>
+            </div>
+            <div class="q">
+              <button class="q-btn" type="button"><span class="q-n">Q5</span><span>How do you check a URDF quickly before writing a launch file?</span></button>
+              <div class="q-a">Run <code class="inl">check_urdf</code> for syntax and tree, then <code class="inl">ros2 launch urdf_tutorial display.launch.py model:=...</code> to put it straight into RViz. <span class="ref">→ Slide 27 · 29</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="notes-src">The last slide. Q5 is the habit you will use most often, so make sure to land it before closing. Leaving every answer open turns the screen into a summary while you take questions.</div>
+      </section>
+    </div>
+    </div><!-- /stage -->
+  </div><!-- /stage-wrap -->
+
+  <div class="notes" id="notes" aria-live="polite">
+    <div class="n-h">Speaker notes</div>
+    <div id="notesBody"></div>
+  </div>
+
+  <div class="chrome">
+    <span class="deck-id">URDF Robot Modeling</span>
+    <div class="rail" id="rail"></div>
+    <span class="counter" id="counter"><span class="cur">01</span> / 34</span>
+    <div class="keys">
+      <button class="kbtn" id="btnOverview" type="button" aria-pressed="false" title="Overview (O)">Overview</button>
+      <button class="kbtn" id="btnNotes" type="button" aria-pressed="false" title="Speaker notes (N)">Notes</button>
+      <button class="kbtn" id="btnTheme" type="button" title="Toggle theme (T)">Theme</button>
+      <button class="kbtn" id="btnHelp" type="button" title="Shortcuts (?)">?</button>
+    </div>
+  </div>
+
+  <div class="help" id="help">
+    <div class="help-box">
+      <h3>Shortcuts</h3>
+      <dl>
+        <dt>→ · Space · PgDn</dt><dd>Next slide</dd>
+        <dt>← · PgUp</dt><dd>Previous slide</dd>
+        <dt>Home · End</dt><dd>First · Last</dd>
+        <dt>O</dt><dd>Slide overview</dd>
+        <dt>N</dt><dd>Speaker notes</dd>
+        <dt>T</dt><dd>Light / dark theme</dd>
+        <dt>F</dt><dd>Fullscreen</dd>
+        <dt>Esc</dt><dd>Close</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var deck     = document.getElementById("deck");
+  var stage    = document.getElementById("stage");
+  var wrap     = document.getElementById("stageWrap");
+  var rail     = document.getElementById("rail");
+  var counter  = document.getElementById("counter");
+  var notesEl  = document.getElementById("notes");
+  var notesBody= document.getElementById("notesBody");
+  var helpEl   = document.getElementById("help");
+  var holders  = Array.prototype.slice.call(stage.querySelectorAll(".holder"));
+  var total    = holders.length;
+  var idx      = 0;
+  var overview = false;
+  var reduce   = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ── 눈금 레일 ─────────────────────────────────── */
+  var ticks = holders.map(function (h, i) {
+    var t = document.createElement("span");
+    t.className = "tick" + (h.hasAttribute("data-chapter") ? " chap" : "");
+    t.title = "Slide " + (i + 1);
+    t.addEventListener("click", function () { go(i); });
+    rail.appendChild(t);
+    return t;
+  });
+
+  function pad(n) { return (n < 10 ? "0" : "") + n; }
+
+  /* ── 무대 스케일 ───────────────────────────────── */
+  /* 무대는 stage-wrap 의 좌상단에 고정(place-items:start)해 두고,
+     축소한 뒤 남는 여백만큼 직접 translate 해서 가운데로 옮긴다.
+     transform-origin 을 center 로 두고 grid 중앙 정렬에 맡기면,
+     뷰포트가 1280x720 보다 작을 때 브라우저가 넘치는 항목을
+     좌상단에 고정(safe alignment)해 버려서 축소 결과가 오른쪽 아래로 쏠린다. */
+  function fit() {
+    if (overview) { stage.style.transform = ""; return; }
+    var k = Math.min(wrap.clientWidth / 1280, wrap.clientHeight / 720);
+    var tx = (wrap.clientWidth - 1280 * k) / 2;
+    var ty = (wrap.clientHeight - 720 * k) / 2;
+    stage.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + k + ")";
+  }
+
+  /* ── 이동 ──────────────────────────────────────── */
+  function go(n, silent) {
+    n = Math.max(0, Math.min(total - 1, n));
+    idx = n;
+    holders.forEach(function (h, i) { h.classList.toggle("is-active", i === n); });
+    ticks.forEach(function (t, i) {
+      t.classList.toggle("done", i < n);
+      t.classList.toggle("now", i === n);
+    });
+    counter.innerHTML = '<span class="cur">' + pad(n + 1) + "</span> / " + total;
+    var src = holders[n].querySelector(".notes-src");
+    notesBody.textContent = src ? src.textContent.trim() : "—";
+    if (!silent) { history.replaceState(null, "", "#" + (n + 1)); }
+    runOdometers(holders[n]);
+    if (overview) {
+      holders[n].scrollIntoView({ block: "nearest", behavior: reduce ? "auto" : "smooth" });
+    }
+  }
+
+  /* ── 카디널리티 카운터 ─────────────────────────── */
+  function runOdometers(holder) {
+    var list = holder.querySelectorAll("[data-odo]");
+    Array.prototype.forEach.call(list, function (el, i) {
+      var to = parseInt(el.getAttribute("data-odo"), 10);
+      if (reduce) { el.textContent = to.toLocaleString("en-US"); return; }
+      var dur = 900, delay = i * 420, t0 = null;
+      el.textContent = "0";
+      function frame(ts) {
+        if (t0 === null) { t0 = ts; }
+        var p = (ts - t0 - delay) / dur;
+        if (p < 0) { requestAnimationFrame(frame); return; }
+        if (p > 1) { p = 1; }
+        var e = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(to * e).toLocaleString("en-US");
+        if (p < 1) { requestAnimationFrame(frame); }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
+  /* ── 개요 모드 ─────────────────────────────────── */
+  function setOverview(on) {
+    overview = on;
+    deck.classList.toggle("is-overview", on);
+    document.getElementById("btnOverview").setAttribute("aria-pressed", String(on));
+    fit();
+    if (on) { holders[idx].scrollIntoView({ block: "center" }); }
+  }
+
+  holders.forEach(function (h, i) {
+    h.addEventListener("click", function () { if (overview) { setOverview(false); go(i); } });
+  });
+
+  /* ── 노트 · 테마 · 도움말 ──────────────────────── */
+  function setNotes(on) {
+    notesEl.classList.toggle("on", on);
+    document.getElementById("btnNotes").setAttribute("aria-pressed", String(on));
+  }
+  function toggleTheme() {
+    var cur = document.documentElement.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try { localStorage.setItem("deck-theme", next); } catch (e) {}
+    drawHero();
+  }
+  try {
+    var saved = localStorage.getItem("deck-theme");
+    if (saved) { document.documentElement.setAttribute("data-theme", saved); }
+  } catch (e) {}
+
+  document.getElementById("btnOverview").addEventListener("click", function () { setOverview(!overview); });
+  document.getElementById("btnNotes").addEventListener("click", function () { setNotes(!notesEl.classList.contains("on")); });
+  document.getElementById("btnTheme").addEventListener("click", toggleTheme);
+  document.getElementById("btnHelp").addEventListener("click", function () { helpEl.classList.toggle("on"); });
+  helpEl.addEventListener("click", function () { helpEl.classList.remove("on"); });
+
+  /* ── 클릭 리빌 · 이미지 토글 ───────────────────── */
+  document.addEventListener("click", function (e) {
+    var qb = e.target.closest ? e.target.closest(".q-btn") : null;
+    if (qb) { qb.parentNode.classList.toggle("is-open"); return; }
+
+    var tg = e.target.closest ? e.target.closest(".tg") : null;
+    if (tg) {
+      var group = tg.getAttribute("data-swap");
+      var target = tg.getAttribute("data-target");
+      Array.prototype.forEach.call(document.querySelectorAll('.tg[data-swap="' + group + '"]'), function (b) {
+        b.setAttribute("aria-pressed", String(b === tg));
+      });
+      Array.prototype.forEach.call(document.querySelectorAll('[data-swap-group="' + group + '"] > .swap-i'), function (item) {
+        item.classList.toggle("on", item.getAttribute("data-swap-item") === target);
+      });
+    }
+  });
+
+  /* ── 키보드 ────────────────────────────────────── */
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) { return; }
+    var k = e.key;
+    if (k === "ArrowRight" || k === "PageDown" || k === " " || k === "Spacebar") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowLeft" || k === "PageUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "ArrowDown") { e.preventDefault(); go(idx + 1); }
+    else if (k === "ArrowUp") { e.preventDefault(); go(idx - 1); }
+    else if (k === "Home") { e.preventDefault(); go(0); }
+    else if (k === "End") { e.preventDefault(); go(total - 1); }
+    else if (k === "o" || k === "O" || k === "ㅐ") { setOverview(!overview); }
+    else if (k === "n" || k === "N" || k === "ㅜ") { setNotes(!notesEl.classList.contains("on")); }
+    else if (k === "t" || k === "T" || k === "ㅅ") { toggleTheme(); }
+    else if (k === "f" || k === "F" || k === "ㄹ") {
+      if (document.fullscreenElement) { document.exitFullscreen(); }
+      else if (document.documentElement.requestFullscreen) { document.documentElement.requestFullscreen(); }
+    }
+    else if (k === "?" || k === "/") { helpEl.classList.toggle("on"); }
+    else if (k === "Escape") {
+      if (helpEl.classList.contains("on")) { helpEl.classList.remove("on"); }
+      else if (overview) { setOverview(false); }
+    }
+  });
+
+  /* ── 표지 스파크라인 ───────────────────────────── */
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  function drawHero() {
+    var cv = document.getElementById("heroCanvas");
+    if (!cv) { return; }
+    var ctx = cv.getContext("2d");
+    var W = cv.width, H = cv.height;
+    ctx.clearRect(0, 0, W, H);
+
+    var accent = css("--accent") || "#B98CF7";
+    var line   = css("--line") || "#272F3A";
+    var faint  = css("--ink-faint") || "#6B7688";
+
+    /* 격자 */
+    ctx.strokeStyle = line;
+    ctx.lineWidth = 1;
+    var i, y, x;
+    for (i = 1; i <= 4; i++) {
+      y = Math.round((H / 5) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    for (i = 1; i <= 5; i++) {
+      x = Math.round((W / 6) * i) + .5;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+    }
+
+    /* 결정적인 CPU 곡선 (난수 없이 재현 가능하게) */
+    var N = 180, pts = [];
+    for (i = 0; i < N; i++) {
+      var t = i / (N - 1);
+      var v = 0.42
+        + 0.16 * Math.sin(t * 8.1 + 0.6)
+        + 0.09 * Math.sin(t * 21.3 + 1.9)
+        + 0.05 * Math.sin(t * 47.7 + 4.2)
+        + 0.10 * Math.exp(-Math.pow((t - 0.68) * 9, 2));
+      v = Math.max(0.08, Math.min(0.92, v));
+      pts.push([6 + t * (W - 12), H - v * H]);
+    }
+
+    var steps = reduce ? N : 0;
+    function render(n) {
+      ctx.clearRect(0, 0, W, H);
+      ctx.strokeStyle = line;
+      for (i = 1; i <= 4; i++) {
+        y = Math.round((H / 5) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+      }
+      for (i = 1; i <= 5; i++) {
+        x = Math.round((W / 6) * i) + .5;
+        ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+      }
+
+      var m = Math.max(2, n);
+      var grad = ctx.createLinearGradient(0, 0, 0, H);
+      grad.addColorStop(0, accent + "55");
+      grad.addColorStop(1, accent + "00");
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], H);
+      for (i = 0; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.lineTo(pts[m - 1][0], H);
+      ctx.closePath();
+      ctx.fillStyle = grad;
+      ctx.fill();
+
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (i = 1; i < m; i++) { ctx.lineTo(pts[i][0], pts[i][1]); }
+      ctx.strokeStyle = accent;
+      ctx.lineWidth = 2.4;
+      ctx.lineJoin = "round";
+      ctx.stroke();
+
+      /* 마지막 점 강조 */
+      ctx.beginPath();
+      ctx.arc(pts[m - 1][0], pts[m - 1][1], 4.5, 0, Math.PI * 2);
+      ctx.fillStyle = accent;
+      ctx.fill();
+
+      ctx.font = "500 20px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = faint;
+      ctx.textAlign = "left";
+      ctx.fillText("100%", 8, 22);
+      ctx.fillText("0", 8, H - 8);
+    }
+
+    if (reduce) { render(N); return; }
+    var n0 = 2, t0 = null;
+    function frame(ts) {
+      if (t0 === null) { t0 = ts; }
+      var p = Math.min(1, (ts - t0) / 1100);
+      var e = 1 - Math.pow(1 - p, 3);
+      render(Math.max(n0, Math.round(N * e)));
+      if (p < 1) { requestAnimationFrame(frame); }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  /* ── 초기화 ────────────────────────────────────── */
+  window.addEventListener("resize", fit);
+  window.addEventListener("hashchange", function () {
+    var n = parseInt(location.hash.replace("#", ""), 10);
+    if (!isNaN(n)) { go(n - 1, true); }
+  });
+
+  var start = parseInt(location.hash.replace("#", ""), 10);
+  fit();
+  go(isNaN(start) ? 0 : start - 1, true);
+  drawHero();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

#598 에서 만든 `generate-slides` 영문 모드를 나머지 6개 글에 적용했다. 이제 데크가 있는 글 **7개 전부** 영문판을 갖는다.

| 글 | 장수 |
|---|---|
| `cloud/grafana-완벽-가이드-1` | 38 |
| `go/golang-concurrency-1-goroutine-기초` | 36 |
| `go/golang-concurrency-2-channel-완전-정복` | 36 |
| `go/golang-concurrency-3-select와-channel-심화` | 27 |
| `go/golang-generics-1-개요와-기본-문법` | 24 |
| `ros/urdf를-이용한-로봇-모델링` | 34 |

총 195장. 한국어 데크를 **번역**했고 구조·장수·번호·액센트 색은 그대로 두었다. 각 `index_en.md` 첫 섹션 끝에 `<!-- slides -->` 마커를 넣었고, `/en/slides` 목록이 7개로 채워진다.

## Test plan

전수 실측 완료.

- [x] 장 수·카운터 일치 (7개 데크 전부)
- [x] 주석 밖 한글 0건, 미번역 `슬라이드 NN` 참조 0건
- [x] **엔진 동일성** — head(CSS)·tail(chrome·JS)이 ko/en 바이트 동일 (허용된 치환만 차이)
- [x] 브라우저 넘침 검사 — grafana 12·14 압축해 해결, 나머지 6개 데크 0건
- [x] `npm run build` → `Slides copied: 14` (ko 7 + en 7)
- [x] 영문 글 임베드 7개 모두 `src=/en/.../slides/`
- [x] `/en/slides` 헤더 `7 slide decks`, 카드 7개
- [x] 전 파일 UTF-8, 이중 이스케이프 0건

## 검증 스크립트 개선

번역을 검증하다 검사 자체의 결함 셋을 잡아 고쳤다. 앞의 둘은 **에이전트가 검사를 통과시키려고 원문 내용을 바꾸는** 부작용을 실제로 일으켰던 것이라 되돌렸다.

| 결함 | 증상 | 조치 |
|---|---|---|
| 카운터 정규식 `/ (\d+)</span>` | `<span class="t-cm">// 12</span>` 같은 **코드 주석**에 오탐 | 크롬 구조 `<span class="cur">01</span> / 38</span>` 에 anchor |
| 한글 잔여 검사 | 여러 줄 CSS 주석의 **이어지는 줄**을 주석으로 인식 못 해 엔진 주석을 오탐 | 주석 내용을 공백 치환(줄 번호 보존) 후 검사 |
| — | 본문이 개행 없이 시작해 첫 슬라이드가 `<div class="stage">` 에 눌어붙음 | **엔진 동일성 검사 신설**로 발견, 병합 시 개행 정규화 |

## 발견한 기존 결함 (이 PR 범위 밖)

번역 과정에서 드러난 것으로, **한국어 데크에도 똑같이 존재**한다. 이번 변경이 만든 게 아니라 손대지 않았다.

**1. grafana 데크의 이미지가 전부 깨져 있다**
데크가 상대경로로 참조하는데(`src="histogram-heatmap.png"`) 빌드는 `/images/{category}/{slug}/` 로 내보낸다. 배포된 슬라이드에서 404다.

```
out/images/cloud/grafana-.../histogram-heatmap.png   ← 실제 위치
/grafana-.../slides/histogram-heatmap.png            → 404
```

ko·en 양쪽 모두 해당한다. 이미지 8장이 alt 텍스트로만 보인다.

**2. grafana 28번 슬라이드가 넘친다 (58px)**
ko·en **동일하게** 58px 넘친다. 위 이미지 문제와 별개로 텍스트 컬럼 자체가 초과한다.

둘 다 한국어 발행본에 영향을 주는 사안이라 별도로 판단이 필요해 보인다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)